### PR TITLE
Add Node.js support to development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,10 @@ RUN apk update && \
         linux-headers \
         python3-dev \
         libffi-dev \
-        openssl-dev
+        openssl-dev \
+        nodejs \
+        npm \
+        coreutils
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /usr/src
@@ -21,7 +24,16 @@ WORKDIR /usr/src/aiocamedomotic
 
 # Create a non-root user
 RUN adduser -D vscode
+# Create npm global directory for the vscode user
+RUN mkdir -p /home/vscode/.npm-global
+RUN chown -R vscode:vscode /home/vscode/.npm-global
+
 USER vscode
+# Configure npm to use the new directory path
+RUN npm config set prefix '/home/vscode/.npm-global'
+
+# Add npm global bin to PATH
+ENV PATH="/home/vscode/.npm-global/bin:$PATH"
 
 ENV VIRTUAL_ENV="/home/vscode/.local/aiocamedomotic-venv"
 RUN python3 -m venv $VIRTUAL_ENV


### PR DESCRIPTION
## Summary
  - Add nodejs, npm, and coreutils packages to the development Dockerfile
  - Configure npm global directory for the vscode user
  - Add npm global bin to PATH environment variable

  ## Test plan
  - Build the development container with `docker build -f Dockerfile.dev -t aiocamedomotic-dev .`
  - Verify Node.js is available by running `docker run --rm aiocamedomotic-dev node --version`
  - Verify npm is available by running `docker run --rm aiocamedomotic-dev npm --version`