### PR TITLE
fix(security): harden input validation, logging, and resource cleanup

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -31,6 +31,7 @@ import time
 from typing import Optional
 from asyncio import Lock
 from importlib.metadata import version, PackageNotFoundError
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -116,7 +117,6 @@ class Auth:
         "Accept": "application/json, text/plain, */*",  # Desumed from pycame library
         "Content-Type": "application/x-www-form-urlencoded",
         "Connection": "Keep-Alive",
-        # "Authorization": f"access_token {self._token}", # Desumed from pycame library
     }
 
     # Factory method to create an Auth instance
@@ -188,9 +188,28 @@ class Auth:
                 close the websession when disposing the Auth instance (default: True).
 
         Note:
-            This method doesn't check the validity of the host URL.
             The session is not logged in until the first request is made.
+
+        Raises:
+            ValueError: if the host contains invalid characters.
         """
+
+        # Validate the host to prevent URL injection by constructing the full
+        # URL and parsing it. This correctly handles IPv4, IPv6 (bracketed),
+        # FQDNs, and optional port suffixes.
+        parsed = urlsplit(f"http://{host}/domo/")
+        if (
+            not parsed.hostname
+            or parsed.path != "/domo/"
+            or parsed.query
+            or parsed.fragment
+            or "@" in (parsed.netloc or "")
+        ):
+            raise ValueError(
+                f"Invalid host: '{host}'. Expected a hostname, IPv4 address, "
+                "or bracketed IPv6 address, optionally followed by a port "
+                "(e.g., '192.168.1.100', 'my-server:8080', or '[::1]')."
+            )
 
         # Encrypt the username and password for security reasons:
         # the encryption key is generated at runtime and not stored anywhere.
@@ -309,7 +328,7 @@ class Auth:
                 timeout=aiohttp.ClientTimeout(total=timeout),
             )
 
-            LOGGER.debug("HTTP response (%s): %s", response.status, response.text)
+            LOGGER.debug("HTTP response status: %s", response.status)
 
             # Check if the response HTTP status is 2xx
             if 200 <= response.status < 300:

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -264,13 +264,19 @@ class CameDomoticAPI:
         Note:
             The session is not logged in until the first request is made.
         """
-        auth = await Auth.async_create(
-            websession or aiohttp.ClientSession(),
-            host,
-            username,
-            password,
-            close_websession_on_disposal=(
-                close_websession_on_disposal if websession else True
-            ),
-        )
+        session = websession or aiohttp.ClientSession()
+        try:
+            auth = await Auth.async_create(
+                session,
+                host,
+                username,
+                password,
+                close_websession_on_disposal=(
+                    close_websession_on_disposal if websession else True
+                ),
+            )
+        except Exception:
+            if not websession:
+                await session.close()
+            raise
         return cls(auth)

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -37,6 +37,6 @@ class UpdateList(UserList[dict[str, Any]], CameEntity):
     def __init__(self, updates: UserList[dict[str, Any]] | None = None):
         try:
             super().__init__(updates)
-        except Exception as exc:
-            LOGGER.warning("Catched exception in the UpdateList method", exc_info=exc)
+        except TypeError as exc:
+            LOGGER.warning("Caught exception in the UpdateList method", exc_info=exc)
             super().__init__()

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -41,6 +41,46 @@ from tests.aiocamedomotic.const import (
 )
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "192.168.1.100",
+        "192.168.1.100:8080",
+        "10.0.0.1",
+        "my-server",
+        "came.local",
+        "came.example.com",
+        "came.local:443",
+        "[::1]",
+        "[2001:db8::1]",
+        "[::1]:8080",
+        "[fe80::1%25eth0]",
+    ],
+)
+def test_init_valid_hosts(host):
+    session = Mock()
+    auth = Auth(session, host, "user", "password")
+    assert auth.host == host
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "",
+        "example.com/../../admin",
+        "example.com?q=1",
+        "example.com#frag",
+        "user:pass@example.com",
+        "@evil.com",
+        "example.com/@evil",
+    ],
+)
+def test_init_invalid_hosts(host):
+    session = Mock()
+    with pytest.raises(ValueError, match="Invalid host"):
+        Auth(session, host, "user", "password")
+
+
 @freezegun.freeze_time(
     "2022-01-01 12:00:00"
 )  # To ensure that the session expiration timestamp is in the past


### PR DESCRIPTION
## Summary
- **Sanitize debug logging**: removed full HTTP response body from debug logs to prevent leaking session tokens and device state
- **Add host input validation**: validate the `host` parameter via `urllib.parse.urlsplit` to prevent URL injection (supports IPv4, IPv6, FQDNs, and optional ports)
- **Prevent websession leak**: wrap `Auth.async_create()` in `CameDomoticAPI.async_create()` with try/except to close internally-created sessions on failure
- **Narrow exception handling**: catch `TypeError` instead of bare `Exception` in `UpdateList`, fix typo "Catched" → "Caught"
- **Remove dead code**: delete commented-out `Authorization` header from `_DEFAULT_HTTP_HEADERS`
- **Add unit tests**: parameterized tests for 11 valid and 7 invalid host formats

## Test plan
- [x] All 161 tests pass (`pytest -q`)
- [x] mypy clean (`mypy aiocamedomotic`)
- [x] pylint 9.54/10 (all warnings pre-existing)
- [x] Host validation verified against IPv4, IPv6 (bracketed, with zone ID), FQDNs, optional ports
- [x] Injection vectors verified as rejected: path traversal, query/fragment injection, credential-in-URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented stricter host validation to reject invalid hosts in authentication
  * Improved error handling and resource cleanup during session initialization
  * Corrected log message wording

* **Tests**
  * Added validation tests for host format handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->