### PR TITLE
Add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add Python 3.13 to the GitHub Actions test matrix to ensure compatibility with the upcoming Python version
- Leverage GitHub Actions' support for pre-release Python versions

## Test plan
- Verify GitHub Actions workflow runs successfully with both Python 3.12 and 3.13

🤖 Generated with [Claude Code](https://claude.ai/code)