### PR TITLE
Fix test warnings by using regular Mock for synchronous method

### DIFF
--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -628,13 +628,14 @@ async def test_async_raise_for_status_and_ack_http_error(mock_post):
     """Test handling of HTTP errors in async_raise_for_status_and_ack."""
     mock_response = AsyncMock()
     mock_response.status = 500
-    mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
-        request_info=AsyncMock(), 
-        history=AsyncMock(), 
+    # Use a regular Mock for raise_for_status since it's a synchronous method
+    mock_response.raise_for_status = Mock(side_effect=aiohttp.ClientResponseError(
+        request_info=Mock(), 
+        history=[], 
         status=500, 
         message="Any message", # Not testing specific message
-        headers=AsyncMock()
-    )
+        headers=Mock()
+    ))
     
     # Verify the method properly converts HTTP errors to CameDomoticServerError
     with pytest.raises(CameDomoticServerError):


### PR DESCRIPTION
## Summary
- Fixed RuntimeWarning about unawaited coroutines in tests
- Changed AsyncMock to regular Mock for aiohttp.ClientResponse.raise_for_status method
- This method is synchronous in the actual aiohttp library, so AsyncMock was incorrect

## Test plan
- Run the tests with `pytest` to verify that the warnings are gone
- All 65 tests pass with 6 skipped tests and no warnings
- Type checking with mypy also passes

🤖 Generated with [Claude Code](https://claude.ai/code)