### PR TITLE
Fix build-publish: use --auto instead of --admin for PR merge

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -109,7 +109,7 @@ jobs:
         if: steps.create_branch_tag.outcome == 'success'
         run: |
           gh pr create --title "Update version to ${{ steps.update_version.outputs.version }}" --body "This pull request updates the library version to ${{ steps.update_version.outputs.version }}." --base master --head update-version
-          gh pr merge --admin --squash --delete-branch --auto
+          gh pr merge --auto --squash --delete-branch
 
       - name: Wait for PR to be merged
         if: steps.create_pr.outcome == 'success'


### PR DESCRIPTION
## Summary
- `--auto` and `--admin` are mutually exclusive flags in `gh pr merge`
- Replace `--admin` with `--auto` so the merge waits for the 3 required status checks to pass before merging

## Context
The previous fix (#182) added `--auto` alongside `--admin`, but `gh` rejects that combination with: `specify only one of --auto, --disable-auto, or --admin`