### PR TITLE
fix(security): add explicit permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   claude-response:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
- Adds explicit permissions block to the Claude Assistant workflow
- Resolves CodeQL security alert #7 (missing workflow permissions)
- Follows the principle of least privilege by specifying only required permissions

## Changes
Added permissions to `claude-response` job:
- `contents: read` - read repository contents
- `issues: write` - comment on issues
- `pull-requests: write` - comment on PRs

## Test plan
- [ ] Verify workflow still triggers on issue/PR comments
- [ ] Verify CodeQL alert #7 is resolved after merge

Closes https://github.com/camedomotic-unofficial/aiocamedomotic/security/code-scanning/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation configuration to enhance system reliability and permissions management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->