### PR TITLE
Remove unused get_http_headers method

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -215,19 +215,6 @@ class Auth:
 
         return f"http://{self.host}/domo/"
 
-    @staticmethod
-    def get_http_headers() -> dict:
-        """Provide the default HTTP headers to use in the requests.
-
-        Returns:
-            dict: the HTTP headers.
-        """
-
-        return {
-            "Content-Type": "application/json",  # "application/x-www-form-urlencoded",
-            "Connection": "Keep-Alive",
-        }
-
     async def async_get_valid_client_id(self) -> str:
         """Get a valid client ID, eventually logging in if needed.
 

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -661,15 +661,6 @@ async def test_no_deadlocks_under_load(auth_instance):
     assert all(task.done() for task in tasks), "All tasks should complete successfully"
 
 
-def test_get_http_headers():
-    """Test the static get_http_headers method."""
-    headers = Auth.get_http_headers()
-    # Verify the method returns a dictionary with expected headers
-    assert isinstance(headers, dict)
-    assert "Content-Type" in headers
-    assert "Connection" in headers
-
-
 @patch.object(ClientSession, "post", new_callable=AsyncMock)
 async def test_async_raise_for_status_and_ack_http_error(mock_post):
     """Test handling of HTTP errors in async_raise_for_status_and_ack."""


### PR DESCRIPTION
## Summary
- Remove the unused `get_http_headers()` static method from Auth class
- Remove corresponding test case

## Test plan
- Run existing tests to ensure no functionality is broken

🤖 Generated with [Claude Code](https://claude.ai/code)