### PR TITLE
Fix build-publish workflow: use auto-merge for version bump PR

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -109,7 +109,34 @@ jobs:
         if: steps.create_branch_tag.outcome == 'success'
         run: |
           gh pr create --title "Update version to ${{ steps.update_version.outputs.version }}" --body "This pull request updates the library version to ${{ steps.update_version.outputs.version }}." --base master --head update-version
-          gh pr merge --admin --squash --delete-branch
+          gh pr merge --admin --squash --delete-branch --auto
+
+      - name: Wait for PR to be merged
+        if: steps.create_pr.outcome == 'success'
+        run: |
+          PR_NUMBER=$(gh pr list --head update-version --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "PR already merged or not found, checking by state..."
+            PR_NUMBER=$(gh pr list --head update-version --state merged --json number --jq '.[0].number')
+            if [ -n "$PR_NUMBER" ]; then
+              echo "PR #$PR_NUMBER already merged."
+              exit 0
+            fi
+            echo "::error::Could not find the PR"
+            exit 1
+          fi
+          echo "Waiting for PR #$PR_NUMBER to be merged..."
+          for i in $(seq 1 30); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR #$PR_NUMBER merged successfully."
+              exit 0
+            fi
+            echo "Attempt $i/30: PR state is '$STATE'. Waiting 10s..."
+            sleep 10
+          done
+          echo "::error::Timed out waiting for PR to be merged"
+          exit 1
 
       - name: Checkout and push to master
         run: |


### PR DESCRIPTION
## Summary
- Add `--auto` flag to `gh pr merge` so the version bump PR waits for required status checks to pass before merging, instead of failing immediately
- Keep `--admin` to bypass required reviews on the automated PR
- Add a polling step (up to 5 minutes) to block subsequent workflow steps until the merge completes

## Test plan
- [ ] Re-run the "Build and publish" workflow after merging this PR and verify the version bump PR is auto-merged successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated build and deployment pipeline to ensure more reliable release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->