### PR TITLE
chore(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -65,12 +65,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: master
   
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload built package as artifact
         if: ${{ github.event.inputs.publish_to_test == 'true' || github.event.inputs.publish_to_production == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: built-package
           path: dist/*
@@ -175,7 +175,7 @@ jobs:
       id-token: write
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: built-package
           path: dist
@@ -198,7 +198,7 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: built-package
           path: dist

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,12 +40,12 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -79,7 +79,7 @@ jobs:
     - name: SonarCloud Scan
       # continue-on-error for PRs where SONAR_TOKEN may not be available (e.g., dependabot)
       continue-on-error: true
-      uses: SonarSource/sonarcloud-github-action@v2
+      uses: SonarSource/sonarcloud-github-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -39,10 +39,10 @@ jobs:
         python-version: ['3.12', '3.13']
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -61,10 +61,10 @@ jobs:
       run: poetry run pytest --timeout 10 --cov=aiocamedomotic --cov-report xml --cov-report term-missing
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: "pytest-${{ matrix.python-version }}"
         flags: "pytest-coverage,python-${{ matrix.python-version }}"
         fail_ci_if_error: false
-        file: ./coverage.xml
+        files: ./coverage.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'  # Set this to your required version of Python
 

--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply stale policy
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           days-before-stale: 90
           stale-issue-message: >

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,12 +42,12 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # fetch all history so multiple commits can be scanned
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v6
- `actions/download-artifact` v4 → v7
- `codecov/codecov-action` v4 → v5 (includes `file` → `files` input rename)
- `SonarSource/sonarcloud-github-action` v2 → v5
- `actions/stale` v9 → v10

## Test plan
- [x] Verify all workflows pass with the updated action versions