### PR TITLE
Add real-time updates listener test

### DIFF
--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -68,14 +68,23 @@ class DeviceType(IntEnum):
     Each device in the CAME Domotic system is associated with one of these type
     identifiers. Not all device types are currently supported by this library.
 
-    Supported types:
+    Values:
         - ENERGY_SENSOR (-2)
         - ANALOG_SENSOR (-1)
         - LIGHT (0)
         - OPENING (1)
         - THERMOSTAT (2)
+        - PAGE (3)
         - SCENARIO (4)
+        - CAMERA (5)
+        - SECURITY_PANEL (6)
+        - SECURITY_AREA (7)
+        - SECURITY_SCENARIO (8)
+        - SECURITY_INPUT (9)
+        - SECURITY_OUTPUT (10)
         - GENERIC_RELAY (11)
+        - GENERIC_TEXT (12)
+        - SOUND_ZONE (13)
         - DIGITAL_INPUT (14)
     """
 
@@ -179,6 +188,24 @@ class UpdateIndicator(Enum):
     item. Some indicators have two variants: one observed in real API traffic
     and one documented in API_reference.md. Both are mapped for firmware
     compatibility.
+
+    Values:
+        - LIGHT ("light_switch_ind")
+        - OPENING ("opening_move_ind")
+        - THERMOSTAT ("thermo_zone_info_ind")
+        - DIGITAL_INPUT ("digitalin_status_ind")
+        - SCENARIO_STATUS ("scenario_status_ind")
+        - SCENARIO_ACTIVATION ("scenario_activation_ind")
+        - ENERGY_METER ("meter_instant_power_ind")
+        - LOADSCTRL_METER ("loadsctrl_meter_ind")
+        - LOADSCTRL_RELAY ("loadsctrl_relay_ind")
+        - PLANT ("plant_update_ind")
+        - LIGHT_LEGACY ("light_update_ind")
+        - OPENING_LEGACY ("opening_update_ind")
+        - THERMOSTAT_LEGACY ("thermo_update_ind")
+        - RELAY_LEGACY ("relay_update_ind")
+        - DIGITAL_INPUT_LEGACY ("digitalin_update_ind")
+        - SCENARIO_USER_LEGACY ("scenario_user_ind")
     """
 
     # Traffic-observed names

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -28,7 +28,15 @@ import asyncio
 import pytest
 
 from aiocamedomotic import CameDomoticAPI
-from aiocamedomotic.models import LightStatus
+from aiocamedomotic.models import (
+    DigitalInputUpdate,
+    LightStatus,
+    LightUpdate,
+    OpeningUpdate,
+    PlantUpdate,
+    ScenarioUpdate,
+    ThermoZoneUpdate,
+)
 from aiocamedomotic.models.opening import OpeningStatus
 
 RUN_TESTS_ON_REAL_SERVER = False
@@ -307,3 +315,95 @@ async def test_async_dimmable_light(api_instance_real: CameDomoticAPI):
             f"Light '{light_name}' reverted to: "
             f"status={initial_status.name}, brightness={initial_brightness}%"
         )
+
+
+@pytest.mark.timeout(90)
+async def test_listen_for_updates(api_instance_real: CameDomoticAPI):
+    """Listens for 10 API calls and prints typed information for all updates."""
+    max_api_calls = 20
+    print(
+        f"\nListening for real-time updates (waiting for {max_api_calls} API calls)..."
+    )
+
+    total_updates = 0
+    batch_num = 0
+
+    for batch_num in range(1, max_api_calls + 1):
+        print(f"\n--- Waiting for batch {batch_num}/{max_api_calls}... ---")
+        updates = await api_instance_real.async_get_updates()
+
+        batch_count = len(updates)
+        print(f"Batch {batch_num}: received {batch_count} update(s)")
+
+        if updates.has_plant_update:
+            print(
+                "  *** Plant configuration changed — cached devices "
+                "should be refreshed ***"
+            )
+
+        for update in updates.get_typed_updates():
+            total_updates += 1
+            print(f"\n  Update #{total_updates}:")
+
+            if isinstance(update, LightUpdate):
+                print(
+                    f"    [Light] '{update.name}' (act_id={update.act_id})\n"
+                    f"      Status: {update.status.name}, "
+                    f"Type: {update.light_type.name}, "
+                    f"Brightness: {update.perc}%"
+                )
+                if update.rgb is not None:
+                    print(f"      RGB: {update.rgb}")
+
+            elif isinstance(update, OpeningUpdate):
+                print(
+                    f"    [Opening] '{update.name}' "
+                    f"(open_id={update.open_act_id}, "
+                    f"close_id={update.close_act_id})\n"
+                    f"      Status: {update.status.name}"
+                )
+
+            elif isinstance(update, ThermoZoneUpdate):
+                print(
+                    f"    [ThermoZone] '{update.name}' "
+                    f"(act_id={update.act_id})\n"
+                    f"      Temp: {update.temperature}\u00b0C, "
+                    f"Setpoint: {update.set_point}\u00b0C\n"
+                    f"      Mode: {update.mode.name}, "
+                    f"Season: {update.season.name}, "
+                    f"Status: {update.status.name}"
+                )
+
+            elif isinstance(update, ScenarioUpdate):
+                print(
+                    f"    [Scenario] '{update.name}' (id={update.id})\n"
+                    f"      Status: {update.scenario_status.name}"
+                )
+
+            elif isinstance(update, DigitalInputUpdate):
+                print(
+                    f"    [DigitalInput] '{update.name}' "
+                    f"(act_id={update.act_id})\n"
+                    f"      Status: {update.status}, "
+                    f"Addr: {update.addr}, "
+                    f"UTC time: {update.utc_time}"
+                )
+
+            elif isinstance(update, PlantUpdate):
+                print(
+                    "    [Plant] Configuration change detected — "
+                    "full device cache invalidation needed"
+                )
+
+            else:
+                print(
+                    f"    [Unknown] cmd_name='{update.cmd_name}', "
+                    f"device_type={update.device_type}, "
+                    f"device_id={update.device_id}, "
+                    f"name='{update.name}'"
+                )
+
+    print(
+        f"\nDone — collected {total_updates} update(s) "
+        f"across {max_api_calls} API call(s)."
+    )


### PR DESCRIPTION
## Summary
- Add `test_listen_for_updates` to `test_real.py` for listening to real-time status updates across multiple API calls with typed update printing
- Expand `DeviceType` and `UpdateIndicator` docstrings with all enum values

## Test plan
- [x] Run `pytest tests/aiocamedomotic/test_real.py::test_listen_for_updates -v -s` against a real server with `RUN_TESTS_ON_REAL_SERVER = True`
- [x] Verify all update types (Light, Opening, ThermoZone, Scenario, DigitalInput, Plant) are printed correctly
- [x] Confirm CI passes (test is skipped by default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for supported device types, expanding the list of available device categories.
  * Added comprehensive values documentation for update indicators with detailed enumeration of indicator types.

* **Tests**
  * Added new test for asynchronously listening to update batches with support for multiple typed update categories and structured output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->