### PR TITLE
feat: add DeviceType enum, RGB lights, and slat control

### DIFF
--- a/API_reference.md
+++ b/API_reference.md
@@ -1,0 +1,637 @@
+# CAME ETI/Domo API — Comprehensive Documentation
+
+## Context
+
+This document fully describes the CAME ETI/Domo HTTP API as reverse-engineered from the existing `pycame` wrapper in `custom_components/came/pycame/`. The goal is to provide everything needed to write a new, clean API wrapper from scratch.
+
+---
+
+## 1. Transport Layer
+
+### 1.1 Connection Details
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `http://{host}/domo/` |
+| **HTTP Method** | `POST` (all requests) |
+| **Content-Type** | `application/x-www-form-urlencoded` |
+| **Body encoding** | `command=<JSON string>` |
+| **Response format** | JSON |
+
+### 1.2 Request Headers
+
+```
+User-Agent: PythonCameManager/{VERSION}
+Accept: application/json, text/plain, */*
+Content-Type: application/x-www-form-urlencoded
+Authorization: access_token {TOKEN}
+```
+
+The `TOKEN` is a pre-existing access token provided at configuration time (not obtained via login — it is required before any API call).
+
+### 1.3 Raw HTTP Example
+
+```http
+POST /domo/ HTTP/1.1
+Host: 192.168.1.100
+Content-Type: application/x-www-form-urlencoded
+Authorization: access_token mytoken123
+
+command={"sl_cmd":"sl_registration_req","sl_login":"user","sl_pwd":"pass"}
+```
+
+---
+
+## 2. Protocol Layers
+
+The API uses a **two-layer protocol**:
+
+### 2.1 Session Layer (`sl_*`)
+
+All requests are wrapped in a session-layer envelope.
+
+**Login request:**
+```json
+{
+  "sl_cmd": "sl_registration_req",
+  "sl_login": "<username>",
+  "sl_pwd": "<password>"
+}
+```
+
+**Application-layer request (after login):**
+```json
+{
+  "sl_cmd": "sl_data_req",
+  "sl_client_id": "<client_id>",
+  "sl_appl_msg": { /* application command */ }
+}
+```
+
+**All responses** include:
+```json
+{
+  "sl_data_ack_reason": 0,
+  "sl_cmd": "<response_command>"
+}
+```
+
+### 2.2 Application Layer (`cmd_name`)
+
+Nested inside `sl_appl_msg`. Each command has a `cmd_name` field. Responses contain the application-layer fields at top level (alongside the session-layer fields).
+
+---
+
+## 3. Authentication & Session Management
+
+### 3.1 Login
+
+| Field | Value |
+|-------|-------|
+| **Request `sl_cmd`** | `sl_registration_req` |
+| **Response `sl_cmd`** | `sl_registration_ack` |
+
+**Request:**
+```json
+{
+  "sl_cmd": "sl_registration_req",
+  "sl_login": "<username>",
+  "sl_pwd": "<password>"
+}
+```
+
+**Response (success):**
+```json
+{
+  "sl_cmd": "sl_registration_ack",
+  "sl_client_id": "<session_id>",
+  "sl_data_ack_reason": 0
+}
+```
+
+The returned `sl_client_id` must be included in every subsequent `sl_data_req`.
+
+### 3.2 Session Lifecycle
+
+- `sl_client_id` is set upon successful login
+- On any connection error, the client should clear `sl_client_id` and re-login on the next request
+- The wrapper auto-logs-in before every `application_request` if not already logged in
+
+---
+
+## 4. Error Codes
+
+The field `sl_data_ack_reason` appears in every response:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Invalid user |
+| 3 | Too many sessions during login |
+| 4 | Error in JSON syntax |
+| 5 | No session layer command tag |
+| 6 | Unrecognized session layer command |
+| 7 | No client ID in request |
+| 8 | Wrong client ID in request |
+| 9 | Wrong application command |
+| 10 | No reply to application command (service may be down) |
+| 11 | Wrong application data |
+
+---
+
+## 5. Discovery Commands
+
+### 5.1 Feature List
+
+Returns which device categories the ETI/Domo supports plus device metadata.
+
+**Request:**
+```json
+{ "cmd_name": "feature_list_req" }
+```
+
+**Response (`feature_list_resp`):**
+```json
+{
+  "cmd_name": "feature_list_resp",
+  "swver": "<software_version>",
+  "serial": "<serial_number>",
+  "keycode": "<keycode>",
+  "list": ["lights", "openings", "thermoregulation", "energy", "digitalin", "scenarios", "relays"]
+}
+```
+
+**Known feature strings:** `lights`, `openings`, `relays`, `thermoregulation`, `energy`, `digitalin`, `scenarios`
+
+### 5.2 Floor List
+
+**Request:**
+```json
+{
+  "cmd_name": "floor_list_req",
+  "topologic_scope": "plant"
+}
+```
+
+**Response (`floor_list_resp`):**
+```json
+{
+  "cmd_name": "floor_list_resp",
+  "floor_list": [
+    { "floor_ind": 0, "name": "Ground Floor" }
+  ]
+}
+```
+
+### 5.3 Room List
+
+**Request:**
+```json
+{
+  "cmd_name": "room_list_req",
+  "topologic_scope": "plant"
+}
+```
+
+**Response (`room_list_resp`):**
+```json
+{
+  "cmd_name": "room_list_resp",
+  "room_list": [
+    { "room_ind": 0, "name": "Living Room", "floor_ind": 0 }
+  ]
+}
+```
+
+---
+
+## 6. Device List Commands
+
+All device list commands use `"topologic_scope": "plant"` to retrieve all devices, or `"topologic_scope": "act"` with `"value": <act_id>` to get a single device.
+
+### 6.1 Lights
+
+**Request:** `light_list_req` / **Response:** `light_list_resp`
+
+```json
+{ "cmd_name": "light_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `act_id` | int | Unique actuator ID |
+| `name` | str | Device name |
+| `type` | str | `"STEP_STEP"`, `"DIMMER"`, or `"RGB"` |
+| `status` | int | `0`=OFF, `1`=ON, `4`=AUTO |
+| `perc` | int | Brightness 0-100 (for DIMMER/RGB) |
+| `rgb` | [int,int,int] | RGB values 0-255 each (for RGB type) |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+**Light types:**
+
+| Type | Supports Brightness | Supports Color |
+|------|--------------------:|---------------:|
+| `STEP_STEP` | No | No |
+| `DIMMER` | Yes (0-100%) | No |
+| `RGB` | Yes (via HSV V channel) | Yes (RGB) |
+
+**Light states:** `0`=OFF, `1`=ON, `4`=AUTO
+
+### 6.2 Openings (Covers/Blinds)
+
+**Request:** `openings_list_req` / **Response:** `openings_list_resp`
+
+```json
+{ "cmd_name": "openings_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `open_act_id` | int | Actuator ID (**note: different key from other devices**) |
+| `name` | str | Device name |
+| `status` | int | `0`=STOP, `1`=OPEN, `2`=CLOSE |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+**Opening states:** `0`=STOP, `1`=OPEN, `2`=CLOSE (also `3`=slat open, `4`=slat close — referenced in comments but not implemented)
+
+### 6.3 Relays (Generic Switches)
+
+**Request:** `relays_list_req` / **Response:** `relays_list_resp`
+
+```json
+{ "cmd_name": "relays_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `act_id` | int | Actuator ID |
+| `name` | str | Device name |
+| `status` | int | `0`=OFF, `1`=ON |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+### 6.4 Thermostats (Thermoregulation)
+
+**Request:** `thermo_list_req` / **Response:** `thermo_list_resp`
+
+```json
+{ "cmd_name": "thermo_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields (in `array`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `act_id` | int | Actuator ID |
+| `name` | str | Device name |
+| `status` | int | `0`=OFF, `1`=ON |
+| `mode` | int | `0`=OFF, `1`=MANUAL, `2`=AUTO, `3`=JOLLY |
+| `season` | str | `"plant_off"`, `"winter"`, `"summer"` |
+| `temp` | int | Current temperature × 10 (e.g. 215 = 21.5°C) |
+| `temp_dec` | int | Alternative field for current temperature × 10 |
+| `set_point` | int | Target temperature × 10 |
+| `fan_speed` | int | `0`=OFF, `1`=SLOW, `2`=MEDIUM, `3`=FAST, `4`=AUTO |
+| `dehumidifier` | object | `{ "enabled": 0\|1, "setpoint": <humidity%> }` |
+| `t1` | int\|null | Temperature sensor 1 |
+| `t2` | int\|null | Temperature sensor 2 |
+| `t3` | int\|null | Temperature sensor 3 |
+| `antifreeze` | int | Antifreeze setting |
+| `reason` | int | Mode reason code |
+| `f3a` | object | Advanced settings |
+| `thermo_algo` | object | Algorithm settings |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+**Additionally**, the thermo_list_resp contains **analog sensors** as top-level fields (not in the `array`):
+
+```json
+{
+  "cmd_name": "thermo_list_resp",
+  "array": [ /* thermostat zones */ ],
+  "temperature": { "name": "...", "value": 215, "unit": "°C", "act_id": ... },
+  "humidity":    { "name": "...", "value": 55,  "unit": "%",  "act_id": ... },
+  "pressure":    { "name": "...", "value": 1013, "unit": "hPa", "act_id": ... }
+}
+```
+
+**Thermostat modes:** `0`=OFF, `1`=MANUAL, `2`=AUTO, `3`=JOLLY
+
+**Seasons:** `"plant_off"`, `"winter"`, `"summer"`
+
+**Fan speeds:** `0`=OFF, `1`=SLOW, `2`=MEDIUM, `3`=FAST, `4`=AUTO
+
+**Dehumidifier states:** `0`=OFF, `1`=ON
+
+### 6.5 Energy Meters
+
+**Request:** `meters_list_req` / **Response:** `meters_list_resp`
+
+```json
+{ "cmd_name": "meters_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Meter identifier (used for matching in push updates) |
+| `act_id` | int\|null | Actuator ID (may be absent — these are "unmanaged") |
+| `name` | str | Device name |
+| `instant_power` | float | Current power in Watts |
+| `produced` | float | Total energy produced |
+| `last_24h_avg` | float | 24-hour average power |
+| `last_month_avg` | float | Monthly average power |
+| `unit` | str | Power unit (default "W") |
+| `energy_unit` | str | Energy unit (e.g. "kWh") |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+### 6.6 Digital Inputs (Binary Sensors)
+
+**Request:** `digitalin_list_req` / **Response:** `digitalin_list_resp`
+
+```json
+{ "cmd_name": "digitalin_list_req", "topologic_scope": "plant" }
+```
+
+**Response item fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `act_id` | int | Actuator ID |
+| `name` | str | Device name |
+| `status` | int | `0`=OFF, `1`=ON |
+| `floor_ind` | int | Floor index |
+| `room_ind` | int | Room index |
+
+### 6.7 Scenarios
+
+**Request:** `scenarios_list_req` / **Response:** `scenarios_list_resp`
+
+```json
+{ "cmd_name": "scenarios_list_req" }
+```
+
+Note: No `topologic_scope` needed.
+
+**Response item fields (in `array`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Scenario identifier |
+| `name` | str | Scenario name |
+
+---
+
+## 7. Control Commands
+
+All control commands return `generic_reply` unless noted:
+
+```json
+{ "cmd_name": "generic_reply", "sl_data_ack_reason": 0 }
+```
+
+### 7.1 Light Switch
+
+```json
+{
+  "cmd_name": "light_switch_req",
+  "act_id": <int>,
+  "wanted_status": <0|1|4>,
+  "perc": <0-100>,
+  "rgb": [<R>, <G>, <B>]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `act_id` | Yes | Target light |
+| `wanted_status` | Yes | `0`=OFF, `1`=ON, `4`=AUTO |
+| `perc` | No | Brightness 0-100 (DIMMER/RGB) |
+| `rgb` | No | RGB color [0-255, 0-255, 0-255] (RGB type only) |
+
+### 7.2 Opening Move
+
+```json
+{
+  "cmd_name": "opening_move_req",
+  "act_id": <int>,
+  "wanted_status": <0|1|2>
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `act_id` | Yes | Target opening (uses `open_act_id` from device info) |
+| `wanted_status` | Yes | `0`=STOP, `1`=OPEN, `2`=CLOSE |
+
+### 7.3 Relay Activation
+
+```json
+{
+  "cmd_name": "relay_activation_req",
+  "act_id": <int>,
+  "wanted_status": <0|1>
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `act_id` | Yes | Target relay |
+| `wanted_status` | Yes | `0`=OFF, `1`=ON |
+
+### 7.4 Thermostat Zone Config
+
+```json
+{
+  "cmd_name": "thermo_zone_config_req",
+  "act_id": <int>,
+  "mode": <0|1|2|3>,
+  "set_point": <int>,
+  "extended_infos": <0|1>,
+  "season": "<string>",
+  "fan_speed": <0|1|2|3|4>
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `act_id` | Yes | Target thermostat zone |
+| `mode` | Yes | `0`=OFF, `1`=MANUAL, `2`=AUTO, `3`=JOLLY (falls back to current if not changing) |
+| `set_point` | Yes | Target temperature × 10 (falls back to current if not changing) |
+| `extended_infos` | Yes | Set to `1` if `season` or `fan_speed` is included, else `0` |
+| `season` | No | `"plant_off"`, `"winter"`, `"summer"` |
+| `fan_speed` | No | `0`=OFF, `1`=SLOW, `2`=MEDIUM, `3`=FAST, `4`=AUTO |
+
+### 7.5 Scenario Activation
+
+```json
+{
+  "cmd_name": "scenario_activation_req",
+  "id": <int>
+}
+```
+
+**Note:** The expected response may be `generic_reply` but the actual response name can differ. The existing wrapper sets `resp_command=None` and catches mismatches.
+
+### 7.6 Scenario Creation
+
+```json
+{
+  "cmd_name": "scenario_registration_start",
+  "name": "<scenario_name>"
+}
+```
+
+**Response:** `scenario_registration_start_ack`
+
+### 7.7 Scenario Deletion
+
+```json
+{
+  "cmd_name": "scenario_delete_req",
+  "id": <int>
+}
+```
+
+**Response:** `scenario_delete_resp`
+
+---
+
+## 8. Status Update (Long Polling)
+
+The primary mechanism for real-time state changes.
+
+**Request:**
+```json
+{
+  "cmd_name": "status_update_req",
+  "timeout": <seconds>
+}
+```
+
+The `timeout` field is optional.
+
+**Response (`status_update_resp`):**
+```json
+{
+  "cmd_name": "status_update_resp",
+  "result": [
+    { "cmd_name": "<update_type>", "act_id": <int>, ...fields... },
+    ...
+  ]
+}
+```
+
+### 8.1 Update Indication Types
+
+The `cmd_name` within each result item indicates what changed:
+
+| cmd_name | Meaning |
+|----------|---------|
+| `light_update_ind` | Light state changed |
+| `opening_update_ind` | Opening state changed |
+| `relay_update_ind` | Relay state changed |
+| `thermo_update_ind` | Thermostat state changed |
+| `digitalin_update_ind` | Digital input state changed |
+| `plant_update_ind` | Plant configuration changed (full device refresh needed) |
+| `scenario_status_ind` | Scenario status changed (has `id` field) |
+| `scenario_user_ind` | User scenario action (`action` field: `"add"`, `"create"`) |
+
+Each update indication contains the same fields as the corresponding device in the list response, keyed by `act_id` for matching.
+
+When `plant_update_ind` is received, all cached devices should be discarded and re-fetched.
+
+---
+
+## 9. Single-Device Force Update
+
+To refresh a single device, use the list command with per-actuator scope:
+
+```json
+{
+  "cmd_name": "<type>_list_req",
+  "topologic_scope": "act",
+  "value": <act_id>
+}
+```
+
+Where `<type>` is: `light`, `opening`, `relay`, `thermo`, `meters`, `digitalin`.
+
+The response uses the corresponding `<type>_list_resp` with the same field structure.
+
+**Note:** For some types (e.g. analog sensors returned under `thermo`), the response field may not be `"array"` but a named field like `"temperature"`, `"humidity"`, or `"pressure"`.
+
+---
+
+## 10. Device Type Registry
+
+These are all known device types in the ETI/Domo system:
+
+| Type ID | Name | Implemented | API Feature |
+|---------|------|:-----------:|-------------|
+| -2 | Energy Sensor | Yes | `energy` |
+| -1 | Analog Sensor | Yes | (embedded in `thermoregulation`) |
+| 0 | Light | Yes | `lights` |
+| 1 | Opening | Yes | `openings` |
+| 2 | Thermostat | Yes | `thermoregulation` |
+| 3 | Page | No | — |
+| 4 | Scenario | Yes | `scenarios` |
+| 5 | Camera | No | — |
+| 6 | Security Panel | No | — |
+| 7 | Security Area | No | — |
+| 8 | Security Scenario | No | — |
+| 9 | Security Input | No | — |
+| 10 | Security Output | No | — |
+| 11 | Generic Relay | Yes | `relays` |
+| 12 | Generic Text | No (disabled) | — |
+| 13 | Sound Zone | No | — |
+| 14 | Digital Input | Yes | `digitalin` |
+
+---
+
+## 11. Complete API Endpoint Summary
+
+| # | Request `cmd_name` | Response `cmd_name` | `topologic_scope` | Key Response Fields |
+|---|-------------------|---------------------|-------------------|---------------------|
+| 1 | `feature_list_req` | `feature_list_resp` | — | `swver`, `serial`, `keycode`, `list` |
+| 2 | `floor_list_req` | `floor_list_resp` | `plant` | `floor_list` |
+| 3 | `room_list_req` | `room_list_resp` | `plant` | `room_list` |
+| 4 | `light_list_req` | `light_list_resp` | `plant` or `act` | `array` |
+| 5 | `openings_list_req` | `openings_list_resp` | `plant` or `act` | `array` |
+| 6 | `relays_list_req` | `relays_list_resp` | `plant` or `act` | `array` |
+| 7 | `thermo_list_req` | `thermo_list_resp` | `plant` or `act` | `array`, `temperature`, `humidity`, `pressure` |
+| 8 | `meters_list_req` | `meters_list_resp` | `plant` or `act` | `array` |
+| 9 | `digitalin_list_req` | `digitalin_list_resp` | `plant` or `act` | `array` |
+| 10 | `scenarios_list_req` | `scenarios_list_resp` | — | `array` |
+| 11 | `light_switch_req` | `generic_reply` | — | — |
+| 12 | `opening_move_req` | `generic_reply` | — | — |
+| 13 | `relay_activation_req` | `generic_reply` | — | — |
+| 14 | `thermo_zone_config_req` | `generic_reply` | — | — |
+| 15 | `scenario_activation_req` | *(varies)* | — | — |
+| 16 | `scenario_registration_start` | `scenario_registration_start_ack` | — | — |
+| 17 | `scenario_delete_req` | `scenario_delete_resp` | — | — |
+| 18 | `status_update_req` | `status_update_resp` | — | `result` (array of update indications) |
+
+---
+
+## 12. Known Quirks & Edge Cases
+
+1. **Opening uses `open_act_id`** instead of `act_id` — the only device type that does this.
+2. **Energy sensors may lack `act_id`** — they use `id` for matching in push updates and may raise "unmanaged device" errors on force-update.
+3. **Thermostat temperatures are × 10** — `set_point=215` means 21.5°C.
+4. **Analog sensors are nested** in the `thermo_list_resp` as top-level fields (`temperature`, `humidity`, `pressure`), not in the `array`.
+5. **Scenario activation response** doesn't always match `generic_reply` — the wrapper catches this mismatch specially.
+6. **`plant_update_ind`** in status updates means the entire device topology changed and all caches must be invalidated.
+7. **`extended_infos`** flag in thermostat config must be set to `1` when sending `season` or `fan_speed`.
+8. **Digital input** references `self._update_cmd_base` and `self._update_src_field` which are never initialized in its `__init__` — this is a bug in the current wrapper.
+9. **Fan speed `0` (OFF)** is treated as AUTO in the HA mapping — when the fan is OFF, the app shows it as AUTO.
+10. **`status_update_req`** blocks (long polls) until a state change occurs or the optional timeout expires.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,10 @@ Tests can run against a real CAME Domotic server (skipped by default):
 
 **Never commit** `test_config.ini` or leave `SKIP_TESTS_ON_REAL_SERVER = False`.
 
+## API Reference
+
+The complete CAME Domotic API reference, reverse engineered from another library, is available in `API_reference.md`.
+
 ## Other notes
 
 - The `master` git branch is protected, to merge you must create a new branch and raise a PR

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -16,7 +16,7 @@
 Constants for the CAME Domotic API.
 """
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 # ACK error codes and their meanings from the CAME Domotic server
 ACK_ERROR_CODES = {
@@ -58,6 +58,42 @@ def is_auth_error(ack_code: int) -> bool:
         bool: True if the error code is authentication-related.
     """
     return ack_code in AUTH_ERROR_CODES
+
+
+class DeviceType(IntEnum):
+    """Device type IDs used by the CAME ETI/Domo system.
+
+    Each device in the CAME Domotic system is associated with one of these type
+    identifiers. Not all device types are currently supported by this library.
+
+    Supported types:
+        - ENERGY_SENSOR (-2)
+        - ANALOG_SENSOR (-1)
+        - LIGHT (0)
+        - OPENING (1)
+        - THERMOSTAT (2)
+        - SCENARIO (4)
+        - GENERIC_RELAY (11)
+        - DIGITAL_INPUT (14)
+    """
+
+    ENERGY_SENSOR = -2
+    ANALOG_SENSOR = -1
+    LIGHT = 0
+    OPENING = 1
+    THERMOSTAT = 2
+    PAGE = 3
+    SCENARIO = 4
+    CAMERA = 5
+    SECURITY_PANEL = 6
+    SECURITY_AREA = 7
+    SECURITY_SCENARIO = 8
+    SECURITY_INPUT = 9
+    SECURITY_OUTPUT = 10
+    GENERIC_RELAY = 11
+    GENERIC_TEXT = 12
+    SOUND_ZONE = 13
+    DIGITAL_INPUT = 14
 
 
 # region Enums for building the JSON commands to be sent to the Came Domotic server
@@ -123,6 +159,7 @@ class _TopologicScope(Enum):
 class _ServerFeature(Enum):
     LIGHTS = "lights"
     OPENINGS = "openings"
+    RELAYS = "relays"
     THERMOREGULATION = "thermoregulation"
     SCENARIOS = "scenarios"
     DIGITALIN = "digitalin"
@@ -131,3 +168,27 @@ class _ServerFeature(Enum):
 
 
 # endregion
+
+
+# Mapping from status update cmd_name to DeviceType
+_UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
+    "light_update_ind": DeviceType.LIGHT,
+    "opening_update_ind": DeviceType.OPENING,
+    "relay_update_ind": DeviceType.GENERIC_RELAY,
+    "thermo_update_ind": DeviceType.THERMOSTAT,
+    "thermo_zone_info_ind": DeviceType.THERMOSTAT,
+    "digitalin_update_ind": DeviceType.DIGITAL_INPUT,
+    "scenario_status_ind": DeviceType.SCENARIO,
+    "scenario_user_ind": DeviceType.SCENARIO,
+}
+
+# Mapping from DeviceType to the corresponding server feature
+_DEVICE_TYPE_TO_FEATURE: dict[DeviceType, _ServerFeature] = {
+    DeviceType.LIGHT: _ServerFeature.LIGHTS,
+    DeviceType.OPENING: _ServerFeature.OPENINGS,
+    DeviceType.GENERIC_RELAY: _ServerFeature.RELAYS,
+    DeviceType.THERMOSTAT: _ServerFeature.THERMOREGULATION,
+    DeviceType.SCENARIO: _ServerFeature.SCENARIOS,
+    DeviceType.DIGITAL_INPUT: _ServerFeature.DIGITALIN,
+    DeviceType.ENERGY_SENSOR: _ServerFeature.ENERGY,
+}

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -19,8 +19,10 @@ CAME Domotic API.
 
 from .base import CameEntity, ServerInfo, User, Floor, Room  # noqa: F401
 from .light import Light, LightType, LightStatus  # noqa: F401
-from .update import UpdateList  # noqa: F401
+from .update import UpdateList, get_update_device_type  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
+
+from ..const import DeviceType  # noqa: F401
 
 # Digital inputs

--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -16,15 +16,15 @@
 CAME Domotic light entity models and control functionality.
 
 This module implements the classes for working with lights in a CAME Domotic
-system, supporting both standard on/off lights (STEP_STEP type) and dimmable
-lights (DIMMER type). It provides properties to access light attributes and
-methods to control light state, including on/off functionality and brightness
-control for dimmable lights.
+system, supporting standard on/off lights (STEP_STEP type), dimmable lights
+(DIMMER type), and RGB color lights (RGB type). It provides properties to
+access light attributes and methods to control light state, including on/off
+functionality, brightness control, and RGB color control.
 """
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from ..auth import Auth
 from ..const import _CommandName
@@ -42,10 +42,12 @@ class LightStatus(Enum):
     Allowed values are:
         - OFF (0)
         - ON (1)
+        - AUTO (4)
     """
 
     OFF = 0
     ON = 1
+    AUTO = 4
 
 
 class LightType(Enum):
@@ -54,10 +56,12 @@ class LightType(Enum):
     Allowed values are:
         - STEP_STEP (normal lights)
         - DIMMER (dimmable lights)
+        - RGB (color lights with brightness via HSV V channel)
     """
 
     STEP_STEP = "STEP_STEP"
     DIMMER = "DIMMER"
+    RGB = "RGB"
     UNKNOWN = "UNKNOWN_LIGHT_TYPE"
 
 
@@ -104,14 +108,14 @@ class Light(CameEntity):
 
     @property
     def status(self) -> LightStatus:
-        """Status of the light. Allowed values are ON (1) and OFF (0)."""
+        """Status of the light. Allowed values are OFF (0), ON (1) and AUTO (4)."""
         return LightStatus(self.raw_data["status"])
 
     @property
     def type(self) -> LightType:
         """
-        Light type. Allowed values are "STEP_STEP" (normal lights) and "DIMMER"
-        (dimmable lights).
+        Light type. Allowed values are "STEP_STEP" (normal lights),
+        "DIMMER" (dimmable lights), and "RGB" (color lights).
 
         Raises:
             ValueError: If the light type is not recognized.
@@ -136,8 +140,19 @@ class Light(CameEntity):
         """
         return self.raw_data.get("perc", 100)
 
+    @property
+    def rgb(self) -> Optional[List[int]]:
+        """
+        RGB color values of the light as [R, G, B], each in range 0-255.
+        Returns None for non-RGB lights.
+        """
+        return self.raw_data.get("rgb")
+
     async def async_set_status(
-        self, status: LightStatus, brightness: Optional[int] = None
+        self,
+        status: LightStatus,
+        brightness: Optional[int] = None,
+        rgb: Optional[List[int]] = None,
     ) -> None:
         """Control the light.
 
@@ -145,21 +160,34 @@ class Light(CameEntity):
             status (LightStatus): Status of the light.
             brightness (Optional[int]): Brightness percentage of the light (range
                 0-100). If the brightness is not provided, it will stay unchanged.
-                This argument is ignored for non-dimmable lights.
+                This argument is ignored for STEP_STEP lights.
+            rgb (Optional[List[int]]): RGB color values as [R, G, B], each in
+                range 0-255. If not provided, the color stays unchanged.
+                This argument is ignored for non-RGB lights.
 
         Raises:
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
         """
-        # Early exit for non-dimmable lights receiving a brightness value
-        if self.type != LightType.DIMMER:
+        # Ignore brightness for non-dimmable/non-RGB lights
+        if self.type not in (LightType.DIMMER, LightType.RGB):
             LOGGER.debug(
                 "Light '%s' (type: %s) is not dimmable or type is unknown. "
                 "Ignoring brightness setting.",
                 self.name,
                 self.type.name,
             )
-            brightness = None  # Ignore brightness since it's not applicable
+            brightness = None
+
+        # Ignore RGB for non-RGB lights
+        if self.type != LightType.RGB and rgb is not None:
+            LOGGER.debug(
+                "Light '%s' (type: %s) does not support RGB. "
+                "Ignoring rgb setting.",
+                self.name,
+                self.type.name,
+            )
+            rgb = None
 
         if self.type == LightType.UNKNOWN:
             LOGGER.warning(
@@ -173,16 +201,22 @@ class Light(CameEntity):
         LOGGER.debug(
             "User authenticated, sending 'light_switch_req' command to the API."
         )
-        payload = self._prepare_light_payload(status, brightness, client_id)
+        payload = self._prepare_light_payload(status, brightness, rgb, client_id)
         await self.auth.async_send_command(payload)
 
         # Update the status of the light if everything went as expected
         self.raw_data["status"] = status.value
         if brightness is not None:
             self.raw_data["perc"] = max(0, min(brightness, 100))
+        if rgb is not None:
+            self.raw_data["rgb"] = [max(0, min(v, 255)) for v in rgb]
 
     def _prepare_light_payload(
-        self, status: LightStatus, brightness: Optional[int], client_id: str
+        self,
+        status: LightStatus,
+        brightness: Optional[int],
+        rgb: Optional[List[int]],
+        client_id: str,
     ) -> Dict:
         """Prepare the payload for the light control API call."""
         payload = {
@@ -192,8 +226,9 @@ class Light(CameEntity):
         }
 
         if brightness is not None and isinstance(brightness, int):
-            payload["perc"] = max(  # type: ignore
-                0, min(brightness, 100)
-            )  # Normalize and add brightness
+            payload["perc"] = max(0, min(brightness, 100))
+
+        if rgb is not None and isinstance(rgb, list) and len(rgb) == 3:
+            payload["rgb"] = [max(0, min(v, 255)) for v in rgb]
 
         return payload

--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -182,8 +182,7 @@ class Light(CameEntity):
         # Ignore RGB for non-RGB lights
         if self.type != LightType.RGB and rgb is not None:
             LOGGER.debug(
-                "Light '%s' (type: %s) does not support RGB. "
-                "Ignoring rgb setting.",
+                "Light '%s' (type: %s) does not support RGB. " "Ignoring rgb setting.",
                 self.name,
                 self.type.name,
             )

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -42,11 +42,15 @@ class OpeningStatus(Enum):
         - STOPPED (0)
         - OPENING (1)
         - CLOSING (2)
+        - SLAT_OPEN (3)
+        - SLAT_CLOSE (4)
     """
 
     STOPPED = 0
     OPENING = 1
     CLOSING = 2
+    SLAT_OPEN = 3
+    SLAT_CLOSE = 4
     UNKNOWN = -1
 
 
@@ -98,8 +102,8 @@ class Opening(CameEntity):
 
     @property
     def status(self) -> OpeningStatus:
-        """Current status of the opening. Allowed values: STOPPED (0), OPENING (1) and
-        CLOSING (2)."""
+        """Current status of the opening. Allowed values: STOPPED (0), OPENING (1),
+        CLOSING (2), SLAT_OPEN (3) and SLAT_CLOSE (4)."""
         try:
             return OpeningStatus(self.raw_data["status"])
         except ValueError:
@@ -160,7 +164,7 @@ class Opening(CameEntity):
 
     async def async_set_status(self, status: OpeningStatus) -> None:
         """
-        Control the opening (open, close, stop).
+        Control the opening (open, close, stop, slat open, slat close).
 
         Args:
             status (OpeningStatus): Status to set for the opening.
@@ -170,7 +174,9 @@ class Opening(CameEntity):
             CameDomoticServerError: If the server returns an error.
         """
         act_id = (
-            self.close_act_id if status == OpeningStatus.CLOSING else self.open_act_id
+            self.close_act_id
+            if status in (OpeningStatus.CLOSING, OpeningStatus.SLAT_CLOSE)
+            else self.open_act_id
         )
         LOGGER.debug(
             "Sending cmd 'opening_move_req' for ID %s to status %s.",

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -23,11 +23,29 @@ the CAME Domotic API, facilitating the consumption of system state changes.
 
 from dataclasses import dataclass
 
-from typing import Any
+from typing import Any, Optional
 from collections import UserList
 
 from .base import CameEntity
+from ..const import DeviceType, _UPDATE_CMD_TO_DEVICE_TYPE
 from ..utils import LOGGER
+
+
+def get_update_device_type(update: dict[str, Any]) -> Optional[DeviceType]:
+    """Return the device type for a status update dict, or None if unknown.
+
+    Args:
+        update: A single update dict from the ``status_update_resp`` result
+            array. Must contain a ``cmd_name`` key.
+
+    Returns:
+        The corresponding :class:`~aiocamedomotic.const.DeviceType`, or
+        ``None`` if the ``cmd_name`` is not recognized.
+    """
+    cmd_name: str | None = update.get("cmd_name")
+    if cmd_name is None:
+        return None
+    return _UPDATE_CMD_TO_DEVICE_TYPE.get(cmd_name)
 
 
 @dataclass

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -50,6 +50,13 @@ Entity models
    :members:
 
 
+Constants
+---------
+
+.. automodule:: aiocamedomotic.const
+   :members: DeviceType
+
+
 Errors
 ------
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -48,7 +48,9 @@ To work with CAME devices, you may need one or more of the following imports:
 
 .. code-block:: python
 
-    from aiocamedomotic.models import LightStatus, OpeningStatus, ScenarioStatus
+    from aiocamedomotic.models import (
+        DeviceType, LightStatus, OpeningStatus, ScenarioStatus,
+    )
 
 
 Handling Exceptions

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -150,6 +150,20 @@ def light_data_dimmable():
 
 
 @pytest.fixture
+def light_data_rgb():
+    return {
+        "act_id": 1,
+        "floor_ind": 2,
+        "name": "Test RGB Light",
+        "room_ind": 3,
+        "status": 1,
+        "type": "RGB",
+        "perc": 75,
+        "rgb": [255, 128, 0],
+    }
+
+
+@pytest.fixture
 def opening_data_shutter_stopped():
     """Mock data for a stopped shutter opening."""
     return {

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from aiocamedomotic import Auth
 from aiocamedomotic.errors import CameDomoticAuthError
+from aiocamedomotic.const import DeviceType, _UPDATE_CMD_TO_DEVICE_TYPE, _DEVICE_TYPE_TO_FEATURE, _ServerFeature
 from aiocamedomotic.models import (
     ServerInfo,
     User,
@@ -36,9 +37,59 @@ from aiocamedomotic.models import (
     Room,
     Scenario,
     ScenarioStatus,
+    get_update_device_type,
 )
 
 from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
+
+
+class TestDeviceType:
+    def test_enum_values(self):
+        assert DeviceType.ENERGY_SENSOR == -2
+        assert DeviceType.ANALOG_SENSOR == -1
+        assert DeviceType.LIGHT == 0
+        assert DeviceType.OPENING == 1
+        assert DeviceType.THERMOSTAT == 2
+        assert DeviceType.PAGE == 3
+        assert DeviceType.SCENARIO == 4
+        assert DeviceType.CAMERA == 5
+        assert DeviceType.SECURITY_PANEL == 6
+        assert DeviceType.SECURITY_AREA == 7
+        assert DeviceType.SECURITY_SCENARIO == 8
+        assert DeviceType.SECURITY_INPUT == 9
+        assert DeviceType.SECURITY_OUTPUT == 10
+        assert DeviceType.GENERIC_RELAY == 11
+        assert DeviceType.GENERIC_TEXT == 12
+        assert DeviceType.SOUND_ZONE == 13
+        assert DeviceType.DIGITAL_INPUT == 14
+
+    def test_lookup_by_value(self):
+        assert DeviceType(0) == DeviceType.LIGHT
+        assert DeviceType(-2) == DeviceType.ENERGY_SENSOR
+        assert DeviceType(14) == DeviceType.DIGITAL_INPUT
+
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError):
+            DeviceType(99)
+
+    def test_update_cmd_to_device_type_mapping(self):
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["light_update_ind"] == DeviceType.LIGHT
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["opening_update_ind"] == DeviceType.OPENING
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["relay_update_ind"] == DeviceType.GENERIC_RELAY
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["thermo_update_ind"] == DeviceType.THERMOSTAT
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["thermo_zone_info_ind"] == DeviceType.THERMOSTAT
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["digitalin_update_ind"] == DeviceType.DIGITAL_INPUT
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_status_ind"] == DeviceType.SCENARIO
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_user_ind"] == DeviceType.SCENARIO
+
+    def test_device_type_to_feature_mapping(self):
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.LIGHT] == _ServerFeature.LIGHTS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.OPENING] == _ServerFeature.OPENINGS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.GENERIC_RELAY] == _ServerFeature.RELAYS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.THERMOSTAT] == _ServerFeature.THERMOREGULATION
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.SCENARIO] == _ServerFeature.SCENARIOS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.DIGITAL_INPUT] == _ServerFeature.DIGITALIN
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.ENERGY_SENSOR] == _ServerFeature.ENERGY
 
 
 class TestServerInfo:
@@ -215,6 +266,17 @@ class TestUpdateList:
         updates = UpdateList(12345)
         assert updates.data == []
 
+    def test_get_update_device_type_known(self):
+        assert get_update_device_type({"cmd_name": "light_update_ind"}) == DeviceType.LIGHT
+        assert get_update_device_type({"cmd_name": "opening_update_ind"}) == DeviceType.OPENING
+        assert get_update_device_type({"cmd_name": "thermo_zone_info_ind"}) == DeviceType.THERMOSTAT
+
+    def test_get_update_device_type_unknown(self):
+        assert get_update_device_type({"cmd_name": "plant_update_ind"}) is None
+
+    def test_get_update_device_type_missing_cmd_name(self):
+        assert get_update_device_type({}) is None
+
 
 class TestLight:
     def test_initialization(self, light_data_on_off, auth_instance):
@@ -328,6 +390,150 @@ class TestLight:
         assert light.act_id == 1
         assert light.status == LightStatus.ON
 
+    def test_status_auto(self, auth_instance):
+        light_data = {
+            "act_id": 1,
+            "name": "Auto Light",
+            "status": 4,
+            "type": "STEP_STEP",
+        }
+
+        light = Light(light_data, auth_instance)
+
+        assert light.status == LightStatus.AUTO
+
+    def test_rgb_type(self, light_data_rgb, auth_instance):
+        light = Light(light_data_rgb, auth_instance)
+
+        assert light.type == LightType.RGB
+        assert light.perc == 75
+        assert light.rgb == [255, 128, 0]
+
+    def test_rgb_property_non_rgb_light(self, light_data_on_off, auth_instance):
+        light = Light(light_data_on_off, auth_instance)
+
+        assert light.rgb is None
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_rgb(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        light_data_rgb,
+        auth_instance,
+    ):
+        light = Light(light_data_rgb, auth_instance)
+
+        await light.async_set_status(LightStatus.ON, brightness=80, rgb=[0, 255, 0])
+
+        mock_send_command.assert_called_once()
+        payload = mock_send_command.call_args[0][0]
+        assert payload["wanted_status"] == LightStatus.ON.value
+        assert payload["perc"] == 80
+        assert payload["rgb"] == [0, 255, 0]
+        assert light.rgb == [0, 255, 0]
+        assert light.perc == 80
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_rgb_ignored_for_non_rgb(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        light_data_dimmable,
+        auth_instance,
+    ):
+        light = Light(light_data_dimmable, auth_instance)
+
+        await light.async_set_status(LightStatus.ON, brightness=50, rgb=[0, 255, 0])
+
+        payload = mock_send_command.call_args[0][0]
+        assert "rgb" not in payload
+        assert payload["perc"] == 50
+        assert light.rgb is None
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_rgb_brightness_supported(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        light_data_rgb,
+        auth_instance,
+    ):
+        light = Light(light_data_rgb, auth_instance)
+
+        await light.async_set_status(LightStatus.ON, brightness=60)
+
+        payload = mock_send_command.call_args[0][0]
+        assert payload["perc"] == 60
+        assert "rgb" not in payload
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_rgb_clamps_values(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        light_data_rgb,
+        auth_instance,
+    ):
+        light = Light(light_data_rgb, auth_instance)
+
+        await light.async_set_status(LightStatus.ON, rgb=[300, -10, 128])
+
+        payload = mock_send_command.call_args[0][0]
+        assert payload["rgb"] == [255, 0, 128]
+        assert light.rgb == [255, 0, 128]
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_auto(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        light_data_on_off,
+        auth_instance,
+    ):
+        light = Light(light_data_on_off, auth_instance)
+
+        await light.async_set_status(LightStatus.AUTO)
+
+        payload = mock_send_command.call_args[0][0]
+        assert payload["wanted_status"] == 4
+        assert light.status == LightStatus.AUTO
+
     def test_status_unknown_value(self, auth_instance):
         light_data = {
             "act_id": 1,
@@ -397,6 +603,8 @@ class TestOpening:
         assert OpeningStatus.STOPPED.value == 0
         assert OpeningStatus.OPENING.value == 1
         assert OpeningStatus.CLOSING.value == 2
+        assert OpeningStatus.SLAT_OPEN.value == 3
+        assert OpeningStatus.SLAT_CLOSE.value == 4
 
     def test_type_enum(self):
         assert OpeningType.SHUTTER.value == 0
@@ -517,6 +725,88 @@ class TestOpening:
         mock_send_command.assert_called_with(expected_payload_stopped)
         assert opening.status == OpeningStatus.STOPPED
         assert mock_send_command.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="mock_client_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_slat_open(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        opening_data_shutter_stopped,
+        auth_instance,
+    ):
+        opening = Opening(opening_data_shutter_stopped, auth_instance)
+
+        await opening.async_set_status(OpeningStatus.SLAT_OPEN)
+
+        expected_payload = {
+            "act_id": opening.open_act_id,
+            "cmd_name": "opening_move_req",
+            "wanted_status": OpeningStatus.SLAT_OPEN.value,
+        }
+        mock_send_command.assert_called_with(expected_payload)
+        assert opening.status == OpeningStatus.SLAT_OPEN
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="mock_client_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_slat_close(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        opening_data_shutter_stopped,
+        auth_instance,
+    ):
+        opening = Opening(opening_data_shutter_stopped, auth_instance)
+
+        await opening.async_set_status(OpeningStatus.SLAT_CLOSE)
+
+        expected_payload = {
+            "act_id": opening.close_act_id,
+            "cmd_name": "opening_move_req",
+            "wanted_status": OpeningStatus.SLAT_CLOSE.value,
+        }
+        mock_send_command.assert_called_with(expected_payload)
+        assert opening.status == OpeningStatus.SLAT_CLOSE
+
+    def test_status_slat_open_from_raw_data(self, auth_instance):
+        data = {
+            "open_act_id": 10,
+            "close_act_id": 11,
+            "name": "Slat Opening",
+            "status": 3,
+            "type": 0,
+            "partial": [],
+        }
+
+        opening = Opening(data, auth_instance)
+
+        assert opening.status == OpeningStatus.SLAT_OPEN
+
+    def test_status_slat_close_from_raw_data(self, auth_instance):
+        data = {
+            "open_act_id": 10,
+            "close_act_id": 11,
+            "name": "Slat Opening",
+            "status": 4,
+            "type": 0,
+            "partial": [],
+        }
+
+        opening = Opening(data, auth_instance)
+
+        assert opening.status == OpeningStatus.SLAT_CLOSE
 
     def test_auth_type_validation(self):
         opening_data = {


### PR DESCRIPTION
## Summary
- Add `DeviceType` IntEnum with all known CAME ETI/Domo device type IDs, plus mappings from status update commands to device types and from device types to server features
- Extend light model with RGB type (color control via `[R, G, B]` values) and AUTO status
- Add SLAT_OPEN / SLAT_CLOSE statuses for opening slat positioning control
- Add reverse-engineered CAME API reference document

## Test plan
- [x] All 206 existing + new tests pass (`pytest` green)
- [x] New tests cover DeviceType enum values, mappings, RGB light control (including value clamping), AUTO status, and slat open/close operations
- [ ] Verify CI passes on all supported Python versions (3.12, 3.13, 3.14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RGB color control support for compatible lights.
  * Added slat open/close controls for window coverings.
  * Introduced DeviceType enumeration for improved type safety across the library.

* **Documentation**
  * Added comprehensive API reference documentation detailing endpoints, protocols, and device types.
  * Updated usage examples with new DeviceType imports.

* **Tests**
  * Expanded test coverage for new device types, mappings, and light/opening control features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->