### PR TITLE
fix: catch bare TimeoutError in Auth.async_validate_host

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -424,6 +424,12 @@ class Auth:
             raise CameDomoticServerNotFoundError(
                 f"HTTP GET of '{endpoint_url}' resulted in a timeout error)"
             ) from e
+        except TimeoutError as e:
+            # Handle generic asyncio timeouts (raised by aiohttp's internal
+            # TimerContext when a host is unreachable)
+            raise CameDomoticServerNotFoundError(
+                f"HTTP GET of '{endpoint_url}' resulted in a timeout error)"
+            ) from e
         except aiohttp.ClientError as e:
             # Broader category for client-side issues
             raise CameDomoticServerNotFoundError(

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -621,6 +621,30 @@ class TestAuthValidateHost:
                     timeout=aiohttp.ClientTimeout(total=10),
                 )
 
+    async def test_failure_timeout_error(self):
+        async with aiohttp.ClientSession() as session:
+            with patch("aiohttp.ClientSession.get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 200
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                async with await Auth.async_create(
+                    session, "192.168.x.x", "username", "password"
+                ) as auth:
+                    auth.client_id = "test_client_id"
+                    auth.keep_alive_timeout_sec = 900
+                    auth.session_expiration_timestamp = time.monotonic() + 3600
+
+                mock_get.side_effect = TimeoutError()
+
+                with pytest.raises(CameDomoticServerNotFoundError):
+                    await auth.async_validate_host()
+
+                mock_get.assert_called_with(
+                    auth.get_endpoint_url(),
+                    timeout=aiohttp.ClientTimeout(total=10),
+                )
+
 
 class TestAuthLogin:
     """Tests for async_login method."""


### PR DESCRIPTION
## Summary
- `async_validate_host` catches `aiohttp.ServerTimeoutError` but not the generic `TimeoutError` raised by aiohttp's internal `TimerContext` when a host is unreachable
- Added `except TimeoutError` handler to wrap it in `CameDomoticServerNotFoundError`
- Added test `test_failure_timeout_error` to cover the new case

## Test plan
- [x] Existing `TestAuthValidateHost` tests pass
- [x] New `test_failure_timeout_error` test verifies `TimeoutError` is caught and wrapped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved host validation to handle timeout errors with consistent error messaging and behavior.

* **Tests**
  * Added test coverage for host validation timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->