### PR TITLE
docs: update AnalogSensor usage example for real temperature values

### DIFF
--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -418,14 +418,9 @@ Example output for analog sensors:
 
 .. code-block:: text
 
-    Name: Outdoor Temperature, Value: 215, Unit: °C
+    Name: Outdoor Temperature, Value: 21.5, Unit: °C
     Name: Indoor Humidity, Value: 55, Unit: %
     Name: Barometric Pressure, Value: 1013, Unit: hPa
-
-.. note::
-    The ``value`` property returns the raw value from the API.
-    For temperature sensors, the value follows the x10 convention
-    (e.g., 215 = 21.5°C). Humidity and pressure values are returned as-is.
 
 
 Checking Authentication Status


### PR DESCRIPTION
## Summary
- Update usage example output to show real temperature value (21.5) instead of raw x10 value (215)
- Remove the note about x10 convention since `AnalogSensor.value` now returns real values (see #189)

## Test plan
- [ ] Verify docs build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analog sensor usage example output to display converted values for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->