### PR TITLE
Refactor: Use auth_instance fixture from const module

### DIFF
--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -34,15 +34,7 @@ from aiocamedomotic.models import (
 )
 
 from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
-
-
-@pytest_asyncio.fixture
-async def auth_instance() -> AsyncGenerator[Auth, None]:
-    session = ClientSession()
-    with patch.object(Auth, "async_validate_host", return_value=True):
-        auth = await Auth.async_create(session, "192.168.x.x", "user", "password")
-    yield auth
-    await session.close()
+from tests.aiocamedomotic.const import auth_instance  # noqa: F401
 
 
 # region CameFeature and ServerInfo tests


### PR DESCRIPTION
## Summary
- Replaces locally defined `auth_instance` fixture with the shared implementation from `const.py`
- Improves code reuse across test modules and reduces duplication
- Maintains the same functionality while simplifying test setup

## Test plan
- Existing tests should continue to pass without changes
- No functional changes to the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test setup to use a shared authentication fixture, improving consistency across tests. No changes to test behavior or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->