### PR TITLE
chore: update devcontainer VSCode extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
                 "ms-python.pylint",
                 "ms-python.vscode-pylance",
                 "ms-azuretools.vscode-docker",
-                "visualstudioexptteam.vscodeintellicode",
+                "anthropic.claude-code",
                 "redhat.vscode-yaml",
                 "esbenp.prettier-vscode",
                 "GitHub.vscode-pull-request-github",


### PR DESCRIPTION
## Summary
- Remove deprecated `visualstudioexptteam.vscodeintellicode` extension
- Add `anthropic.claude-code` extension

## Test plan
- [ ] Rebuild devcontainer and verify Claude Code extension is installed
- [ ] Verify IntelliCode extension is no longer installed