### PR TITLE
Fix redundant elif condition in Auth class

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -369,7 +369,7 @@ class Auth:
                     ack_reason = data.get("sl_data_ack_reason")
                     if ack_reason and ack_reason == 1:
                         raise CameDomoticAuthError("Bad credentials.")
-                    elif ack_reason and ack_reason != 0:
+                    if ack_reason and ack_reason != 0:
                         raise CameDomoticAuthError(
                             f"Authentication failed (ACK error: {ack_reason})"
                         )


### PR DESCRIPTION
## Summary
  - Replace redundant 'elif' with 'if' in authentication error handling logic
  - Simplifies code flow without changing functionality

  ## Test plan
  - Existing tests verify the authentication error handling still works correctly
  - Run tests with `pytest tests/aiocamedomotic/test_auth.py`