### PR TITLE
Add ThermoZone and AnalogSensor to API reference docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ AIOCameDomotic is an unofficial Python library that provides an asynchronous API
   - Private methods: prefixed with underscore (e.g., `_attempt_login`)
   - Constants: UPPER_SNAKE_CASE (typically in const.py)
 - **Error Handling**: Custom exceptions from base `CameDomoticError`, specific try/except blocks
-- **Documentation**: Docstrings for all public classes/methods with parameters, return values, and exceptions
+- **Documentation**: Docstrings for all public classes/methods with parameters, return values, and exceptions. When adding a new model module, also add a corresponding `.. automodule::` entry in `docs/source/api_reference.rst`
 - **Testing**: Pytest with mocks, fixtures, parameterization, and freezegun for time-dependent tests
 - **Comments**: never mention in comments of code, commits, PRs, etc. that have been generated with the help of Claude or any other AI tool
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -46,6 +46,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.scenario
    :members:
 
+.. automodule:: aiocamedomotic.models.thermo_zone
+   :members:
+
 .. automodule:: aiocamedomotic.models.update
    :members:
 


### PR DESCRIPTION
## Summary
- Add `thermo_zone` module to `api_reference.rst` so ThermoZone, AnalogSensor, and related enums appear in the generated API docs
- Update CLAUDE.md documentation guidelines to remind contributors to keep `api_reference.rst` in sync when adding new model modules

## Test plan
- [ ] Verify `cd docs && make html` builds without errors
- [ ] Confirm ThermoZone, AnalogSensor, ThermoZoneStatus, ThermoZoneMode, and ThermoZoneSeason appear in the generated API reference page