### PR TITLE
chore: remove GH_TOKEN forwarding from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
     "name": "aiocamedomotic library development",
     "context": "..",
     "dockerFile": "../Dockerfile.dev",
-    "remoteEnv": {
-        "GH_TOKEN": "${localEnv:GH_TOKEN}"
-    },
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
## Summary
- Remove the `GH_TOKEN` remoteEnv forwarding from devcontainer config as it is no longer needed

## Test plan
- [ ] Verify devcontainer builds and starts correctly
- [ ] Verify gh CLI still authenticates properly within the container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic propagation of the GH_TOKEN environment variable to the development container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->