### PR TITLE
chore: forward GH_TOKEN to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
     "name": "aiocamedomotic library development",
     "context": "..",
     "dockerFile": "../Dockerfile.dev",
+    "remoteEnv": {
+        "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    },
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
## Summary
- Add `remoteEnv` config to forward host's `GH_TOKEN` into the devcontainer
- Enables `gh` CLI usage without interactive `gh auth login`

## Test plan
- [ ] Set `GH_TOKEN` on host machine, rebuild devcontainer, and verify `gh auth status` works