### PR TITLE
Add Opening Model and API Integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,17 +22,16 @@ reflects our commitment to making home automation more accessible and manageable
 This roadmap is subject to change based on community feedback and ongoing development
 insights. We look forward to growing this library together with our users and contributors.
 
-## Current Features (Version 1.0)
+## Current Features (Version 1.1)
 
-- **Lights management**: List and set the status of lights in the domotic environment.
 - **Session management**: Automated handling of login and logout processes for the API.
+- **Lights management**: List and set the status of lights in the domotic environment.
+- **Openings management**: Control and monitor shutters, including listing and setting
+their status.
 
 ## Planned Features
 
-### Short-term goals (Versions 1.1 to 1.3)
-
-- **Openings management**: Control and monitor doors and windows, including listing
-  and setting their status.
+### Short-term goals (Versions 1.2 to 1.3)
 
 - **Scenarios management**: Support for listing available scenarios and triggering them.
 
@@ -55,6 +54,9 @@ insights. We look forward to growing this library together with our users and co
 - **User management**:
   - Implement functionality to list users defined on the remote server, enhancing
     control over who has access to the domotic plant management.
+- **Digital-in**:
+  - Implement functionalities to list and acts on the digital-ins (e.g. digital switches)
+- **Terminals**: Implement functionality to list the configured terminals (i.e. CAME Domotic servers)
 
 ## Future considerations
 

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -20,8 +20,8 @@ CAME Domotic API.
 from .base import CameEntity, ServerInfo, User  # noqa: F401
 from .light import Light, LightType, LightStatus  # noqa: F401
 from .update import UpdateList  # noqa: F401
+from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
 
 
-# Openings
 # Scenarios
 # Digital inputs

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -38,14 +38,14 @@ class OpeningStatus(Enum):
     """Status of an opening.
 
     Allowed values are:
-        - CLOSED (0)
-        - OPEN (1)
-        - STOPPED (2)
+        - STOPPED (0)
+        - OPENING (1)
+        - CLOSING (2)
     """
 
-    CLOSED = 0
-    OPEN = 1
-    STOPPED = 2
+    STOPPED = 0
+    OPENING = 1
+    CLOSING = 2
 
 
 class OpeningType(Enum):
@@ -90,7 +90,8 @@ class Opening(CameEntity):
 
     @property
     def status(self) -> OpeningStatus:
-        """Current status of the opening. Allowed values: OPEN (1), CLOSED (0), STOPPED (2)."""
+        """Current status of the opening. Allowed values: STOPPED (0), OPENING (1) and
+        CLOSING (2)."""
         return OpeningStatus(self.raw_data["status"])
 
     @property
@@ -151,7 +152,7 @@ class Opening(CameEntity):
         client_id = await self.auth.async_get_valid_client_id()
         LOGGER.debug(
             "User auth ok, sending cmd 'opening_move_req' for ID %s to status %s.",
-            status == self.close_act_id if OpeningStatus.CLOSED else self.open_act_id,
+            status == self.close_act_id if OpeningStatus.CLOSING else self.open_act_id,
             status.name,
         )
 
@@ -159,7 +160,7 @@ class Opening(CameEntity):
         payload = {
             "sl_appl_msg": {
                 "act_id": self.close_act_id
-                if status == OpeningStatus.CLOSED
+                if status == OpeningStatus.CLOSING
                 else self.open_act_id,
                 "client": client_id,
                 "cmd_name": "opening_move_req",

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -159,9 +159,11 @@ class Opening(CameEntity):
         # Using the opening ID (open_act_id) for control commands
         payload = {
             "sl_appl_msg": {
-                "act_id": self.close_act_id
-                if status == OpeningStatus.CLOSING
-                else self.open_act_id,
+                "act_id": (
+                    self.close_act_id
+                    if status == OpeningStatus.CLOSING
+                    else self.open_act_id
+                ),
                 "client": client_id,
                 "cmd_name": "opening_move_req",
                 "cseq": self.auth.cseq + 1,

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -1,0 +1,183 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic opening entity models and control functionality.
+
+This module implements the classes for working with openings in a CAME Domotic
+system, supporting various types of openings like shutters, awnings, and gates.
+It provides properties to access opening attributes and methods to control
+opening state, including open, close, and stop functionality.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional, List
+
+from ..auth import Auth
+from ..const import (
+    EntityValidator,
+    LOGGER,
+)
+
+from .base import CameEntity
+
+
+class OpeningStatus(Enum):
+    """Status of an opening.
+
+    Allowed values are:
+        - CLOSED (0)
+        - OPEN (1)
+        - STOPPED (2)
+    """
+
+    CLOSED = 0
+    OPEN = 1
+    STOPPED = 2
+
+
+class OpeningType(Enum):
+    """Type of an opening.
+
+    Allowed values are:
+        - SHUTTER (0)
+    """
+
+    SHUTTER = 0
+
+
+## Other types as guessed by AI chatbot, not tested yet.
+## If uncommented, update the docstring above and the unit test too.
+#    AWNING = 1
+#    VENETIAN_BLIND = 2
+#    GATE = 3
+
+
+@dataclass
+class Opening(CameEntity):
+    """
+    Opening entity in the CameDomotic API.
+
+    Raises:
+        ValueError: If `name` or `open_act_id` keys are missing from the input data
+            or the auth argument is not an instance of the expected `Auth` class.
+    """
+
+    raw_data: dict
+    auth: Auth
+
+    def __post_init__(self):
+        EntityValidator.validate_data(
+            self.raw_data, required_keys=["open_act_id", "close_act_id"]
+        )
+
+    @property
+    def name(self) -> str:
+        """Name of the opening."""
+        return self.raw_data["name"]
+
+    @property
+    def status(self) -> OpeningStatus:
+        """Current status of the opening. Allowed values: OPEN (1), CLOSED (0), STOPPED (2)."""
+        return OpeningStatus(self.raw_data["status"])
+
+    @property
+    def type(self) -> OpeningType:
+        """
+        Opening type.
+
+        Raises:
+            ValueError: If the opening type is not recognized.
+        """
+        try:
+            return OpeningType(self.raw_data["type"])
+        except ValueError as e:
+            LOGGER.warning(
+                "Unknown opening type: %s for opening %s",
+                self.raw_data["type"],
+                self.name,
+            )
+            raise ValueError(f"Unknown opening type: {self.raw_data['type']}") from e
+
+    @property
+    def floor_ind(self) -> Optional[int]:
+        """Floor index where the opening is located."""
+        return self.raw_data.get("floor_ind")
+
+    @property
+    def room_ind(self) -> Optional[int]:
+        """Room index where the opening is located."""
+        return self.raw_data.get("room_ind")
+
+    @property
+    def open_act_id(self) -> int:
+        """Actuator ID for opening action."""
+        return self.raw_data["open_act_id"]
+
+    @property
+    def close_act_id(self) -> int:
+        """Actuator ID for closing action."""
+        return self.raw_data["close_act_id"]
+
+    @property
+    def partial_positions(self) -> List[str]:
+        """List of configured partial opening positions, if any."""
+        # TODO Check against actual values if it's a list of dict, int or strings
+        return self.raw_data.get("partial", [])
+
+    async def async_set_status(self, status: OpeningStatus) -> None:
+        """
+        Control the opening (open, close, stop).
+
+        Args:
+            status (OpeningStatus): Status to set for the opening.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        client_id = await self.auth.async_get_valid_client_id()
+        LOGGER.debug(
+            "User auth ok, sending cmd 'opening_move_req' for ID %s to status %s.",
+            status == self.close_act_id if OpeningStatus.CLOSED else self.open_act_id,
+            status.name,
+        )
+
+        # Using the opening ID (open_act_id) for control commands
+        payload = {
+            "sl_appl_msg": {
+                "act_id": self.close_act_id
+                if status == OpeningStatus.CLOSED
+                else self.open_act_id,
+                "client": client_id,
+                "cmd_name": "opening_move_req",
+                "cseq": self.auth.cseq + 1,
+                "wanted_status": status.value,
+            },
+            "sl_appl_msg_type": "domo",
+            "sl_client_id": client_id,
+            "sl_cmd": "sl_data_req",
+        }
+
+        await self.auth.async_send_command(payload)
+
+        # Update the status of the opening if everything went as expected
+        self.raw_data["status"] = status.value
+        LOGGER.info(
+            "Successfully set status of opening '%s' (ID: %s) to %s.",
+            self.name,
+            self.open_act_id,
+            status.name,
+        )

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -40,6 +40,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.light
    :members:
 
+.. automodule:: aiocamedomotic.models.opening
+   :members:
+
 .. automodule:: aiocamedomotic.models.update
    :members:
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -48,7 +48,7 @@ To work with the CAME devices you may need one or more of the following imports:
 
 .. code-block:: python
 
-    from aiocamedomotic.models import LightStatus
+    from aiocamedomotic.models import LightStatus, OpeningStatus
 
 
 Handling Exceptions
@@ -244,6 +244,69 @@ The following example shows different ways to interact with a light device:
         # Turn the light off
         await hallway_night_light.async_set_status(LightStatus.OFF)
 
+
+Openings
+-------
+
+List of available openings
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can get the list of all the available openings with the ``async_get_openings()``
+method:
+
+.. code-block:: python
+
+    openings = await api.async_get_openings()
+
+    for opening in openings:
+        print(f"ID: {opening.id}, Name: {opening.name}, Status: {opening.status}, Type: {opening.type}")
+
+Example output for openings:
+
+.. code-block:: text
+
+    ID: 10, Name: Living Room Shutter, Status: OpeningStatus.STOPPED, Type: OpeningType.SHUTTER
+    ID: 20, Name: Patio Awning, Status: OpeningStatus.OPENING, Type: OpeningType.SHUTTER
+
+Change opening status
+^^^^^^^^^^^^^^^^^^^^
+
+You can control an opening with the ``async_set_status`` method, allowing you to open, close,
+or stop an opening.
+
+The following example shows different ways to interact with opening devices:
+
+.. code-block:: python
+
+    # Get the list of all the openings configured on the CAME server
+    openings = await api.async_get_openings()
+
+    # Get a specific opening by ID
+    living_room_shutter = next((o for o in openings if o.open_act_id == 10), None)
+
+    # Get a specific opening by name
+    patio_awning = next(
+        (o for o in openings if o.name == "Patio Awning"), None
+    )
+
+    # Ensure the opening is found
+    if living_room_shutter:
+        # Open the shutter
+        await living_room_shutter.async_set_status(OpeningStatus.OPENING)
+
+        # Stop the shutter movement
+        await living_room_shutter.async_set_status(OpeningStatus.STOPPED)
+
+        # Close the shutter
+        await living_room_shutter.async_set_status(OpeningStatus.CLOSING)
+
+    # Ensure the opening is found
+    if patio_awning:
+        # Open the awning
+        await patio_awning.async_set_status(OpeningStatus.OPENING)
+
+        # Close the awning
+        await patio_awning.async_set_status(OpeningStatus.CLOSING)
 
 
 Checking Authentication Status

--- a/tests/aiocamedomotic/const.py
+++ b/tests/aiocamedomotic/const.py
@@ -51,18 +51,6 @@ async def auth_instance() -> AsyncGenerator[Auth, None]:
 
 
 @pytest.fixture
-async def api_instance() -> AsyncGenerator[CameDomoticAPI, None]:
-    with patch("aiocamedomotic.Auth.async_validate_host", return_value=True):
-        async with await CameDomoticAPI.async_create(
-            "192.168.x.x", "username", "password"
-        ) as api:
-            api.auth.client_id = "my_client_id"
-            api.auth.keep_alive_timeout_sec = 900  # 15min
-            api.auth.session_expiration_timestamp = time.monotonic() + (60 * 60)  # 1h
-            yield api
-
-
-@pytest.fixture
 async def api_instance_real() -> AsyncGenerator[CameDomoticAPI, None]:
     """
     Create an API instance for testing with a real CAME Domotic server.

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -635,12 +635,12 @@ async def test_concurrent_logins(auth_instance):
         await asyncio.gather(*(auth_instance.async_keep_alive() for _ in range(10)))
 
         # Check that login was initiated and is now valid
-        assert auth_instance.is_session_valid(), (
-            "Session should be valid after concurrent logins"
-        )
-        assert auth_instance.async_login.call_count == 1, (
-            "Login should be called exactly once"
-        )
+        assert (
+            auth_instance.is_session_valid()
+        ), "Session should be valid after concurrent logins"
+        assert (
+            auth_instance.async_login.call_count == 1
+        ), "Login should be called exactly once"
 
 
 @pytest.mark.asyncio

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -31,6 +31,9 @@ from aiocamedomotic.models import (
     UpdateList,
     LightStatus,
     LightType,
+    Opening,
+    OpeningStatus,
+    OpeningType,
 )
 
 from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
@@ -108,7 +111,34 @@ def test_came_user_invalid_input(auth_instance):
 
 
 # endregion
-# region sLight tests
+# region UpdateList tests
+
+
+def test_updatelist_init_with_data():
+    updates = UpdateList(STATUS_UPDATE_RESP)
+    assert updates._raw_data == STATUS_UPDATE_RESP
+    assert updates.data == STATUS_UPDATE_RESP.get("result")
+
+
+def test_updatelist_init_without_data():
+    updates = UpdateList()
+    assert updates._raw_data is None
+    assert updates.data == []
+
+
+def test_updatelist_init_with_empty_data():
+    updates = UpdateList({})
+    assert updates._raw_data == {}
+    assert updates.data == []
+
+
+def test_updatelist_init_with_non_dict_data():
+    updates = UpdateList("non-dict data")
+    assert updates._raw_data == "non-dict data"
+    assert updates.data == []
+
+
+# region Light tests
 
 
 @pytest.fixture
@@ -136,34 +166,14 @@ def light_data_dimmable():
     }
 
 
-def test_updatelist_init_with_data():
-    updates = UpdateList(STATUS_UPDATE_RESP)
-    assert updates._raw_data == STATUS_UPDATE_RESP
-    assert updates.data == STATUS_UPDATE_RESP.get("result")
-
-
-def test_updatelist_init_without_data():
-    updates = UpdateList()
-    assert updates._raw_data is None
-    assert updates.data == []
-
-
-def test_updatelist_init_with_empty_data():
-    updates = UpdateList({})
-    assert updates._raw_data == {}
-    assert updates.data == []
-
-
-def test_updatelist_init_with_non_dict_data():
-    updates = UpdateList("non-dict data")
-    assert updates._raw_data == "non-dict data"
-    assert updates.data == []
-
-
 def test_came_light_initialization(light_data_on_off, auth_instance):
     light = Light(light_data_on_off, auth_instance)
     assert light.raw_data == light_data_on_off
     assert light.auth == auth_instance
+
+    # Test post_init validation
+    with pytest.raises(ValueError):
+        Opening({"name": "Test"}, auth_instance)  # Missing act_id
 
 
 def test_came_light_properties(light_data_dimmable, auth_instance):
@@ -234,6 +244,154 @@ async def test_came_light_async_set_status_invalid_brightness(
     await light_dimm.async_set_status(LightStatus.OFF, -50)
     assert mock_send_command.call_count == 3
     assert light_dimm.perc == 0  # brightness is capped at 0
+
+
+# endregion
+
+# region Opening tests
+
+
+@pytest.fixture
+def opening_data_shutter_closed():
+    """Mock data for a closed shutter opening."""
+    return {
+        "open_act_id": 10,
+        "close_act_id": 11,
+        "floor_ind": 1,
+        "name": "Living Room Shutter",
+        "room_ind": 2,
+        "status": 0,  # Corresponds to OpeningStatus.CLOSED
+        "type": 0,  # Corresponds to OpeningType.SHUTTER
+        "partial": [],
+    }
+
+
+@pytest.fixture
+def opening_data_awning_open():
+    """Mock data for an open awning."""
+    return {
+        "open_act_id": 20,
+        "close_act_id": 21,
+        "floor_ind": 1,
+        "name": "Patio Shutter",
+        "room_ind": 3,
+        "status": 1,  # Corresponds to OpeningStatus.OPEN
+        "type": 0,  # OpeningType.SHUTTER
+        "partial": [],
+    }
+
+
+def test_opening_status_enum():
+    """Test the OpeningStatus enum values."""
+    assert OpeningStatus.CLOSED.value == 0
+    assert OpeningStatus.OPEN.value == 1
+    assert OpeningStatus.STOPPED.value == 2
+
+
+def test_opening_type_enum():
+    """Test the OpeningType enum values."""
+    assert OpeningType.SHUTTER.value == 0
+
+
+def test_came_opening_initialization(opening_data_shutter_closed, auth_instance):
+    """Test Opening class initialization."""
+    opening = Opening(opening_data_shutter_closed, auth_instance)
+    assert opening.raw_data == opening_data_shutter_closed
+    assert opening.auth == auth_instance
+
+    # Test post_init validation
+    with pytest.raises(ValueError):
+        Opening({"open_act_id": 1}, auth_instance)  # Missing close_act_id
+    with pytest.raises(ValueError):
+        Opening({"close_act_id": 2}, auth_instance)  # Missing open_act_id
+
+
+def test_came_opening_properties(opening_data_awning_open, auth_instance):
+    """Test Opening class properties."""
+    opening = Opening(opening_data_awning_open, auth_instance)
+    assert opening.open_act_id == opening_data_awning_open["open_act_id"]
+    assert opening.close_act_id == opening_data_awning_open["close_act_id"]
+    assert opening.name == opening_data_awning_open["name"]
+    assert opening.status == OpeningStatus.OPEN
+    assert opening.type == OpeningType.SHUTTER
+    assert opening.floor_ind == opening_data_awning_open["floor_ind"]
+    assert opening.room_ind == opening_data_awning_open["room_ind"]
+    assert len(opening.partial_positions) == 0
+
+
+@pytest.mark.asyncio
+@patch.object(
+    Auth,
+    "async_get_valid_client_id",
+    new_callable=AsyncMock,
+    return_value="mock_client_id",
+)
+@patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+async def test_came_opening_async_set_status(
+    mock_send_command,
+    mock_get_client_id,  # pylint: disable=unused-argument
+    opening_data_shutter_closed,
+    auth_instance,
+):
+    """Test Opening.async_set_status method."""
+    opening = Opening(opening_data_shutter_closed, auth_instance)
+    initial_cseq = auth_instance.cseq
+
+    # Test setting status to OPEN
+    await opening.async_set_status(OpeningStatus.OPEN)
+
+    expected_payload_open = {
+        "sl_appl_msg": {
+            "act_id": opening.open_act_id,
+            "client": "mock_client_id",
+            "cmd_name": "opening_move_req",
+            "cseq": initial_cseq + 1,
+            "wanted_status": OpeningStatus.OPEN.value,
+        },
+        "sl_appl_msg_type": "domo",
+        "sl_client_id": "mock_client_id",
+        "sl_cmd": "sl_data_req",
+    }
+    mock_send_command.assert_called_with(expected_payload_open)
+    assert opening.status == OpeningStatus.OPEN  # Check internal state update
+
+    # Test setting status to CLOSED
+    await opening.async_set_status(OpeningStatus.CLOSED)
+
+    expected_payload_closed = {
+        "sl_appl_msg": {
+            "act_id": opening.close_act_id,
+            "client": "mock_client_id",
+            "cmd_name": "opening_move_req",
+            "cseq": mock_send_command.call_args_list[-1][0][0]["sl_appl_msg"]["cseq"],
+            "wanted_status": OpeningStatus.CLOSED.value,
+        },
+        "sl_appl_msg_type": "domo",
+        "sl_client_id": "mock_client_id",
+        "sl_cmd": "sl_data_req",
+    }
+    mock_send_command.assert_called_with(expected_payload_closed)
+    assert opening.status == OpeningStatus.CLOSED
+    assert mock_send_command.call_count == 2
+
+    # Test setting status to STOPPED
+    await opening.async_set_status(OpeningStatus.STOPPED)
+
+    expected_payload_stopped = {
+        "sl_appl_msg": {
+            "act_id": opening.open_act_id,
+            "client": "mock_client_id",
+            "cmd_name": "opening_move_req",
+            "cseq": mock_send_command.call_args_list[-1][0][0]["sl_appl_msg"]["cseq"],
+            "wanted_status": OpeningStatus.STOPPED.value,
+        },
+        "sl_appl_msg_type": "domo",
+        "sl_client_id": "mock_client_id",
+        "sl_cmd": "sl_data_req",
+    }
+    mock_send_command.assert_called_with(expected_payload_stopped)
+    assert opening.status == OpeningStatus.STOPPED
+    assert mock_send_command.call_count == 3
 
 
 # endregion

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -43,7 +43,9 @@ from aiocamedomotic import CameDomoticAPI
 from aiocamedomotic.models import LightStatus
 from aiocamedomotic.models.opening import Opening, OpeningStatus, OpeningType
 
-from tests.aiocamedomotic.const import api_instance_real as api  # pylint: disable=unused-import  # noqa: F401
+from tests.aiocamedomotic.const import (
+    api_instance_real as api,
+)  # pylint: disable=unused-import  # noqa: F401
 
 
 SKIP_TESTS_ON_REAL_SERVER = True


### PR DESCRIPTION
## Summary
- Add new Opening model for controlling shutters and other opening devices
- Implement API support for retrieving and controlling opening devices
- Add unit tests and real server tests for the new functionality
- Update documentation with usage examples

## Test plan
- Unit tests pass with the new model
- Real server tests verify the functionality with actual devices
- Documentation updated with examples for working with opening devices

This feature represents a significant enhancement to the library functionality, enabling control of shutters, awnings, and other opening devices through the CAME Domotic API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for listing and controlling opening devices (such as shutters and awnings), including retrieving their status and changing their state.
- **Documentation**
  - Updated API reference and usage examples to include information and instructions for working with opening devices.
- **Tests**
  - Introduced new tests to verify listing, controlling, and validating opening devices, both in unit and real integration scenarios.
- **Chores**
  - Improved code structure and test organization for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->