### PR TITLE
Fix: Store enum value rather than enum object in light.py

### DIFF
--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -149,7 +149,7 @@ class Light(CameEntity):
         await self.auth.async_send_command(payload)
 
         # Update the status of the light if everything went as expected
-        self.raw_data["status"] = status
+        self.raw_data["status"] = status.value
         if brightness is not None:
             self.raw_data["perc"] = max(0, min(brightness, 100))
 


### PR DESCRIPTION
## Summary
- Fixes a bug in the Light.async_set_status method where the LightStatus enum object was stored directly in raw_data
- Updates the method to properly store the status.value (integer) instead
- Ensures consistency between how the status is stored and how it's read

## Test plan
- The existing tests for Light.async_set_status should continue to pass
- This fix corrects behavior when the status is later accessed by other code