### PR TITLE
chore: rename master branch references to main

### DIFF
--- a/.github/workflows/build-llms-docs.yml
+++ b/.github/workflows/build-llms-docs.yml
@@ -17,7 +17,7 @@ name: Build LLM documentation
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "README.rst"
       - "docs/source/**"
@@ -82,7 +82,7 @@ jobs:
           Sphinx documentation.
           EOF
           )" \
-            --base master \
+            --base main \
             --head "$BRANCH_NAME"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -108,7 +108,7 @@ jobs:
         id: create_pr
         if: steps.create_branch_tag.outcome == 'success'
         run: |
-          gh pr create --title "Update version to ${{ steps.update_version.outputs.version }}" --body "This pull request updates the library version to ${{ steps.update_version.outputs.version }}." --base master --head update-version
+          gh pr create --title "Update version to ${{ steps.update_version.outputs.version }}" --body "This pull request updates the library version to ${{ steps.update_version.outputs.version }}." --base main --head update-version
           gh pr merge --auto --squash --delete-branch
 
       - name: Wait for PR to be merged
@@ -138,23 +138,23 @@ jobs:
           echo "::error::Timed out waiting for PR to be merged"
           exit 1
 
-      - name: Checkout and push to master
+      - name: Checkout and push to main
         run: |
-          git checkout master
-          git pull origin master
-          git push origin master
+          git checkout main
+          git pull origin main
+          git push origin main
 
       - name: Remove new version tag on PR merging failure
         if: always() && steps.create_pr.outcome == 'failure'
         run: |
-          git checkout master
+          git checkout main
           git tag -d "${{ steps.update_version.outputs.version }}"
           git push origin --delete "${{ steps.update_version.outputs.version }}"
 
       - name: Delete temporary branch
         if: always() && steps.create_pr.outcome == 'failure'
         run: |
-          git checkout master
+          git checkout main
           git branch -D update-version
           git push origin --delete update-version
 
@@ -224,7 +224,7 @@ jobs:
       - name: Checkout repository for tag lookup
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ name: Code quality check
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "aiocamedomotic/**/*.py"
       - "pyproject.toml"
@@ -24,7 +24,7 @@ on:
       # - 'mypy.ini'
   pull_request:
     # Always run for PRs to satisfy required status checks
-    branches: [master, update-version]
+    branches: [main, update-version]
   schedule:
     # At 06:30 on day-of-month 24.
     - cron: "30 6 24 * *"

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -16,7 +16,7 @@ name: Unit tests and coverage report
 
 on:
   push:
-    branches: [master, update-version]
+    branches: [main, update-version]
     paths:
       - "aiocamedomotic/**/*.py"
       - "tests/**/*.py"
@@ -24,7 +24,7 @@ on:
       - ".github/workflows/code-tests.yml"
   pull_request:
     # Always run for PRs to satisfy required status checks
-    branches: [master, update-version]
+    branches: [main, update-version]
   workflow_dispatch:
 
 # Define minimal required permissions at workflow level

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,14 +20,14 @@ name: Build ReadTheDocs documentation
 on:
   push:
     branches:
-      - master # Trigger on pushes to the master branch
+      - main # Trigger on pushes to the main branch
     paths:
       - README.rst
       - "docs/**" # Trigger only when documentation changes
       - ".readthedocs.yaml" # Also trigger when RTD configuration changes
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - README.rst
       - "docs/**"
@@ -37,7 +37,7 @@ on:
     #   branch:
     #     description: 'Branch to build documentation for'
     #     required: false
-    #     default: 'master'
+    #     default: 'main'
 
 # Define minimal required permissions at workflow level
 permissions:

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
@@ -44,7 +44,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v6 # v6.0.0
         with:
           prerelease: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ name: Security checks
 
 on:
   push:
-    branches: [master, update-version]
+    branches: [main, update-version]
     paths-ignore:
       - "**.rst"
       - "**.md"
@@ -24,7 +24,7 @@ on:
       - ".github/**"
   pull_request:
     # Always run for PRs to satisfy required status checks
-    branches: [master, update-version]
+    branches: [main, update-version]
   schedule:
     # Twice per month (7th and 22nd) at 5:45 AM UTC
     - cron: "45 5 7 * *"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ The full documentation of the CAME Domotic API that this library wraps is in `lo
 
 ## Other notes
 
-- The `master` git branch is protected, to merge you must create a new branch and raise a PR
+- The `main` git branch is protected, to merge you must create a new branch and raise a PR
 - Never mention in comments (commits, PRs, etc.) Claude or any other AI tool
 - Python 3.12, 3.13 and 3.14 are supported
 - Library is available under Apache License 2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ To allow proper autolabeling of changes, please name your branches as follows:
 
 ## Submitting a Pull Request
 
-1. Fork the repository and create your branch from `master`.
+1. Fork the repository and create your branch from `main`.
 2. If you've added code, add tests. Make sure all tests pass.
 3. If you've changed the public interface of this library, update the documentation.
 4. Ensure your code is formatted with Black, linted with Pylint, and type-checked with

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,9 @@ resources too:
 
 - `API reference <https://aiocamedomotic.readthedocs.io/latest/api_reference.html>`_
 - `What's new (releases) <https://github.com/camedomotic-unofficial/aiocamedomotic/releases>`_
-- `Development roadmap <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/ROADMAP.md#development-roadmap>`_
-- `Security Policy <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/SECURITY.md#security-policy>`_
-- `Contributing to Our Project <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/CONTRIBUTING.md#contributing-to-our-project>`_
+- `Development roadmap <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap>`_
+- `Security Policy <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy>`_
+- `Contributing to Our Project <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md#contributing-to-our-project>`_
 
 
 Acknowledgments
@@ -104,5 +104,5 @@ the Home Assistant document
 License
 =======
 This project is licensed under the Apache License 2.0. For more details, see the
-`LICENSE file <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/LICENSE>`_
+`LICENSE file <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/LICENSE>`_
 on GitHub.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -44,9 +44,9 @@ resources too:
 
 - [API reference](https://aiocamedomotic.readthedocs.io/latest/api_reference.html)
 - [What’s new (releases)](https://github.com/camedomotic-unofficial/aiocamedomotic/releases)
-- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/ROADMAP.md#development-roadmap)
-- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/SECURITY.md#security-policy)
-- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/CONTRIBUTING.md#contributing-to-our-project)
+- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap)
+- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy)
+- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md#contributing-to-our-project)
 
 ### Acknowledgments
 
@@ -59,7 +59,7 @@ the Home Assistant document
 ## License
 
 This project is licensed under the Apache License 2.0. For more details, see the
-[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/LICENSE)
+[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/LICENSE)
 on GitHub.
 
 ## Getting started

--- a/llms.txt
+++ b/llms.txt
@@ -44,9 +44,9 @@ resources too:
 
 - [API reference](https://aiocamedomotic.readthedocs.io/latest/api_reference.html)
 - [What’s new (releases)](https://github.com/camedomotic-unofficial/aiocamedomotic/releases)
-- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/ROADMAP.md#development-roadmap)
-- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/SECURITY.md#security-policy)
-- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/CONTRIBUTING.md#contributing-to-our-project)
+- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap)
+- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy)
+- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md#contributing-to-our-project)
 
 ### Acknowledgments
 
@@ -59,7 +59,7 @@ the Home Assistant document
 ## License
 
 This project is licensed under the Apache License 2.0. For more details, see the
-[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/master/LICENSE)
+[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/LICENSE)
 on GitHub.
 
 ## Getting started


### PR DESCRIPTION
## Summary
- Update all `master` → `main` branch references across 12 files
- 7 GitHub Actions workflow files (triggers, checkout refs, PR base branches, git commands)
- 4 documentation files (README.rst, CONTRIBUTING.md, llms.txt, llms-full.txt) 
- CLAUDE.md project configuration

Sphinx documentation URLs (`sphinx.org/en/master/`) are intentionally left unchanged as they refer to Sphinx's own branch, not ours.

## Test plan
- [ ] Verify workflows trigger correctly on push to `main`
- [ ] Verify PR-triggered workflows fire on PRs targeting `main`
- [ ] Spot-check documentation links resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default branch references across GitHub Actions workflows from master to main.
  * Updated documentation files and embedded links to reference the main branch instead of master.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->