### PR TITLE
Use environment variables for test credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,31 @@ We use 4 spaces for indentation. Our code is formatted with [Black](https://blac
 Before submitting a pull request, please make sure your code is formatted, linted,
 type-checked, and all tests pass.
 
+### Testing with real CAME servers
+
+The project includes tests that can be run against a real CAME Domotic server. These tests are skipped by default, but can be enabled for testing if you have access to a CAME Domotic server.
+
+To run tests against a real server:
+
+1. Set the following environment variables:
+   ```bash
+   export CAMEDOMOTIC_HOST="192.168.x.y"      # Replace with your server IP
+   export CAMEDOMOTIC_USERNAME="your-username" # Replace with your username
+   export CAMEDOMOTIC_PASSWORD="your-password" # Replace with your password
+   ```
+
+2. Edit the `SKIP_TESTS_ON_REAL_SERVER` variable in `tests/aiocamedomotic/test_real.py` to `False`
+
+3. Run the tests:
+   ```bash
+   pytest tests/aiocamedomotic/test_real.py -v
+   ```
+
+**Important security notes:**
+- Never commit your real server credentials to the repository
+- Always reset `SKIP_TESTS_ON_REAL_SERVER` to `True` before committing changes
+- Consider using a dedicated test user account on your CAME Domotic server for testing
+
 ## Branch naming convention
 
 To allow proper autolabeling of changes, please name your branches as follows:

--- a/tests/aiocamedomotic/const.py
+++ b/tests/aiocamedomotic/const.py
@@ -16,6 +16,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=redefined-outer-name
 
+import os
 import time
 from typing import AsyncGenerator
 from unittest.mock import patch
@@ -63,7 +64,23 @@ async def api_instance() -> AsyncGenerator[CameDomoticAPI, None]:
 
 @pytest.fixture
 async def api_instance_real() -> AsyncGenerator[CameDomoticAPI, None]:
-    async with await CameDomoticAPI.async_create(
-        "192.168.1.3", "admin", "admin"
-    ) as api:
+    """
+    Create an API instance for testing with a real CAME Domotic server.
+
+    This fixture configures the connection using environment variables:
+    - CAMEDOMOTIC_HOST: The IP address of the server
+    - CAMEDOMOTIC_USERNAME: The username for authentication
+    - CAMEDOMOTIC_PASSWORD: The password for authentication
+
+    For secure testing, it's recommended to set these environment variables rather
+    than relying on the defaults.
+
+    Returns:
+        AsyncGenerator[CameDomoticAPI, None]: The API instance for testing.
+    """
+    host = os.environ.get("CAMEDOMOTIC_HOST")
+    username = os.environ.get("CAMEDOMOTIC_USERNAME")
+    password = os.environ.get("CAMEDOMOTIC_PASSWORD")
+
+    async with await CameDomoticAPI.async_create(host, username, password) as api:
         yield api

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -12,21 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=missing-module-docstring
+"""
+Test module for real server connections.
+
+These tests are designed to be run against a real CAME Domotic server.
+They are skipped by default, but can be enabled by setting the SKIP_TESTS_ON_REAL_SERVER
+variable to False.
+
+To configure the connection to a real server, set the following environment variables:
+- CAMEDOMOTIC_HOST: The IP address of the CAME Domotic server
+- CAMEDOMOTIC_USERNAME: The username for authentication
+- CAMEDOMOTIC_PASSWORD: The password for authentication
+
+Example:
+    $ export CAMEDOMOTIC_HOST="192.168.1.3"
+    $ export CAMEDOMOTIC_USERNAME="my_username"
+    $ export CAMEDOMOTIC_PASSWORD="my_password"
+    $ pytest tests/aiocamedomotic/test_real.py -v
+"""
 # pylint: disable=missing-function-docstring
 # pylint: disable=redefined-outer-name
 
 # flake8: noqa: F811
 
 import asyncio
+import os
 import pytest
 
 from aiocamedomotic import CameDomoticAPI
 from aiocamedomotic.models import LightStatus
 
-from tests.aiocamedomotic.const import (
-    api_instance_real as api,  # pylint: disable=unused-import  # noqa: F401
-)
+from tests.aiocamedomotic.const import api_instance_real as api  # pylint: disable=unused-import  # noqa: F401
 
 
 SKIP_TESTS_ON_REAL_SERVER = True
@@ -91,10 +107,11 @@ async def test_async_change_light_status(api: CameDomoticAPI):
 
 
 async def test_async_usage_example():
-    async with await CameDomoticAPI.async_create(
-        "192.168.1.3", "admin", "admin"
-    ) as api:
+    host = os.environ.get("CAMEDOMOTIC_HOST")
+    username = os.environ.get("CAMEDOMOTIC_USERNAME")
+    password = os.environ.get("CAMEDOMOTIC_PASSWORD")
 
+    async with await CameDomoticAPI.async_create(host, username, password) as api:
         # Get the list of all the lights configured on the CAME server
         lights = await api.async_get_lights()
 


### PR DESCRIPTION
## Summary
- Replace hardcoded credentials in tests with environment variables
- Add documentation explaining how to use environment variables for testing
- Improve security by not storing credentials in the code
- Add comprehensive docstrings with examples

## Test plan
- The tests are skipped by default (no change to existing behavior)
- When tests are enabled, they use environment variables instead of hardcoded values
- Default values for environment variables are not provided for security reasons
- Added documentation in CONTRIBUTING.md about how to set up and use the environment variables