### PR TITLE
Fix documentation orthography and formatting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ cmd
 
 # Test configuration for real server tests
 tests/aiocamedomotic/test_config.ini
+
+tmp

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ interested in experimenting with a CAME Domotic plant.
 .. important::
     This library is independently developed and is not affiliated with, endorsed by,
     or supported by `CAME <https://www.came.com/>`_. It may not be compatible with all
-    CAME Domotic systems. While this library is stable and publicly released, it comesù
+    CAME Domotic systems. While this library is stable and publicly released, it comes
     with no guarantees. Use at your own risk.
 
 .. danger::

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,7 @@ their status.
   - Implement functionality to list users defined on the remote server, enhancing
     control over who has access to the domotic plant management.
 - **Digital-in**:
-  - Implement functionalities to list and acts on the digital-ins (e.g. digital switches)
+  - Implement functionalities to list and act on the digital-ins (e.g. digital switches)
 - **Terminals**: Implement functionality to list the configured terminals (i.e. CAME Domotic servers)
 
 ## Future considerations

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -74,7 +74,7 @@ class CameDomoticAPI:
         return [User(user, self.auth) for user in users_list]
 
     async def async_get_server_info(self) -> ServerInfo:
-        """Get the server information
+        """Get the server information.
 
         Provides info about the server (keycode, software version, etc.) and the list of
         features supported by the CAME Domotic server.
@@ -145,7 +145,7 @@ class CameDomoticAPI:
         """Get the list of status updates from the server.
 
         Returns:
-            CameUpdates: List of status updates.
+            UpdateList: List of status updates.
 
         Raises:
             CameDomoticAuthError: If the authentication fails.
@@ -224,7 +224,7 @@ class CameDomoticAPI:
 
         Raises:
             CameDomoticServerNotFoundError: if the host doesn't respond to an HTTP
-                request or doesn't expose the CAME Domotic API endopoint.
+                request or doesn't expose the CAME Domotic API endpoint.
 
         Note:
             The session is not logged in until the first request is made.

--- a/aiocamedomotic/errors.py
+++ b/aiocamedomotic/errors.py
@@ -22,7 +22,7 @@ class CameDomoticError(Exception):
 
 
 class CameDomoticServerNotFoundError(CameDomoticError):
-    """Raised when the specified host is not available"""
+    """Raised when the specified host is not available."""
 
 
 # Authentication exception class
@@ -33,7 +33,7 @@ class CameDomoticAuthError(CameDomoticError):
 # Server exception class
 class CameDomoticServerError(CameDomoticError):
     """
-    Raised if an error occurs while interacting with the remote CAME Domotic server
+    Raised if an error occurs while interacting with the remote CAME Domotic server.
     """
 
     @staticmethod
@@ -41,11 +41,11 @@ class CameDomoticServerError(CameDomoticError):
         """Formats the ack code and reason in a human-readable format.
 
         Args:
-            ack_code (str, optional): the ack code. Defaults to "N/A".
-            reason (str, optional): the reason. Defaults to "N/A".
+            ack_code (str, optional): The ack code. Defaults to "N/A".
+            reason (str, optional): The reason. Defaults to "N/A".
 
         Returns:
-            str: the formatted error message.
+            str: The formatted error message.
         """
 
         # Convert with str() to ensure that will never raise an exception

--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -66,7 +66,7 @@ class Light(CameEntity):
     Light entity in the CameDomotic API.
 
     Raises:
-        ValueError: If `name` or `act_id` keys are missing from the input data the auth
+        ValueError: If `name` or `act_id` keys are missing from the input data or the auth
             argument is not an instance of the expected `Auth` class.
     """
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -93,7 +93,7 @@ Let's go step by step:
         ) as api:
 
    This command will raise a ``CameDomoticServerNotFoundError`` exception if the server
-   is not found (tipically, bad IP/hostname or other network issue). Notice that the
+   is not found (typically, bad IP/hostname or other network issue). Notice that the
    ``CameDomoticAPI`` class is an asynchronous context manager, so it must be used with
    the ``async with`` statement.
 


### PR DESCRIPTION
## Summary
- Correct spelling errors in various files (comesù→comes, tipically→typically, endopoint→endpoint)
- Fix grammar issues in ROADMAP.md
- Add missing periods to docstrings
- Standardize docstring capitalization
- Correct mismatched return type in async_get_updates docstring
- Update .gitignore to exclude tmp directory

## Test plan
- Documentation and code comments readability verified
- No functional changes, so no functional testing needed