### PR TITLE
fix: AnalogSensor.value returns real temperature

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -223,11 +223,6 @@ class CameDomoticAPI:
         Retrieves top-level temperature, humidity, and pressure sensor
         readings from the thermoregulation list response.
 
-        Note:
-            Temperature sensor values follow the x10 convention
-            (e.g., 215 = 21.5 degrees C). Humidity and pressure values
-            are returned as-is from the API.
-
         Returns:
             List[AnalogSensor]: List of analog sensors found in the response.
 

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -218,10 +218,8 @@ class AnalogSensor(CameEntity):
     separate from the thermoregulation zones.
 
     Note:
-        The ``value`` property returns the raw value from the API.
-        Temperature sensor values follow the x10 convention
-        (e.g., 215 = 21.5 degrees C). Humidity and pressure values
-        are returned as-is.
+        The ``value`` property returns the real sensor reading in the
+        unit reported by ``unit`` (e.g., degrees C, %, hPa).
 
     Raises:
         ValueError: If ``name`` or ``act_id`` keys are missing from
@@ -245,13 +243,11 @@ class AnalogSensor(CameEntity):
 
     @property
     def value(self) -> float:
-        """Raw sensor value from the API.
-
-        For temperature sensors, this is the temperature multiplied
-        by 10 (e.g., 215 means 21.5 degrees C). For humidity and pressure
-        sensors, this is the direct reading.
-        """
-        return self.raw_data.get("value", 0)
+        """Sensor reading in the unit reported by ``unit``."""
+        raw = self.raw_data.get("value", 0)
+        if self.unit == "°C":
+            return raw / 10.0
+        return float(raw)
 
     @property
     def unit(self) -> str:

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -1052,12 +1052,12 @@ class TestAPIAnalogSensors:
         assert len(sensors) == 3
         assert isinstance(sensors[0], AnalogSensor)
         assert sensors[0].name == "Outdoor Temp"
-        assert sensors[0].value == 215
+        assert sensors[0].value == 21.5
         assert sensors[0].unit == "\u00b0C"
         assert sensors[1].name == "Indoor Humidity"
-        assert sensors[1].value == 55
+        assert sensors[1].value == 55.0
         assert sensors[2].name == "Barometric Pressure"
-        assert sensors[2].value == 1013
+        assert sensors[2].value == 1013.0
 
     @patch.object(Auth, "async_send_command")
     async def test_async_get_analog_sensors_partial(

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -1217,14 +1217,14 @@ class TestAnalogSensor:
         sensor = AnalogSensor(analog_sensor_data_temperature)
         assert sensor.act_id == 100
         assert sensor.name == "Outdoor Temperature"
-        assert sensor.value == 215
+        assert sensor.value == 21.5
         assert sensor.unit == "\u00b0C"
 
     def test_humidity_properties(self, analog_sensor_data_humidity):
         sensor = AnalogSensor(analog_sensor_data_humidity)
         assert sensor.act_id == 101
         assert sensor.name == "Indoor Humidity"
-        assert sensor.value == 55
+        assert sensor.value == 55.0
         assert sensor.unit == "%"
 
     def test_missing_name(self):
@@ -1242,5 +1242,5 @@ class TestAnalogSensor:
         sensor = AnalogSensor(sensor_data)
         assert sensor.name == "Minimal Sensor"
         assert sensor.act_id == 200
-        assert sensor.value == 0
+        assert sensor.value == 0.0
         assert sensor.unit == ""


### PR DESCRIPTION
## Summary
- `AnalogSensor.value` now returns the real temperature (e.g., 21.5) instead of the raw API value (e.g., 215) for temperature sensors (unit `°C`)
- Non-temperature sensors (humidity, pressure) are unaffected
- Consistent with `ThermoZone.temperature` and `ThermoZone.set_point` which already divide by 10

## Test plan
- [x] `TestAnalogSensor` tests updated and passing
- [ ] Verify no regressions in full test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sensor value calculations to return accurate readings in reported units (temperature in °C, humidity in %, etc.) as decimal values instead of raw API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->