### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -191,7 +191,7 @@ jobs:
       id-token: write
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: built-package
           path: dist
@@ -214,7 +214,7 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: built-package
           path: dist

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -79,7 +79,7 @@ jobs:
     - name: SonarCloud Scan
       # continue-on-error for PRs where SONAR_TOKEN may not be available (e.g., dependabot)
       continue-on-error: true
-      uses: SonarSource/sonarcloud-github-action@v5
+      uses: SonarSource/sonarqube-scan-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
       run: bandit -r ./aiocamedomotic
 
     - name: GitGuardian scan
-      uses: GitGuardian/ggshield-action@v1.47.0
+      uses: GitGuardian/ggshield-action@v1.48.0
       env:
         GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
         GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}


### PR DESCRIPTION
## Summary
- Update `actions/download-artifact` from v7 to v8
- Update `GitGuardian/ggshield-action` from v1.47.0 to v1.48.0
- Migrate `SonarSource/sonarcloud-github-action@v5` to `SonarSource/sonarqube-scan-action@v5` (sonarcloud repo was archived Oct 2025)

## Test plan
- [ ] Verify CI workflows pass on this PR
- [ ] Confirm SonarCloud scan still works with the new action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow tools and dependencies, including artifact handling, code quality scanning, and security checks to their latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->