### PR TITLE
chore: add .claude to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ cmd
 
 # MCP servers configuration
 .mcp.json
+**/.claude


### PR DESCRIPTION
Add .claude directory pattern to gitignore to prevent tracking local Claude-related files