### PR TITLE
chore: add Python 3.14 support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           
       - name: Install Poetry
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install Poetry
       run: |

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'  # Set this to your required version of Python
+        python-version: '3.14'  # Set this to your required version of Python
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,7 +23,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.14"
   # jobs:
   #   pre_build:
   #     - pip install -e .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,5 +84,5 @@ Tests can run against a real CAME Domotic server (skipped by default):
 
 - The `master` git branch is protected, to merge you must create a new branch and raise a PR
 - Never mention in comments (commits, PRs, etc.) Claude or any other AI tool
-- Python 3.12 and 3.13 are supported
+- Python 3.12, 3.13 and 3.14 are supported
 - Library is available under Apache License 2.0

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.14-alpine
 
 # Update certificates and install necessary packages
 RUN apk update && \

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ Welcome!
    :target: https://opensource.org/licenses/Apache-2.0
    :alt: License: Apache 2.0
 
-.. image:: https://img.shields.io/badge/python-3.12%20%7C%203.13-417fb0.svg
+.. image:: https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-417fb0.svg
     :target: https://www.python.org
-    :alt: Python 3.12 | 3.13
+    :alt: Python 3.12 | 3.13 | 3.14
 
 .. image:: https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=security_rating
    :target: https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -4,7 +4,7 @@ Getting started
 This guide will walk you through the steps to quickly start using the CAME Domotic
 Unofficial library in your projects. Before you begin, ensure you have:
 
-- Python 3.12 or 3.13 installed on your system.
+- Python 3.12, 3.13 or 3.14 installed on your system.
 - Access to a CAME Domotic server.
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Home Automation",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary
- Add Python 3.14 as an officially supported version (classifier, test matrix, badge, docs)
- Upgrade dev environment to Python 3.14 (CI workflows, ReadTheDocs, Dockerfile)
- Backwards compatibility for Python 3.12 and 3.13 ensured by the CI test matrix

## Test plan
- [x] All 143 existing tests pass locally
- [ ] CI runs tests on Python 3.12, 3.13, and 3.14
- [ ] Code quality checks pass on Python 3.14
- [ ] Documentation builds successfully on Python 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 support across CI/CD workflows, testing infrastructure, and documentation.
  * Updated development environment and build tools to use Python 3.14.
  * Updated project classifiers to reflect Python 3.14 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->