### PR TITLE
feat: add scenarios support

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -350,7 +350,7 @@ class Auth:
                     "Error decoding the response to JSON"
                 ) from e
 
-            cmd_name = json_response.get("sl_cmd")
+            cmd_name = json_response.get("cmd_name")
             if response_command is not None and cmd_name != response_command:
                 raise CameDomoticServerError(
                     f"Invalid server response. Expected {repr(response_command)}. "

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -37,6 +37,7 @@ from .models import (
     Light,
     UpdateList,
     Opening,
+    Scenario,
     Floor,
     Room,
 )
@@ -230,6 +231,28 @@ class CameDomoticAPI:
 
         openings_data = json_response.get("array", [])
         return [Opening(opening_data, self.auth) for opening_data in openings_data]
+
+    async def async_get_scenarios(self) -> List[Scenario]:
+        """Get the list of all scenarios defined on the server.
+
+        Returns:
+            List[Scenario]: List of scenarios.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        payload = {
+            "cmd_name": _CommandName.SCENARIOS_LIST.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.SCENARIOS_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        scenarios_list = json_response.get("array", [])
+        return [Scenario(data, self.auth) for data in scenarios_list]
 
     @classmethod
     async def async_create(

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -82,6 +82,7 @@ class _CommandName(Enum):
     ROOM_LIST = "room_list_req"
     LIGHT_LIST = "light_list_req"
     OPENINGS_LIST = "openings_list_req"
+    SCENARIOS_LIST = "scenarios_list_req"
     RELAYS_LIST = "relays_list_req"
     THERMO_LIST = "thermo_list_req"
     METERS_LIST = "meters_list_req"
@@ -91,6 +92,7 @@ class _CommandName(Enum):
     # Actions
     LIGHT_SWITCH = "light_switch_req"
     OPENING_MOVE = "opening_move_req"
+    SCENARIO_ACTIVATION = "scenario_activation_req"
 
 
 class _CommandNameResponse(Enum):
@@ -102,6 +104,7 @@ class _CommandNameResponse(Enum):
     ROOM_LIST = "room_list_resp"
     LIGHT_LIST = "light_list_resp"
     OPENINGS_LIST = "openings_list_resp"
+    SCENARIOS_LIST = "scenarios_list_resp"
     RELAYS_LIST = "relays_list_resp"
     THERMO_LIST = "thermo_list_resp"
     METERS_LIST = "meters_list_resp"

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -21,6 +21,6 @@ from .base import CameEntity, ServerInfo, User, Floor, Room  # noqa: F401
 from .light import Light, LightType, LightStatus  # noqa: F401
 from .update import UpdateList  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
+from .scenario import Scenario, ScenarioStatus  # noqa: F401
 
-# Scenarios
 # Digital inputs

--- a/aiocamedomotic/models/scenario.py
+++ b/aiocamedomotic/models/scenario.py
@@ -1,0 +1,141 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic scenario entity models and control functionality.
+
+This module implements the classes for working with scenarios in a CAME Domotic
+system. Scenarios represent pre-configured automation sequences that can be
+activated to control multiple devices at once. It provides properties to access
+scenario attributes and a method to activate a scenario.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ..auth import Auth
+from ..const import _CommandName
+from ..utils import (
+    EntityValidator,
+    LOGGER,
+)
+
+from .base import CameEntity
+
+
+class ScenarioStatus(Enum):
+    """Status of a scenario.
+
+    Allowed values are:
+        - OFF (0)
+        - ON (1)
+    """
+
+    OFF = 0
+    ON = 1
+    UNKNOWN = -1
+
+
+@dataclass
+class Scenario(CameEntity):
+    """
+    Scenario entity in the CameDomotic API.
+
+    Represents a pre-configured automation scenario that can be activated
+    to control multiple devices at once.
+
+    Raises:
+        ValueError: If `name` or `id` keys are missing from the input data or the auth
+            argument is not an instance of the expected `Auth` class.
+    """
+
+    raw_data: dict
+    auth: Auth
+
+    def __post_init__(self):
+        EntityValidator.validate_data(self.raw_data, required_keys=["name", "id"])
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def id(self) -> int:
+        """ID of the scenario."""
+        return self.raw_data["id"]
+
+    @property
+    def name(self) -> str:
+        """Name of the scenario."""
+        return self.raw_data["name"]
+
+    @property
+    def icon_id(self) -> int:
+        """Icon ID associated with the scenario."""
+        return self.raw_data.get("icon_id", 0)
+
+    @property
+    def scenario_status(self) -> ScenarioStatus:
+        """Scenario-specific status. Allowed values: OFF (0) and ON (1)."""
+        try:
+            return ScenarioStatus(self.raw_data["scenario_status"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown scenario_status '%s' encountered for scenario '%s' (ID: %s). "
+                "Returning ScenarioStatus.UNKNOWN. "
+                "Please report this to the library developers.",
+                self.raw_data.get("scenario_status"),
+                self.name,
+                self.id,
+            )
+            return ScenarioStatus.UNKNOWN
+
+    @property
+    def status(self) -> int:
+        """General status of the scenario."""
+        return self.raw_data.get("status", 0)
+
+    @property
+    def user_defined(self) -> int:
+        """Whether the scenario is user-defined (1) or system-defined (0)."""
+        return self.raw_data.get("user-defined", 0)
+
+    async def async_activate(self) -> None:
+        """Activate the scenario.
+
+        Sends the scenario activation command to the CAME Domotic server.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug(
+            "Sending cmd 'scenario_activation_req' for scenario '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )
+
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_ACTIVATION.value,
+            "id": self.id,
+        }
+
+        await self.auth.async_send_command(payload)
+
+        LOGGER.info(
+            "Successfully activated scenario '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -179,4 +179,30 @@ def opening_data_awning_opening():
     }
 
 
+@pytest.fixture
+def scenario_data_off():
+    """Mock data for an inactive scenario."""
+    return {
+        "icon_id": 14,
+        "id": 0,
+        "name": "Test Scenario",
+        "scenario_status": 0,
+        "status": 0,
+        "user-defined": 0,
+    }
+
+
+@pytest.fixture
+def scenario_data_on():
+    """Mock data for an active scenario."""
+    return {
+        "icon_id": 5,
+        "id": 7,
+        "name": "Evening Lights",
+        "scenario_status": 1,
+        "status": 0,
+        "user-defined": 1,
+    }
+
+
 # endregion

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -22,12 +22,14 @@ from aiocamedomotic import Auth, CameDomoticAPI
 from tests.aiocamedomotic.mocked_responses import (
     FEATURE_LIST_RESP,
     LIGHT_LIST_RESP,
+    SCENARIOS_LIST_RESP,
 )
 from aiocamedomotic.models import (
     ServerInfo,
     User,
     Light,
     Opening,
+    Scenario,
     UpdateList,
     Floor,
     Room,
@@ -712,6 +714,104 @@ class TestAPIOpenings:
         assert len(openings) == 1
         assert openings[0].status.value == -1  # OpeningStatus.UNKNOWN
         assert openings[0].type.value == -1  # OpeningType.UNKNOWN
+
+
+class TestAPIScenarios:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_scenarios(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = SCENARIOS_LIST_RESP
+
+        scenarios = await api.async_get_scenarios()
+        assert len(scenarios) == len(SCENARIOS_LIST_RESP["array"])
+        assert isinstance(scenarios[0], Scenario)
+        assert isinstance(scenarios[1], Scenario)
+        assert isinstance(scenarios[2], Scenario)
+        # Check properties of first scenario
+        assert scenarios[0].name == "scenario_SGgbR"
+        assert scenarios[0].id == 0
+        assert scenarios[1].name == "scenario_OjEUl"
+        assert scenarios[1].id == 1
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_scenarios_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "scenarios_list_resp",
+            "cseq": 2,
+            "sl_data_ack_reason": 0,
+        }
+
+        scenarios = await api.async_get_scenarios()
+        assert len(scenarios) == 0
+        assert isinstance(scenarios, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_scenarios_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            # "array" key is missing
+            "cmd_name": "scenarios_list_resp",
+            "cseq": 2,
+            "sl_data_ack_reason": 0,
+        }
+
+        scenarios = await api.async_get_scenarios()
+        assert len(scenarios) == 0
+        assert isinstance(scenarios, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_scenarios_missing_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    # Missing "id"
+                    "icon_id": 14,
+                    "name": "scenario_SGgbR",
+                    "scenario_status": 0,
+                    "status": 0,
+                    "user-defined": 0,
+                }
+            ],
+            "cmd_name": "scenarios_list_resp",
+            "cseq": 2,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            await api.async_get_scenarios()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_scenarios_missing_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "icon_id": 14,
+                    "id": 0,
+                    # Missing "name"
+                    "scenario_status": 0,
+                    "status": 0,
+                    "user-defined": 0,
+                }
+            ],
+            "cmd_name": "scenarios_list_resp",
+            "cseq": 2,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            await api.async_get_scenarios()
 
 
 class TestAPIUpdates:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -34,6 +34,8 @@ from aiocamedomotic.models import (
     OpeningType,
     Floor,
     Room,
+    Scenario,
+    ScenarioStatus,
 )
 
 from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
@@ -644,3 +646,97 @@ class TestRoom:
         assert room.id == "10"  # Returns as-is from raw_data
         assert room.name == "Kitchen"
         assert room.floor_id == "2"  # Returns as-is from raw_data
+
+
+class TestScenario:
+    def test_initialization(self, scenario_data_off, auth_instance):
+        scenario = Scenario(scenario_data_off, auth_instance)
+        assert scenario.raw_data == scenario_data_off
+        assert scenario.auth == auth_instance
+
+        # Test post_init validation - missing id
+        with pytest.raises(ValueError):
+            Scenario({"name": "Test"}, auth_instance)
+        # Test post_init validation - missing name
+        with pytest.raises(ValueError):
+            Scenario({"id": 1}, auth_instance)
+
+    def test_properties(self, scenario_data_on, auth_instance):
+        scenario = Scenario(scenario_data_on, auth_instance)
+        assert scenario.id == scenario_data_on["id"]
+        assert scenario.name == scenario_data_on["name"]
+        assert scenario.icon_id == scenario_data_on["icon_id"]
+        assert scenario.scenario_status == ScenarioStatus(
+            scenario_data_on["scenario_status"]
+        )
+        assert scenario.status == scenario_data_on["status"]
+        assert scenario.user_defined == scenario_data_on["user-defined"]
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_activate(
+        self,
+        mock_send_command,
+        scenario_data_off,
+        auth_instance,
+    ):
+        scenario = Scenario(scenario_data_off, auth_instance)
+
+        await scenario.async_activate()
+
+        expected_payload = {
+            "cmd_name": "scenario_activation_req",
+            "id": scenario.id,
+        }
+        mock_send_command.assert_called_once_with(expected_payload)
+
+    def test_unknown_status(self, auth_instance):
+        unknown_status_data = {
+            "id": 5,
+            "name": "Unknown Status Scenario",
+            "scenario_status": 999,
+            "status": 0,
+            "user-defined": 0,
+        }
+
+        scenario = Scenario(unknown_status_data, auth_instance)
+
+        assert scenario.raw_data == unknown_status_data
+        assert scenario.name == "Unknown Status Scenario"
+        assert scenario.scenario_status == ScenarioStatus.UNKNOWN
+
+    def test_auth_type_validation(self):
+        scenario_data = {
+            "id": 1,
+            "name": "Test Scenario",
+            "scenario_status": 0,
+            "status": 0,
+            "user-defined": 0,
+        }
+
+        # Test with non-Auth object (string)
+        with pytest.raises(
+            ValueError, match="'auth' must be an instance of Auth, got str"
+        ):
+            Scenario(scenario_data, "not_an_auth_instance")
+
+        # Test with non-Auth object (dict)
+        with pytest.raises(
+            ValueError, match="'auth' must be an instance of Auth, got dict"
+        ):
+            Scenario(scenario_data, {"fake": "auth"})
+
+    def test_edge_case_missing_optional_field(self, auth_instance):
+        scenario_data = {
+            "id": 1,
+            "name": "Minimal Scenario",
+        }
+
+        scenario = Scenario(scenario_data, auth_instance)
+
+        assert scenario.name == "Minimal Scenario"
+        assert scenario.id == 1
+        assert scenario.icon_id == 0
+        assert scenario.scenario_status == ScenarioStatus.UNKNOWN
+        assert scenario.status == 0
+        assert scenario.user_defined == 0

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -30,12 +30,11 @@ from aiocamedomotic.models import LightStatus
 from aiocamedomotic.models.opening import OpeningStatus
 
 
-
-SKIP_TESTS_ON_REAL_SERVER = True
+RUN_TESTS_ON_REAL_SERVER = False
 
 # Skip all tests in this module by default
 pytestmark = pytest.mark.skipif(
-    SKIP_TESTS_ON_REAL_SERVER,
+    not RUN_TESTS_ON_REAL_SERVER,
     reason="All tests in this module are disabled by default.",
 )
 
@@ -68,7 +67,9 @@ async def test_async_get_lights(api_instance_real: CameDomoticAPI):
         print(f"ID: {light.act_id}, Name: {light.name}, Status: {light.status}")
 
 
-async def test_async_change_light_status(api_instance_real: CameDomoticAPI, real_server_config):
+async def test_async_change_light_status(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
     lights = await api_instance_real.async_get_lights()
 
     # Get device name from config, provide a default if not found or section is missing
@@ -115,7 +116,9 @@ async def test_async_get_openings(api_instance_real: CameDomoticAPI):
     assert openings is not None, "Failed to get openings"
 
 
-async def test_async_control_specific_shutter(api_instance_real: CameDomoticAPI, real_server_config):
+async def test_async_control_specific_shutter(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
     """Tests shutter control: CLOSE -> STOPPED -> OPEN sequence."""
     wait_time_sec = 3
     shutter_name = "Tapparella Camera matrimoniale"
@@ -170,7 +173,61 @@ async def test_async_control_specific_shutter(api_instance_real: CameDomoticAPI,
     assert target_shutter.status == OpeningStatus.OPENING
 
 
-async def test_async_usage_example(api_instance_real: CameDomoticAPI, real_server_config):
+async def test_async_get_scenarios(api_instance_real: CameDomoticAPI):
+    """Tests fetching all scenarios from the server."""
+    print("\nFetching all scenarios...")
+    scenarios = await api_instance_real.async_get_scenarios()
+    if not scenarios:
+        print("No scenarios found on the server.")
+        return
+
+    print(f"Found {len(scenarios)} scenario(s):")
+    for scenario in scenarios:
+        print(
+            f"  ID: {scenario.id}"
+            f" - Name: {scenario.name}"
+            f" - Status: {scenario.scenario_status.name}"
+            f" - Icon: {scenario.icon_id}"
+            f" - User-defined: {scenario.user_defined}"
+        )
+    assert scenarios is not None, "Failed to get scenarios"
+
+
+@pytest.mark.timeout(130)
+async def test_scenario_activation_openings_down_and_up(
+    api_instance_real: CameDomoticAPI,
+):
+    """Tests scenario activation: close all shutters, wait 1 minute, then open them."""
+    scenarios = await api_instance_real.async_get_scenarios()
+    if not scenarios:
+        pytest.skip("No scenarios found on the server.")
+        return
+
+    scenario_down = next((s for s in scenarios if s.id == 8), None)
+    scenario_up = next((s for s in scenarios if s.id == 5), None)
+
+    if scenario_down is None:
+        pytest.skip("Scenario 8 not found on the server.")
+        return
+
+    if scenario_up is None:
+        pytest.skip("Scenario 5 not found on the server.")
+        return
+
+    print(f"\nActivating scenario '{scenario_down.name}' (ID: {scenario_down.id})...")
+    await scenario_down.async_activate()
+
+    print("Waiting 60 seconds...")
+    await asyncio.sleep(60)
+
+    print(f"Activating scenario '{scenario_up.name}' (ID: {scenario_up.id})...")
+    await scenario_up.async_activate()
+    print("Done.")
+
+
+async def test_async_usage_example(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
     # Get the list of all the lights configured on the CAME server
     lights = await api_instance_real.async_get_lights()
 


### PR DESCRIPTION
## Summary

- Add `Scenario` model (`aiocamedomotic/models/scenario.py`) with `async_activate()` method and `ScenarioStatus` enum
- Add `async_get_scenarios()` to `CameDomoticAPI`, exposing the full list of server-defined automation scenarios
- Add `SCENARIOS_LIST` and `SCENARIO_ACTIVATION` constants to `_CommandName` / `_CommandNameResponse` enums
- Fix a bug in `Auth.async_send_command` where response validation was checking `sl_cmd` instead of `cmd_name`, causing all data-request response checks to silently fail against a real server
- Add full unit test coverage (`TestAPIScenarios`, `TestScenario`) and real-server integration tests

## Test plan

- [x] All 186 existing unit tests pass
- [x] `test_async_get_scenarios` passes against real server (returns 8 scenarios)
- [x] `test_scenario_activation_openings_down_and_up` passes against real server (close → 60s wait → open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve and list all available home automation scenarios from the server
  * Activate scenarios to execute automation routines
  * View scenario details including status, name, and icon identification

* **Improvements**
  * Enhanced server response parsing for more reliable communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->