### PR TITLE
Fix: update SKIP_TESTS_ON_REAL_SERVER refs to RUN_TESTS_ON_REAL_SERVER

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,10 @@ Tests can run against a real CAME Domotic server (skipped by default):
 
 1. Copy `tests/aiocamedomotic/test_config.ini.example` to `test_config.ini`
 2. Fill in server credentials (host, username, password)
-3. Set `SKIP_TESTS_ON_REAL_SERVER = False` in `test_real.py`
+3. Set `RUN_TESTS_ON_REAL_SERVER = True` in `test_real.py`
 4. Run: `pytest tests/aiocamedomotic/test_real.py -v`
 
-**Never commit** `test_config.ini` or leave `SKIP_TESTS_ON_REAL_SERVER = False`.
+**Never commit** `test_config.ini` or leave `RUN_TESTS_ON_REAL_SERVER = True`.
 
 ## API Reference
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ To run tests against a real server:
     shutter_name = Your Test Shutter Name
     ```
 3.  **Ensure `test_config.ini` is in your `.gitignore` file** (it should be by default if you pull recent changes).
-4.  Set the `SKIP_TESTS_ON_REAL_SERVER` variable in `tests/aiocamedomotic/test_real.py` to `False`.
+4.  Set the `RUN_TESTS_ON_REAL_SERVER` variable in `tests/aiocamedomotic/test_real.py` to `True`.
 5.  Run the tests:
     ```bash
     pytest tests/aiocamedomotic/test_real.py -v
@@ -67,7 +67,7 @@ To run tests against a real server:
 
 **Important security notes:**
 - Never commit your `test_config.ini` file with real server credentials to the repository.
-- Always reset `SKIP_TESTS_ON_REAL_SERVER` to `True` before committing changes if you modified it locally for testing.
+- Always reset `RUN_TESTS_ON_REAL_SERVER` to `False` before committing changes if you modified it locally for testing.
 - Consider using a dedicated test user account on your CAME Domotic server for testing.
 
 ## Branch naming convention

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -16,8 +16,8 @@
 Test module for real server connections.
 
 These tests are designed to be run against a real CAME Domotic server.
-They are skipped by default, but can be enabled by setting the SKIP_TESTS_ON_REAL_SERVER
-variable to False.
+They are skipped by default, but can be enabled by setting the RUN_TESTS_ON_REAL_SERVER
+variable to True.
 """
 
 # pylint: disable=missing-function-docstring


### PR DESCRIPTION
## Summary
- Update all references to the renamed `RUN_TESTS_ON_REAL_SERVER` variable (formerly `SKIP_TESTS_ON_REAL_SERVER`) in CONTRIBUTING.md, CLAUDE.md, and test_real.py docstring
- The variable was renamed and its logic inverted: set to `True` to enable real server tests instead of `False` to skip them

## Test plan
- [x] Verify CONTRIBUTING.md instructions match the actual variable name and logic in test_real.py
- [x] Verify CLAUDE.md instructions are consistent