### PR TITLE
feat: add typed update classes and real-time updates documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ Key Features
 ------------
 - **Simplicity**: Easy interaction with domotic entities.
 - **Automatic session management**: No need for manual login or session handling.
+- **Real-time updates**: Built-in long-polling support with typed update classes
+  for monitoring device state changes as they happen.
 - **First of its kind**: Unique in providing integration with CAME Domotic systems.
 - **Open source**: Freely available under the Apache 2.0 license, inviting
   contributions and adaptations.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -172,16 +172,54 @@ class _ServerFeature(Enum):
 # endregion
 
 
+class UpdateIndicator(Enum):
+    """Known status-update indication cmd_names from the CAME API.
+
+    These identify the type of state change in a ``status_update_resp`` result
+    item. Some indicators have two variants: one observed in real API traffic
+    and one documented in API_reference.md. Both are mapped for firmware
+    compatibility.
+    """
+
+    # Traffic-observed names
+    LIGHT = "light_switch_ind"
+    OPENING = "opening_move_ind"
+    THERMOSTAT = "thermo_zone_info_ind"
+    DIGITAL_INPUT = "digitalin_status_ind"
+    SCENARIO_STATUS = "scenario_status_ind"
+    SCENARIO_ACTIVATION = "scenario_activation_ind"
+    ENERGY_METER = "meter_instant_power_ind"
+    LOADSCTRL_METER = "loadsctrl_meter_ind"
+    LOADSCTRL_RELAY = "loadsctrl_relay_ind"
+    PLANT = "plant_update_ind"
+    # API_reference.md variants (kept for firmware compatibility)
+    LIGHT_LEGACY = "light_update_ind"
+    OPENING_LEGACY = "opening_update_ind"
+    THERMOSTAT_LEGACY = "thermo_update_ind"
+    RELAY_LEGACY = "relay_update_ind"
+    DIGITAL_INPUT_LEGACY = "digitalin_update_ind"
+    SCENARIO_USER_LEGACY = "scenario_user_ind"
+
+
 # Mapping from status update cmd_name to DeviceType
 _UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
+    # Traffic-observed indicator names
+    "light_switch_ind": DeviceType.LIGHT,
+    "opening_move_ind": DeviceType.OPENING,
+    "thermo_zone_info_ind": DeviceType.THERMOSTAT,
+    "digitalin_status_ind": DeviceType.DIGITAL_INPUT,
+    "scenario_status_ind": DeviceType.SCENARIO,
+    "scenario_activation_ind": DeviceType.SCENARIO,
+    "meter_instant_power_ind": DeviceType.ENERGY_SENSOR,
+    # API_reference.md variant names (firmware compatibility)
     "light_update_ind": DeviceType.LIGHT,
     "opening_update_ind": DeviceType.OPENING,
-    "relay_update_ind": DeviceType.GENERIC_RELAY,
     "thermo_update_ind": DeviceType.THERMOSTAT,
-    "thermo_zone_info_ind": DeviceType.THERMOSTAT,
+    "relay_update_ind": DeviceType.GENERIC_RELAY,
     "digitalin_update_ind": DeviceType.DIGITAL_INPUT,
-    "scenario_status_ind": DeviceType.SCENARIO,
     "scenario_user_ind": DeviceType.SCENARIO,
+    # plant_update_ind intentionally omitted: it requires full cache
+    # invalidation, not a per-device update
 }
 
 # Mapping from DeviceType to the corresponding server feature

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -19,7 +19,7 @@ CAME Domotic API.
 
 from __future__ import annotations
 
-from ..const import DeviceType  # noqa: F401
+from ..const import DeviceType, UpdateIndicator  # noqa: F401
 from .base import CameEntity, Floor, Room, ServerInfo, User  # noqa: F401
 from .light import Light, LightStatus, LightType  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
@@ -31,30 +31,50 @@ from .thermo_zone import (  # noqa: F401
     ThermoZoneSeason,
     ThermoZoneStatus,
 )
-from .update import UpdateList, get_update_device_type  # noqa: F401
+from .update import (  # noqa: F401
+    DeviceUpdate,
+    DigitalInputUpdate,
+    LightUpdate,
+    OpeningUpdate,
+    PlantUpdate,
+    ScenarioUpdate,
+    ThermoZoneUpdate,
+    UpdateList,
+    get_update_device_type,
+    parse_update,
+)
 
 __all__ = [
     "AnalogSensor",
     "CameEntity",
     "DeviceType",
+    "DeviceUpdate",
+    "DigitalInputUpdate",
     "Floor",
     "Light",
     "LightStatus",
     "LightType",
+    "LightUpdate",
     "Opening",
     "OpeningStatus",
     "OpeningType",
+    "OpeningUpdate",
+    "PlantUpdate",
     "Room",
     "Scenario",
     "ScenarioStatus",
+    "ScenarioUpdate",
     "ServerInfo",
     "ThermoZone",
     "ThermoZoneMode",
     "ThermoZoneSeason",
     "ThermoZoneStatus",
+    "ThermoZoneUpdate",
+    "UpdateIndicator",
     "UpdateList",
     "User",
     "get_update_device_type",
+    "parse_update",
 ]
 
 # Digital inputs

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -16,9 +16,10 @@
 CAME Domotic status update handling.
 
 This module provides classes for processing and representing status updates
-from the CAME Domotic system. It implements a specialized list-based data
-structure to track chronological updates and state changes received from
-the CAME Domotic API, facilitating the consumption of system state changes.
+from the CAME Domotic system. It implements typed dataclass wrappers for each
+update indication type, a factory function to parse raw update dicts, and a
+specialized list-based data structure to track chronological updates received
+from the CAME Domotic API.
 """
 
 from __future__ import annotations
@@ -27,9 +28,13 @@ from collections import UserList
 from dataclasses import dataclass
 from typing import Any
 
-from ..const import _UPDATE_CMD_TO_DEVICE_TYPE, DeviceType
+from ..const import _UPDATE_CMD_TO_DEVICE_TYPE, DeviceType, UpdateIndicator
 from ..utils import LOGGER
 from .base import CameEntity
+from .light import LightStatus, LightType
+from .opening import OpeningStatus
+from .scenario import ScenarioStatus
+from .thermo_zone import ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus
 
 
 def get_update_device_type(update: dict[str, Any]) -> DeviceType | None:
@@ -49,9 +54,325 @@ def get_update_device_type(update: dict[str, Any]) -> DeviceType | None:
     return _UPDATE_CMD_TO_DEVICE_TYPE.get(cmd_name)
 
 
+# ---------------------------------------------------------------------------
+# Typed update classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DeviceUpdate(CameEntity):
+    """Base class for a typed status update from the CAME API.
+
+    Wraps the raw update dict and exposes common properties. Subclasses add
+    device-specific accessors.
+
+    Args:
+        raw_data: The original dict from the ``status_update_resp`` result
+            array.
+    """
+
+    raw_data: dict[str, Any]
+
+    @property
+    def cmd_name(self) -> str:
+        """The indication ``cmd_name`` string from the raw update."""
+        return self.raw_data.get("cmd_name", "")
+
+    @property
+    def update_indicator(self) -> UpdateIndicator | None:
+        """The :class:`~aiocamedomotic.const.UpdateIndicator` for this update,
+        or ``None`` if the ``cmd_name`` is not recognized."""
+        try:
+            return UpdateIndicator(self.cmd_name)
+        except ValueError:
+            return None
+
+    @property
+    def device_type(self) -> DeviceType | None:
+        """The :class:`~aiocamedomotic.const.DeviceType` for this update,
+        or ``None`` if the ``cmd_name`` is not recognized."""
+        return _UPDATE_CMD_TO_DEVICE_TYPE.get(self.cmd_name)
+
+    @property
+    def device_id(self) -> int | None:
+        """Primary device identifier (``act_id``, ``open_act_id``, or ``id``).
+
+        Returns the first available identifier, or ``None`` if none is present.
+        """
+        return (
+            self.raw_data.get("act_id")
+            or self.raw_data.get("open_act_id")
+            or self.raw_data.get("id")
+        )
+
+    @property
+    def name(self) -> str:
+        """Device name from the update."""
+        return self.raw_data.get("name", "")
+
+
+@dataclass
+class LightUpdate(DeviceUpdate):
+    """Typed update for a light device (``light_switch_ind`` /
+    ``light_update_ind``).
+    """
+
+    @property
+    def act_id(self) -> int:
+        """Light actuator ID."""
+        return self.raw_data["act_id"]
+
+    @property
+    def floor_ind(self) -> int:
+        """Floor index."""
+        return self.raw_data.get("floor_ind", 0)
+
+    @property
+    def room_ind(self) -> int:
+        """Room index."""
+        return self.raw_data.get("room_ind", 0)
+
+    @property
+    def status(self) -> LightStatus:
+        """Light status (OFF, ON, AUTO)."""
+        return LightStatus(self.raw_data["status"])
+
+    @property
+    def light_type(self) -> LightType:
+        """Light type (STEP_STEP, DIMMER, RGB)."""
+        try:
+            return LightType(self.raw_data.get("type", "UNKNOWN_LIGHT_TYPE"))
+        except ValueError:
+            return LightType.UNKNOWN
+
+    @property
+    def perc(self) -> int:
+        """Brightness percentage (0-100). Defaults to 100 for non-dimmable."""
+        return self.raw_data.get("perc", 100)
+
+    @property
+    def rgb(self) -> list[int] | None:
+        """RGB color values ``[R, G, B]`` (0-255 each), or ``None``."""
+        return self.raw_data.get("rgb")
+
+
+@dataclass
+class OpeningUpdate(DeviceUpdate):
+    """Typed update for an opening device (``opening_move_ind`` /
+    ``opening_update_ind``).
+    """
+
+    @property
+    def open_act_id(self) -> int:
+        """Actuator ID for the opening action."""
+        return self.raw_data["open_act_id"]
+
+    @property
+    def close_act_id(self) -> int:
+        """Actuator ID for the closing action."""
+        return self.raw_data["close_act_id"]
+
+    @property
+    def floor_ind(self) -> int:
+        """Floor index."""
+        return self.raw_data.get("floor_ind", 0)
+
+    @property
+    def room_ind(self) -> int:
+        """Room index."""
+        return self.raw_data.get("room_ind", 0)
+
+    @property
+    def status(self) -> OpeningStatus:
+        """Opening status (STOPPED, OPENING, CLOSING, etc.)."""
+        try:
+            return OpeningStatus(self.raw_data["status"])
+        except ValueError:
+            return OpeningStatus.UNKNOWN
+
+    @property
+    def device_id(self) -> int | None:
+        """For openings the primary ID is ``open_act_id``."""
+        return self.raw_data.get("open_act_id")
+
+
+@dataclass
+class ThermoZoneUpdate(DeviceUpdate):
+    """Typed update for a thermostat zone (``thermo_zone_info_ind`` /
+    ``thermo_update_ind``).
+    """
+
+    @property
+    def act_id(self) -> int:
+        """Zone actuator ID."""
+        return self.raw_data["act_id"]
+
+    @property
+    def floor_ind(self) -> int:
+        """Floor index."""
+        return self.raw_data.get("floor_ind", 0)
+
+    @property
+    def room_ind(self) -> int:
+        """Room index."""
+        return self.raw_data.get("room_ind", 0)
+
+    @property
+    def status(self) -> ThermoZoneStatus:
+        """Zone status (OFF, ON)."""
+        try:
+            return ThermoZoneStatus(self.raw_data["status"])
+        except (ValueError, KeyError):
+            return ThermoZoneStatus.OFF
+
+    @property
+    def temperature(self) -> float:
+        """Current temperature in degrees Celsius (converted from
+        ``temp_dec``).
+        """
+        return self.raw_data.get("temp_dec", 0) / 10.0
+
+    @property
+    def mode(self) -> ThermoZoneMode:
+        """Operating mode (OFF, MANUAL, AUTO, JOLLY)."""
+        try:
+            return ThermoZoneMode(self.raw_data.get("mode", -1))
+        except ValueError:
+            return ThermoZoneMode.UNKNOWN
+
+    @property
+    def set_point(self) -> float:
+        """Target temperature in degrees Celsius (converted from
+        ``set_point``).
+        """
+        return self.raw_data.get("set_point", 0) / 10.0
+
+    @property
+    def season(self) -> ThermoZoneSeason:
+        """Season setting (PLANT_OFF, WINTER, SUMMER)."""
+        try:
+            return ThermoZoneSeason(self.raw_data.get("season", "unknown"))
+        except ValueError:
+            return ThermoZoneSeason.UNKNOWN
+
+
+@dataclass
+class ScenarioUpdate(DeviceUpdate):
+    """Typed update for a scenario (``scenario_status_ind`` /
+    ``scenario_activation_ind`` / ``scenario_user_ind``).
+    """
+
+    @property
+    def id(self) -> int:
+        """Scenario ID."""
+        return self.raw_data["id"]
+
+    @property
+    def scenario_status(self) -> ScenarioStatus:
+        """Scenario status (OFF, TRIGGERED, ACTIVE)."""
+        try:
+            return ScenarioStatus(self.raw_data["scenario_status"])
+        except (ValueError, KeyError):
+            return ScenarioStatus.UNKNOWN
+
+    @property
+    def device_id(self) -> int | None:
+        """For scenarios the primary ID is ``id``."""
+        return self.raw_data.get("id")
+
+
+@dataclass
+class DigitalInputUpdate(DeviceUpdate):
+    """Typed update for a digital input (``digitalin_status_ind`` /
+    ``digitalin_update_ind``).
+    """
+
+    @property
+    def act_id(self) -> int:
+        """Digital input actuator ID."""
+        return self.raw_data["act_id"]
+
+    @property
+    def status(self) -> int:
+        """Digital input status value."""
+        return self.raw_data.get("status", 0)
+
+    @property
+    def addr(self) -> int:
+        """Digital input address."""
+        return self.raw_data.get("addr", 0)
+
+    @property
+    def utc_time(self) -> int:
+        """UTC timestamp of the digital input event."""
+        return self.raw_data.get("utc_time", 0)
+
+
+@dataclass
+class PlantUpdate(DeviceUpdate):
+    """Marker update for ``plant_update_ind``.
+
+    When this indication is received, all cached devices must be discarded and
+    re-fetched from the server.
+    """
+
+    @property
+    def is_plant_update(self) -> bool:
+        """Always returns ``True``."""
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Factory and mapping
+# ---------------------------------------------------------------------------
+
+_INDICATOR_TO_UPDATE_CLASS: dict[str, type[DeviceUpdate]] = {
+    "light_switch_ind": LightUpdate,
+    "light_update_ind": LightUpdate,
+    "opening_move_ind": OpeningUpdate,
+    "opening_update_ind": OpeningUpdate,
+    "thermo_zone_info_ind": ThermoZoneUpdate,
+    "thermo_update_ind": ThermoZoneUpdate,
+    "scenario_status_ind": ScenarioUpdate,
+    "scenario_activation_ind": ScenarioUpdate,
+    "scenario_user_ind": ScenarioUpdate,
+    "digitalin_status_ind": DigitalInputUpdate,
+    "digitalin_update_ind": DigitalInputUpdate,
+    "plant_update_ind": PlantUpdate,
+}
+
+
+def parse_update(raw: dict[str, Any]) -> DeviceUpdate:
+    """Parse a raw update dict into the appropriate typed
+    :class:`DeviceUpdate` subclass.
+
+    Args:
+        raw: A single update dict from the ``status_update_resp`` result
+            array.
+
+    Returns:
+        A typed :class:`DeviceUpdate` subclass instance. If the ``cmd_name``
+        is not recognized, a generic :class:`DeviceUpdate` is returned so
+        that the consumer can still access :attr:`~DeviceUpdate.raw_data`.
+    """
+    cmd_name = raw.get("cmd_name", "")
+    cls = _INDICATOR_TO_UPDATE_CLASS.get(cmd_name, DeviceUpdate)
+    return cls(raw_data=raw)
+
+
+# ---------------------------------------------------------------------------
+# UpdateList
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class UpdateList(UserList[dict[str, Any]], CameEntity):
-    """Chronological list of status updates from the CameDomotic API."""
+    """Chronological list of status updates from the CameDomotic API.
+
+    Extends :class:`~collections.UserList` to maintain backward compatibility:
+    iterating yields raw ``dict`` objects. Additional methods provide typed
+    access and filtering.
+    """
 
     def __init__(self, updates: UserList[dict[str, Any]] | None = None):
         try:
@@ -59,3 +380,51 @@ class UpdateList(UserList[dict[str, Any]], CameEntity):
         except TypeError as exc:
             LOGGER.warning("Caught exception in the UpdateList method", exc_info=exc)
             super().__init__()
+
+    def get_by_device_type(self, device_type: DeviceType) -> list[dict[str, Any]]:
+        """Return raw update dicts filtered to the given device type.
+
+        Args:
+            device_type: The :class:`~aiocamedomotic.const.DeviceType` to
+                filter by.
+
+        Returns:
+            A list of raw update dicts whose ``cmd_name`` maps to
+            *device_type*.
+        """
+        return [u for u in self.data if get_update_device_type(u) == device_type]
+
+    def get_typed_updates(self) -> list[DeviceUpdate]:
+        """Parse all updates into typed :class:`DeviceUpdate` objects.
+
+        Returns:
+            A list of :class:`DeviceUpdate` subclass instances, one per raw
+            update dict.
+        """
+        return [parse_update(u) for u in self.data]
+
+    def get_typed_by_device_type(self, device_type: DeviceType) -> list[DeviceUpdate]:
+        """Parse and filter updates by device type.
+
+        Args:
+            device_type: The :class:`~aiocamedomotic.const.DeviceType` to
+                filter by.
+
+        Returns:
+            Typed :class:`DeviceUpdate` instances whose
+            :attr:`~DeviceUpdate.device_type` matches *device_type*.
+        """
+        return [
+            parse_update(u)
+            for u in self.data
+            if get_update_device_type(u) == device_type
+        ]
+
+    @property
+    def has_plant_update(self) -> bool:
+        """Whether any update in this list is a ``plant_update_ind``.
+
+        When ``True``, the consumer should discard all cached devices and
+        re-fetch them from the server.
+        """
+        return any(u.get("cmd_name") == UpdateIndicator.PLANT.value for u in self.data)

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -57,7 +57,7 @@ Constants
 ---------
 
 .. automodule:: aiocamedomotic.const
-   :members: DeviceType
+   :members: DeviceType, UpdateIndicator
 
 
 Errors

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -53,6 +53,25 @@ To work with CAME devices, you may need one or more of the following imports:
         ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
     )
 
+Working with real-time updates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To receive and process real-time status updates from the CAME Domotic server,
+you will also need the following typed update classes:
+
+.. code-block:: python
+
+    from aiocamedomotic.models import (
+        DeviceType,
+        DeviceUpdate,
+        LightUpdate,
+        OpeningUpdate,
+        ThermoZoneUpdate,
+        ScenarioUpdate,
+        DigitalInputUpdate,
+        PlantUpdate,
+    )
+
 
 Handling Exceptions
 ^^^^^^^^^^^^^^^^^^^
@@ -421,6 +440,154 @@ Example output for analog sensors:
     Name: Outdoor Temperature, Value: 21.5, Unit: °C
     Name: Indoor Humidity, Value: 55, Unit: %
     Name: Barometric Pressure, Value: 1013, Unit: hPa
+
+
+Real-time updates
+-----------------
+
+The CAME Domotic server supports **long polling** for real-time status updates.
+When you call ``async_get_updates()``, the request **blocks on the server**
+until one or more device state changes are detected, then returns an
+:class:`~aiocamedomotic.models.update.UpdateList` containing all pending
+updates. This is the recommended mechanism for monitoring devices in real time
+without repeatedly fetching full device lists.
+
+Basic polling loop
+^^^^^^^^^^^^^^^^^^
+
+A typical polling loop continuously calls ``async_get_updates()`` and processes
+each batch of updates as it arrives:
+
+.. code-block:: python
+
+    async with await CameDomoticAPI.async_create(
+        "192.168.x.x", "username", "password"
+    ) as api:
+        while True:
+            updates = await api.async_get_updates()
+
+            for update in updates.get_typed_updates():
+                print(f"[{update.device_type}] {update.name} (ID: {update.device_id})")
+
+.. note::
+    Because ``async_get_updates()`` blocks until the server has new updates,
+    you do **not** need to add ``asyncio.sleep()`` between calls. If you need
+    to run the polling loop alongside other logic, wrap it in
+    ``asyncio.create_task()``.
+
+Getting typed updates
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``UpdateList`` returned by ``async_get_updates()`` supports iteration over
+raw dicts for backward compatibility. To get **typed** update objects with
+convenient properties, use the ``get_typed_updates()`` method:
+
+.. code-block:: python
+
+    updates = await api.async_get_updates()
+
+    for update in updates.get_typed_updates():
+        print(
+            f"Type: {update.device_type}, "
+            f"ID: {update.device_id}, "
+            f"Name: {update.name}"
+        )
+
+Example output:
+
+.. code-block:: text
+
+    Type: DeviceType.LIGHT, ID: 15, Name: Living Room Spotlights
+    Type: DeviceType.THERMOSTAT, ID: 76, Name: Bathroom
+
+Each typed update is an instance of a :class:`~aiocamedomotic.models.update.DeviceUpdate`
+subclass (e.g. :class:`~aiocamedomotic.models.update.LightUpdate`,
+:class:`~aiocamedomotic.models.update.ThermoZoneUpdate`) and exposes
+device-specific properties.
+
+Filtering updates by device type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To process only updates for a specific device type, use
+``get_typed_by_device_type()``:
+
+.. code-block:: python
+
+    updates = await api.async_get_updates()
+
+    # Get only light updates, already typed as LightUpdate
+    light_updates = updates.get_typed_by_device_type(DeviceType.LIGHT)
+
+    for light in light_updates:
+        print(
+            f"Light '{light.name}': status={light.status}, "
+            f"type={light.light_type}, brightness={light.perc}%"
+        )
+
+Example output:
+
+.. code-block:: text
+
+    Light 'Living Room Spotlights': status=LightStatus.ON, type=LightType.STEP_STEP, brightness=100%
+    Light 'Bedroom Dimmer': status=LightStatus.ON, type=LightType.DIMMER, brightness=50%
+
+Dispatching by update type
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For more granular control, use ``isinstance`` to dispatch each update to
+device-specific handling logic:
+
+.. code-block:: python
+
+    updates = await api.async_get_updates()
+
+    for update in updates.get_typed_updates():
+        if isinstance(update, LightUpdate):
+            print(f"Light '{update.name}': {update.status.name}, brightness={update.perc}%")
+
+        elif isinstance(update, OpeningUpdate):
+            print(f"Opening '{update.name}': {update.status.name}")
+
+        elif isinstance(update, ThermoZoneUpdate):
+            print(
+                f"Thermo '{update.name}': {update.temperature}°C, "
+                f"setpoint={update.set_point}°C, mode={update.mode.name}"
+            )
+
+        elif isinstance(update, ScenarioUpdate):
+            print(f"Scenario '{update.name}': {update.scenario_status.name}")
+
+        elif isinstance(update, DigitalInputUpdate):
+            print(f"Input '{update.name}': status={update.status}, addr={update.addr}")
+
+        elif isinstance(update, PlantUpdate):
+            print("Plant configuration changed, re-fetching devices...")
+
+Handling plant updates
+^^^^^^^^^^^^^^^^^^^^^^
+
+A special ``plant_update_ind`` indication signals that the **device
+configuration on the server has changed** (e.g. devices were added, removed, or
+reconfigured). When this happens, all locally cached device lists must be
+discarded and re-fetched.
+
+You can check for this using the ``has_plant_update`` property:
+
+.. code-block:: python
+
+    updates = await api.async_get_updates()
+
+    if updates.has_plant_update:
+        # Device configuration changed: refresh all cached device lists
+        lights = await api.async_get_lights()
+        openings = await api.async_get_openings()
+        scenarios = await api.async_get_scenarios()
+        thermo_zones = await api.async_get_thermo_zones()
+
+.. note::
+    Plant updates are relatively rare. They typically occur when an installer
+    modifies the system configuration. Failing to handle them may result in
+    stale device data or missing newly added devices.
 
 
 Checking Authentication Status

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -27,29 +27,38 @@ from aiocamedomotic.const import (
     _DEVICE_TYPE_TO_FEATURE,
     _UPDATE_CMD_TO_DEVICE_TYPE,
     DeviceType,
+    UpdateIndicator,
     _ServerFeature,
 )
 from aiocamedomotic.errors import CameDomoticAuthError
 from aiocamedomotic.models import (
     AnalogSensor,
+    DeviceUpdate,
+    DigitalInputUpdate,
     Floor,
     Light,
     LightStatus,
     LightType,
+    LightUpdate,
     Opening,
     OpeningStatus,
     OpeningType,
+    OpeningUpdate,
+    PlantUpdate,
     Room,
     Scenario,
     ScenarioStatus,
+    ScenarioUpdate,
     ServerInfo,
     ThermoZone,
     ThermoZoneMode,
     ThermoZoneSeason,
     ThermoZoneStatus,
+    ThermoZoneUpdate,
     UpdateList,
     User,
     get_update_device_type,
+    parse_update,
 )
 from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
 
@@ -84,6 +93,25 @@ class TestDeviceType:
             DeviceType(99)
 
     def test_update_cmd_to_device_type_mapping(self):
+        # Traffic-observed indicator names
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["light_switch_ind"] == DeviceType.LIGHT
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["opening_move_ind"] == DeviceType.OPENING
+        assert (
+            _UPDATE_CMD_TO_DEVICE_TYPE["thermo_zone_info_ind"] == DeviceType.THERMOSTAT
+        )
+        assert (
+            _UPDATE_CMD_TO_DEVICE_TYPE["digitalin_status_ind"]
+            == DeviceType.DIGITAL_INPUT
+        )
+        assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_status_ind"] == DeviceType.SCENARIO
+        assert (
+            _UPDATE_CMD_TO_DEVICE_TYPE["scenario_activation_ind"] == DeviceType.SCENARIO
+        )
+        assert (
+            _UPDATE_CMD_TO_DEVICE_TYPE["meter_instant_power_ind"]
+            == DeviceType.ENERGY_SENSOR
+        )
+        # API_reference.md variant names (firmware compatibility)
         assert _UPDATE_CMD_TO_DEVICE_TYPE["light_update_ind"] == DeviceType.LIGHT
         assert _UPDATE_CMD_TO_DEVICE_TYPE["opening_update_ind"] == DeviceType.OPENING
         assert (
@@ -91,13 +119,9 @@ class TestDeviceType:
         )
         assert _UPDATE_CMD_TO_DEVICE_TYPE["thermo_update_ind"] == DeviceType.THERMOSTAT
         assert (
-            _UPDATE_CMD_TO_DEVICE_TYPE["thermo_zone_info_ind"] == DeviceType.THERMOSTAT
-        )
-        assert (
             _UPDATE_CMD_TO_DEVICE_TYPE["digitalin_update_ind"]
             == DeviceType.DIGITAL_INPUT
         )
-        assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_status_ind"] == DeviceType.SCENARIO
         assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_user_ind"] == DeviceType.SCENARIO
 
     def test_device_type_to_feature_mapping(self):
@@ -312,6 +336,27 @@ class TestUpdateList:
         assert updates.data == []
 
     def test_get_update_device_type_known(self):
+        # Traffic-observed names
+        assert (
+            get_update_device_type({"cmd_name": "light_switch_ind"}) == DeviceType.LIGHT
+        )
+        assert (
+            get_update_device_type({"cmd_name": "opening_move_ind"})
+            == DeviceType.OPENING
+        )
+        assert (
+            get_update_device_type({"cmd_name": "thermo_zone_info_ind"})
+            == DeviceType.THERMOSTAT
+        )
+        assert (
+            get_update_device_type({"cmd_name": "digitalin_status_ind"})
+            == DeviceType.DIGITAL_INPUT
+        )
+        assert (
+            get_update_device_type({"cmd_name": "scenario_status_ind"})
+            == DeviceType.SCENARIO
+        )
+        # Legacy names
         assert (
             get_update_device_type({"cmd_name": "light_update_ind"}) == DeviceType.LIGHT
         )
@@ -319,16 +364,763 @@ class TestUpdateList:
             get_update_device_type({"cmd_name": "opening_update_ind"})
             == DeviceType.OPENING
         )
-        assert (
-            get_update_device_type({"cmd_name": "thermo_zone_info_ind"})
-            == DeviceType.THERMOSTAT
-        )
 
     def test_get_update_device_type_unknown(self):
         assert get_update_device_type({"cmd_name": "plant_update_ind"}) is None
 
     def test_get_update_device_type_missing_cmd_name(self):
         assert get_update_device_type({}) is None
+
+
+class TestDeviceUpdate:
+    def test_parse_light_update(self):
+        raw = {
+            "cmd_name": "light_switch_ind",
+            "act_id": 32,
+            "name": "Lampada studio",
+            "floor_ind": 37,
+            "room_ind": 42,
+            "status": 0,
+            "type": "DIMMER",
+            "perc": 94,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, LightUpdate)
+        assert update.act_id == 32
+        assert update.name == "Lampada studio"
+        assert update.floor_ind == 37
+        assert update.room_ind == 42
+        assert update.status == LightStatus.OFF
+        assert update.light_type == LightType.DIMMER
+        assert update.perc == 94
+        assert update.rgb is None
+        assert update.device_type == DeviceType.LIGHT
+        assert update.device_id == 32
+        assert update.update_indicator == UpdateIndicator.LIGHT
+
+    def test_parse_light_update_rgb(self):
+        raw = {
+            "cmd_name": "light_switch_ind",
+            "act_id": 10,
+            "name": "Led RGB",
+            "floor_ind": 1,
+            "room_ind": 2,
+            "status": 1,
+            "type": "RGB",
+            "perc": 50,
+            "rgb": [255, 128, 0],
+        }
+        update = parse_update(raw)
+        assert isinstance(update, LightUpdate)
+        assert update.light_type == LightType.RGB
+        assert update.rgb == [255, 128, 0]
+
+    def test_parse_light_update_unknown_type(self):
+        raw = {
+            "cmd_name": "light_switch_ind",
+            "act_id": 10,
+            "name": "Led",
+            "status": 1,
+            "type": "SOMETHING_NEW",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, LightUpdate)
+        assert update.light_type == LightType.UNKNOWN
+
+    def test_parse_opening_update(self):
+        raw = {
+            "cmd_name": "opening_move_ind",
+            "open_act_id": 62,
+            "close_act_id": 63,
+            "name": "Tapparella Bagno Camera matrimo",
+            "floor_ind": 37,
+            "room_ind": 54,
+            "status": 2,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, OpeningUpdate)
+        assert update.open_act_id == 62
+        assert update.close_act_id == 63
+        assert update.name == "Tapparella Bagno Camera matrimo"
+        assert update.status == OpeningStatus.CLOSING
+        assert update.device_type == DeviceType.OPENING
+        assert update.device_id == 62
+        assert update.update_indicator == UpdateIndicator.OPENING
+
+    def test_parse_opening_update_unknown_status(self):
+        raw = {
+            "cmd_name": "opening_move_ind",
+            "open_act_id": 1,
+            "close_act_id": 2,
+            "name": "Test",
+            "status": 99,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, OpeningUpdate)
+        assert update.status == OpeningStatus.UNKNOWN
+
+    def test_parse_thermo_zone_update(self):
+        raw = {
+            "cmd_name": "thermo_zone_info_ind",
+            "act_id": 76,
+            "name": "Bagno",
+            "floor_ind": 37,
+            "room_ind": 45,
+            "temp_dec": 212,
+            "status": 0,
+            "mode": 2,
+            "set_point": 349,
+            "season": "winter",
+            "antifreeze": 30,
+            "t1": 190,
+            "t2": 200,
+            "t3": 210,
+            "thermo_algo": {"type": "D", "diff_t_dec": 2, "pi_set_in_use": 1},
+            "reason": 1,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, ThermoZoneUpdate)
+        assert update.act_id == 76
+        assert update.name == "Bagno"
+        assert update.temperature == 21.2
+        assert update.status == ThermoZoneStatus.OFF
+        assert update.mode == ThermoZoneMode.AUTO
+        assert update.set_point == 34.9
+        assert update.season == ThermoZoneSeason.WINTER
+        assert update.device_type == DeviceType.THERMOSTAT
+        assert update.device_id == 76
+        assert update.update_indicator == UpdateIndicator.THERMOSTAT
+
+    def test_parse_scenario_update(self):
+        raw = {
+            "cmd_name": "scenario_status_ind",
+            "id": 8,
+            "name": "Tapparelle notte chiudi",
+            "scenario_status": 1,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, ScenarioUpdate)
+        assert update.id == 8
+        assert update.name == "Tapparelle notte chiudi"
+        assert update.scenario_status == ScenarioStatus.TRIGGERED
+        assert update.device_type == DeviceType.SCENARIO
+        assert update.device_id == 8
+        assert update.update_indicator == UpdateIndicator.SCENARIO_STATUS
+
+    def test_parse_scenario_update_missing_status(self):
+        raw = {
+            "cmd_name": "scenario_status_ind",
+            "id": 1,
+            "name": "Test",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, ScenarioUpdate)
+        assert update.scenario_status == ScenarioStatus.UNKNOWN
+
+    def test_parse_digitalin_update(self):
+        raw = {
+            "name": "Pulsante faretti sala pranzo anticamera",
+            "act_id": 84,
+            "type": 1,
+            "addr": 96,
+            "ack": 0,
+            "status": 0,
+            "radio_node_id": "00000000",
+            "rf_radio_link_quality": 0,
+            "utc_time": 1772894788,
+            "cmd_name": "digitalin_status_ind",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, DigitalInputUpdate)
+        assert update.act_id == 84
+        assert update.name == "Pulsante faretti sala pranzo anticamera"
+        assert update.status == 0
+        assert update.addr == 96
+        assert update.utc_time == 1772894788
+        assert update.device_type == DeviceType.DIGITAL_INPUT
+        assert update.device_id == 84
+        assert update.update_indicator == UpdateIndicator.DIGITAL_INPUT
+
+    def test_parse_plant_update(self):
+        raw = {"cmd_name": "plant_update_ind"}
+        update = parse_update(raw)
+        assert isinstance(update, PlantUpdate)
+        assert update.is_plant_update is True
+        assert update.device_type is None
+        assert update.update_indicator == UpdateIndicator.PLANT
+
+    def test_parse_unknown_update(self):
+        raw = {"cmd_name": "some_future_ind", "data": 42}
+        update = parse_update(raw)
+        assert isinstance(update, DeviceUpdate)
+        assert not isinstance(update, LightUpdate)
+        assert update.cmd_name == "some_future_ind"
+        assert update.device_type is None
+        assert update.update_indicator is None
+        assert update.raw_data == raw
+
+    def test_device_update_device_id_act_id(self):
+        raw = {"cmd_name": "x", "act_id": 10}
+        assert DeviceUpdate(raw_data=raw).device_id == 10
+
+    def test_device_update_device_id_open_act_id(self):
+        raw = {"cmd_name": "x", "open_act_id": 20}
+        assert DeviceUpdate(raw_data=raw).device_id == 20
+
+    def test_device_update_device_id_id(self):
+        raw = {"cmd_name": "x", "id": 30}
+        assert DeviceUpdate(raw_data=raw).device_id == 30
+
+    def test_device_update_device_id_none(self):
+        raw = {"cmd_name": "x"}
+        assert DeviceUpdate(raw_data=raw).device_id is None
+
+    def test_parse_legacy_cmd_names(self):
+        assert isinstance(
+            parse_update({"cmd_name": "light_update_ind", "act_id": 1, "status": 0}),
+            LightUpdate,
+        )
+        assert isinstance(
+            parse_update(
+                {
+                    "cmd_name": "opening_update_ind",
+                    "open_act_id": 1,
+                    "close_act_id": 2,
+                    "status": 0,
+                }
+            ),
+            OpeningUpdate,
+        )
+        assert isinstance(
+            parse_update(
+                {"cmd_name": "thermo_update_ind", "act_id": 1, "temp_dec": 200}
+            ),
+            ThermoZoneUpdate,
+        )
+        assert isinstance(
+            parse_update(
+                {"cmd_name": "digitalin_update_ind", "act_id": 1, "status": 0}
+            ),
+            DigitalInputUpdate,
+        )
+        assert isinstance(
+            parse_update(
+                {"cmd_name": "scenario_user_ind", "id": 1, "scenario_status": 0}
+            ),
+            ScenarioUpdate,
+        )
+
+
+class TestUpdateListEnhanced:
+    def _make_mixed_updates(self):
+        return [
+            {
+                "cmd_name": "thermo_zone_info_ind",
+                "act_id": 76,
+                "name": "Bagno",
+                "floor_ind": 37,
+                "room_ind": 45,
+                "temp_dec": 212,
+                "status": 0,
+                "mode": 2,
+                "set_point": 349,
+                "season": "winter",
+            },
+            {
+                "cmd_name": "light_switch_ind",
+                "act_id": 32,
+                "name": "Lampada studio",
+                "floor_ind": 37,
+                "room_ind": 42,
+                "status": 0,
+                "type": "DIMMER",
+                "perc": 94,
+            },
+            {
+                "cmd_name": "scenario_status_ind",
+                "id": 5,
+                "name": "Tapparelle apri",
+                "scenario_status": 1,
+            },
+            {
+                "cmd_name": "digitalin_status_ind",
+                "act_id": 84,
+                "name": "Pulsante",
+                "type": 1,
+                "addr": 96,
+                "ack": 0,
+                "status": 0,
+                "radio_node_id": "00000000",
+                "rf_radio_link_quality": 0,
+                "utc_time": 1772894788,
+            },
+            {
+                "cmd_name": "opening_move_ind",
+                "open_act_id": 62,
+                "close_act_id": 63,
+                "name": "Tapparella",
+                "floor_ind": 37,
+                "room_ind": 54,
+                "status": 2,
+            },
+        ]
+
+    def test_get_by_device_type(self):
+        updates = UpdateList(self._make_mixed_updates())
+        thermo = updates.get_by_device_type(DeviceType.THERMOSTAT)
+        assert len(thermo) == 1
+        assert thermo[0]["act_id"] == 76
+
+    def test_get_by_device_type_empty(self):
+        updates = UpdateList(self._make_mixed_updates())
+        relays = updates.get_by_device_type(DeviceType.GENERIC_RELAY)
+        assert relays == []
+
+    def test_get_typed_updates(self):
+        updates = UpdateList(self._make_mixed_updates())
+        typed = updates.get_typed_updates()
+        assert len(typed) == 5
+        assert isinstance(typed[0], ThermoZoneUpdate)
+        assert isinstance(typed[1], LightUpdate)
+        assert isinstance(typed[2], ScenarioUpdate)
+        assert isinstance(typed[3], DigitalInputUpdate)
+        assert isinstance(typed[4], OpeningUpdate)
+
+    def test_get_typed_by_device_type(self):
+        updates = UpdateList(self._make_mixed_updates())
+        lights = updates.get_typed_by_device_type(DeviceType.LIGHT)
+        assert len(lights) == 1
+        assert isinstance(lights[0], LightUpdate)
+        assert lights[0].act_id == 32
+
+    def test_has_plant_update_false(self):
+        updates = UpdateList(self._make_mixed_updates())
+        assert updates.has_plant_update is False
+
+    def test_has_plant_update_true(self):
+        data = self._make_mixed_updates()
+        data.append({"cmd_name": "plant_update_ind"})
+        updates = UpdateList(data)
+        assert updates.has_plant_update is True
+
+    def test_backward_compat_iteration(self):
+        raw_data = self._make_mixed_updates()
+        updates = UpdateList(raw_data)
+        for item in updates:
+            assert isinstance(item, dict)
+        assert list(updates) == raw_data
+
+    def test_empty_update_list_methods(self):
+        updates = UpdateList([])
+        assert updates.get_by_device_type(DeviceType.LIGHT) == []
+        assert updates.get_typed_updates() == []
+        assert updates.get_typed_by_device_type(DeviceType.LIGHT) == []
+        assert updates.has_plant_update is False
+
+
+class TestUpdateClassesRealWorld:
+    """Tests using anonymized payloads derived from real API traffic patterns."""
+
+    @pytest.mark.parametrize(
+        "raw, exp_status, exp_type, exp_perc, exp_floor, exp_room",
+        [
+            pytest.param(
+                {
+                    "cmd_name": "light_switch_ind",
+                    "act_id": 201,
+                    "name": "My ceiling spots",
+                    "floor_ind": 5,
+                    "room_ind": 11,
+                    "status": 0,
+                    "type": "STEP_STEP",
+                },
+                LightStatus.OFF,
+                LightType.STEP_STEP,
+                100,
+                5,
+                11,
+                id="step_step_off_no_perc",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "light_switch_ind",
+                    "act_id": 202,
+                    "name": "My dimmable lamp",
+                    "floor_ind": 3,
+                    "room_ind": 7,
+                    "status": 1,
+                    "type": "DIMMER",
+                    "perc": 14,
+                },
+                LightStatus.ON,
+                LightType.DIMMER,
+                14,
+                3,
+                7,
+                id="dimmer_on_low_brightness",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "light_switch_ind",
+                    "act_id": 203,
+                    "name": "My desk lamp",
+                    "floor_ind": 8,
+                    "room_ind": 12,
+                    "status": 1,
+                    "type": "DIMMER",
+                    "perc": 94,
+                },
+                LightStatus.ON,
+                LightType.DIMMER,
+                94,
+                8,
+                12,
+                id="dimmer_on_high_brightness",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "light_switch_ind",
+                    "act_id": 204,
+                    "name": "My living room light",
+                    "floor_ind": 3,
+                    "room_ind": 7,
+                    "status": 0,
+                    "type": "DIMMER",
+                    "perc": 54,
+                },
+                LightStatus.OFF,
+                LightType.DIMMER,
+                54,
+                3,
+                7,
+                id="dimmer_off_retains_perc",
+            ),
+        ],
+    )
+    def test_light_update_real_world(
+        self, raw, exp_status, exp_type, exp_perc, exp_floor, exp_room
+    ):
+        update = parse_update(raw)
+        assert isinstance(update, LightUpdate)
+        assert update.act_id == raw["act_id"]
+        assert update.name == raw["name"]
+        assert update.floor_ind == exp_floor
+        assert update.room_ind == exp_room
+        assert update.status == exp_status
+        assert update.light_type == exp_type
+        assert update.perc == exp_perc
+        assert update.rgb is None
+        assert update.device_type == DeviceType.LIGHT
+        assert update.device_id == raw["act_id"]
+        assert update.cmd_name == "light_switch_ind"
+        assert update.update_indicator == UpdateIndicator.LIGHT
+
+    @pytest.mark.parametrize(
+        "raw, exp_status",
+        [
+            pytest.param(
+                {
+                    "cmd_name": "opening_move_ind",
+                    "open_act_id": 301,
+                    "close_act_id": 302,
+                    "name": "My office shutter",
+                    "floor_ind": 8,
+                    "room_ind": 12,
+                    "status": 2,
+                },
+                OpeningStatus.CLOSING,
+                id="closing",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "opening_move_ind",
+                    "open_act_id": 303,
+                    "close_act_id": 304,
+                    "name": "My kitchen window shutter",
+                    "floor_ind": 5,
+                    "room_ind": 9,
+                    "status": 0,
+                },
+                OpeningStatus.STOPPED,
+                id="stopped",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "opening_move_ind",
+                    "open_act_id": 303,
+                    "close_act_id": 304,
+                    "name": "My kitchen window shutter",
+                    "floor_ind": 5,
+                    "room_ind": 9,
+                    "status": 1,
+                },
+                OpeningStatus.OPENING,
+                id="opening_same_device",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "opening_move_ind",
+                    "open_act_id": 305,
+                    "close_act_id": 306,
+                    "name": "My living room shutter",
+                    "floor_ind": 5,
+                    "room_ind": 7,
+                    "status": 1,
+                },
+                OpeningStatus.OPENING,
+                id="opening_different_device",
+            ),
+        ],
+    )
+    def test_opening_update_real_world(self, raw, exp_status):
+        update = parse_update(raw)
+        assert isinstance(update, OpeningUpdate)
+        assert update.open_act_id == raw["open_act_id"]
+        assert update.close_act_id == raw["close_act_id"]
+        assert update.name == raw["name"]
+        assert update.floor_ind == raw["floor_ind"]
+        assert update.room_ind == raw["room_ind"]
+        assert update.status == exp_status
+        assert update.device_type == DeviceType.OPENING
+        assert update.device_id == raw["open_act_id"]
+        assert update.cmd_name == "opening_move_ind"
+        assert update.update_indicator == UpdateIndicator.OPENING
+
+    @pytest.mark.parametrize(
+        "raw, exp_temp, exp_set_point",
+        [
+            pytest.param(
+                {
+                    "cmd_name": "thermo_zone_info_ind",
+                    "act_id": 401,
+                    "name": "My zone A",
+                    "floor_ind": 8,
+                    "room_ind": 14,
+                    "temp_dec": 212,
+                    "status": 0,
+                    "mode": 2,
+                    "set_point": 349,
+                    "season": "winter",
+                    "antifreeze": 30,
+                    "t1": 190,
+                    "t2": 200,
+                    "t3": 210,
+                    "thermo_algo": {"type": "D", "diff_t_dec": 2, "pi_set_in_use": 1},
+                    "reason": 1,
+                },
+                21.2,
+                34.9,
+                id="zone_a",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "thermo_zone_info_ind",
+                    "act_id": 402,
+                    "name": "My zone B",
+                    "floor_ind": 5,
+                    "room_ind": 11,
+                    "temp_dec": 219,
+                    "status": 0,
+                    "mode": 2,
+                    "set_point": 310,
+                    "season": "winter",
+                    "antifreeze": 30,
+                    "t1": 185,
+                    "t2": 195,
+                    "t3": 205,
+                    "thermo_algo": {"type": "D", "diff_t_dec": 2, "pi_set_in_use": 1},
+                    "reason": 1,
+                },
+                21.9,
+                31.0,
+                id="zone_b",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "thermo_zone_info_ind",
+                    "act_id": 403,
+                    "name": "My zone C",
+                    "floor_ind": 8,
+                    "room_ind": 16,
+                    "temp_dec": 210,
+                    "status": 0,
+                    "mode": 2,
+                    "set_point": 341,
+                    "season": "winter",
+                    "antifreeze": 30,
+                    "t1": 185,
+                    "t2": 198,
+                    "t3": 210,
+                    "thermo_algo": {"type": "D", "diff_t_dec": 2, "pi_set_in_use": 1},
+                    "reason": 1,
+                },
+                21.0,
+                34.1,
+                id="zone_c",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "thermo_zone_info_ind",
+                    "act_id": 404,
+                    "name": "My zone D",
+                    "floor_ind": 8,
+                    "room_ind": 12,
+                    "temp_dec": 219,
+                    "status": 0,
+                    "mode": 2,
+                    "set_point": 206,
+                    "season": "winter",
+                    "antifreeze": 30,
+                    "t1": 175,
+                    "t2": 200,
+                    "t3": 210,
+                    "thermo_algo": {"type": "D", "diff_t_dec": 2, "pi_set_in_use": 1},
+                    "reason": 1,
+                },
+                21.9,
+                20.6,
+                id="zone_d",
+            ),
+        ],
+    )
+    def test_thermo_zone_update_real_world(self, raw, exp_temp, exp_set_point):
+        update = parse_update(raw)
+        assert isinstance(update, ThermoZoneUpdate)
+        assert update.act_id == raw["act_id"]
+        assert update.name == raw["name"]
+        assert update.floor_ind == raw["floor_ind"]
+        assert update.room_ind == raw["room_ind"]
+        assert update.temperature == pytest.approx(exp_temp)
+        assert update.set_point == pytest.approx(exp_set_point)
+        assert update.status == ThermoZoneStatus.OFF
+        assert update.mode == ThermoZoneMode.AUTO
+        assert update.season == ThermoZoneSeason.WINTER
+        assert update.device_type == DeviceType.THERMOSTAT
+        assert update.device_id == raw["act_id"]
+        assert update.cmd_name == "thermo_zone_info_ind"
+        assert update.update_indicator == UpdateIndicator.THERMOSTAT
+
+    @pytest.mark.parametrize(
+        "raw, exp_scenario_status, exp_indicator",
+        [
+            pytest.param(
+                {
+                    "cmd_name": "scenario_status_ind",
+                    "id": 501,
+                    "name": "My scenario 1",
+                    "scenario_status": 1,
+                },
+                ScenarioStatus.TRIGGERED,
+                UpdateIndicator.SCENARIO_STATUS,
+                id="status_ind_triggered",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "scenario_status_ind",
+                    "id": 501,
+                    "name": "My scenario 1",
+                    "scenario_status": 2,
+                },
+                ScenarioStatus.ACTIVE,
+                UpdateIndicator.SCENARIO_STATUS,
+                id="status_ind_active",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "scenario_status_ind",
+                    "id": 502,
+                    "name": "My scenario 2",
+                    "scenario_status": 0,
+                },
+                ScenarioStatus.OFF,
+                UpdateIndicator.SCENARIO_STATUS,
+                id="status_ind_off",
+            ),
+            pytest.param(
+                {
+                    "cmd_name": "scenario_activation_ind",
+                    "id": 501,
+                    "name": "My scenario 1",
+                    "status": 0,
+                },
+                ScenarioStatus.UNKNOWN,
+                UpdateIndicator.SCENARIO_ACTIVATION,
+                id="activation_ind_no_scenario_status_key",
+            ),
+        ],
+    )
+    def test_scenario_update_real_world(self, raw, exp_scenario_status, exp_indicator):
+        update = parse_update(raw)
+        assert isinstance(update, ScenarioUpdate)
+        assert update.id == raw["id"]
+        assert update.name == raw["name"]
+        assert update.scenario_status == exp_scenario_status
+        assert update.device_type == DeviceType.SCENARIO
+        assert update.device_id == raw["id"]
+        assert update.update_indicator == exp_indicator
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param(
+                {
+                    "name": "My button A",
+                    "act_id": 601,
+                    "type": 1,
+                    "addr": 30,
+                    "ack": 0,
+                    "status": 0,
+                    "radio_node_id": "00000000",
+                    "rf_radio_link_quality": 0,
+                    "utc_time": 1700000001,
+                    "cmd_name": "digitalin_status_ind",
+                },
+                id="button_pressed",
+            ),
+            pytest.param(
+                {
+                    "name": "My button A",
+                    "act_id": 601,
+                    "type": 1,
+                    "addr": 30,
+                    "ack": 0,
+                    "status": 1,
+                    "radio_node_id": "00000000",
+                    "rf_radio_link_quality": 0,
+                    "utc_time": 1700000002,
+                    "cmd_name": "digitalin_status_ind",
+                },
+                id="button_released",
+            ),
+            pytest.param(
+                {
+                    "name": "My button B",
+                    "act_id": 602,
+                    "type": 1,
+                    "addr": 45,
+                    "ack": 0,
+                    "status": 0,
+                    "radio_node_id": "00000000",
+                    "rf_radio_link_quality": 0,
+                    "utc_time": 1700000010,
+                    "cmd_name": "digitalin_status_ind",
+                },
+                id="different_button_pressed",
+            ),
+        ],
+    )
+    def test_digital_input_update_real_world(self, raw):
+        update = parse_update(raw)
+        assert isinstance(update, DigitalInputUpdate)
+        assert update.act_id == raw["act_id"]
+        assert update.name == raw["name"]
+        assert update.status == raw["status"]
+        assert update.addr == raw["addr"]
+        assert update.utc_time == raw["utc_time"]
+        assert update.device_type == DeviceType.DIGITAL_INPUT
+        assert update.device_id == raw["act_id"]
+        assert update.cmd_name == "digitalin_status_ind"
+        assert update.update_indicator == UpdateIndicator.DIGITAL_INPUT
 
 
 class TestLight:


### PR DESCRIPTION
## Summary
- Add typed dataclass wrappers for each update indication type (`LightUpdate`, `OpeningUpdate`, `ThermoZoneUpdate`, `ScenarioUpdate`, `DigitalInputUpdate`, `PlantUpdate`) with a `parse_update` factory function
- Enhance `UpdateList` with filtering (`get_by_device_type`, `get_typed_by_device_type`) and typed access (`get_typed_updates`, `has_plant_update`) methods
- Add comprehensive "Real-time updates" documentation section in `usage_examples.rst` covering long-polling loops, typed updates, device type filtering, `isinstance`-based dispatch, and plant update handling

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, bandit, codespell, mypy, pytest)
- [x] Sphinx docs build successfully (`sphinx-build -b html docs/source docs/build/html`)
- [ ] Review rendered HTML for the new "Real-time updates" section in usage examples
- [ ] Verify API reference auto-generates correctly from updated docstrings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified UpdateIndicator and typed update objects (Light, Opening, ThermoZone, Scenario, DigitalInput, Plant) plus parse/update helpers.
  * Added UpdateList helpers: get_by_device_type, get_typed_updates, get_typed_by_device_type, and has_plant_update.

* **Documentation**
  * Added comprehensive real-time updates guide and examples in docs and README.

* **Tests**
  * Added tests covering update parsing, command-name mappings (including legacy names), and UpdateList behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->