### PR TITLE
feat: add instance-level command_timeout with configurable long-polling override

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -41,7 +41,7 @@ from urllib.parse import urlsplit
 import aiohttp
 from cryptography.fernet import Fernet
 
-from .const import _CommandType
+from .const import _DEFAULT_COMMAND_TIMEOUT, _CommandType
 
 # Get package version to avoid circular imports
 try:
@@ -134,6 +134,7 @@ class Auth:
         password: str,
         *,
         close_websession_on_disposal: bool = True,
+        command_timeout: int = _DEFAULT_COMMAND_TIMEOUT,
     ) -> Auth:
         """Create an Auth instance.
 
@@ -144,6 +145,8 @@ class Auth:
             password (str): the password to use for the authentication.
             close_websession_on_disposal (bool, optional): whether to close the
                 websession when disposing the Auth instance (default: True).
+            command_timeout (int, optional): the default timeout in seconds
+                for commands sent to the server (default: 30s).
 
         Raises:
             CameDomoticServerNotFoundError: if the host doesn't respond to an HTTP
@@ -163,6 +166,7 @@ class Auth:
             password,
             close_websession_on_disposal=close_websession_on_disposal,
         )
+        auth.command_timeout = command_timeout
         await auth.async_validate_host()
 
         return auth
@@ -247,6 +251,7 @@ class Auth:
         self.client_id = ""
         self.keep_alive_timeout_sec = 0
         self.cseq = 0
+        self.command_timeout = _DEFAULT_COMMAND_TIMEOUT
 
         self._lock = Lock()
 
@@ -294,7 +299,7 @@ class Auth:
         command: dict[str, Any],
         *,
         response_command: str | None = None,
-        timeout: int | None = 10,
+        timeout: int | None = None,
         skip_ack_check: bool = False,
         command_type: str = _CommandType.DATA_REQUEST.value,
         additional_payload: dict[str, Any] | None = None,
@@ -305,7 +310,8 @@ class Auth:
             command (dict): the command to send.
             response_command (str, optional): expected response command name to validate
                 against the server response (default: None).
-            timeout (int, optional): the timeout in seconds (default: 10s).
+            timeout (int | None, optional): the timeout in seconds. If None,
+                uses the instance-level ``command_timeout`` (default: 30s).
             skip_ack_check (bool, optional): whether to skip the ACK check (default:
                 False).
             command_type (str, optional): the command type to send
@@ -357,7 +363,9 @@ class Auth:
                 self.get_endpoint_url(),
                 data={"command": json.dumps(request_payload)},
                 headers=Auth._DEFAULT_HTTP_HEADERS,
-                timeout=aiohttp.ClientTimeout(total=timeout),
+                timeout=aiohttp.ClientTimeout(
+                    total=timeout if timeout is not None else self.command_timeout
+                ),
             )
 
             LOGGER.debug("HTTP response status: %s", response.status)
@@ -408,7 +416,7 @@ class Auth:
             raise CameDomoticServerError("Error sending command") from e
 
     # The following method is not async because it is used in the __init__ method
-    async def async_validate_host(self, timeout: int | None = 10) -> None:
+    async def async_validate_host(self, timeout: int = 10) -> None:
         """Validate the host asynchronously using aiohttp.
 
         Args:

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -24,6 +24,7 @@ import aiohttp
 
 from .auth import Auth
 from .const import (
+    _DEFAULT_COMMAND_TIMEOUT,
     _CommandName,
     _CommandNameResponse,
     _CommandType,
@@ -47,14 +48,19 @@ from .utils import LOGGER
 class CameDomoticAPI:
     """Main class, exposes all the public methods of the CAME Domotic API."""
 
-    def __init__(self, auth: Auth):
+    def __init__(self, auth: Auth, *, command_timeout: int = _DEFAULT_COMMAND_TIMEOUT):
         """Initialize the CAME Domotic API object.
 
         Args:
             auth (Auth): the authentication object used to interact with
                 the CAME Domotic API.
+            command_timeout (int, optional): the default timeout in seconds
+                for all commands sent to the server (default: 30s). This
+                applies to all methods unless overridden per-call (e.g. via
+                the ``timeout`` parameter in ``async_get_updates``).
         """
         self.auth = auth
+        self.auth.command_timeout = command_timeout
 
     async def __aenter__(self) -> CameDomoticAPI:
         return self
@@ -251,7 +257,7 @@ class CameDomoticAPI:
                 sensors.append(AnalogSensor(sensor_data))
         return sensors
 
-    async def async_get_updates(self, timeout: int = 120) -> UpdateList:
+    async def async_get_updates(self, timeout: int | None = None) -> UpdateList:
         """Get status updates from the server using long polling.
 
         This method performs a long-polling request: it blocks until the server
@@ -259,8 +265,11 @@ class CameDomoticAPI:
         scenario activated), then returns them all at once.
 
         Args:
-            timeout (int, optional): the timeout in seconds for the
-                long-polling request (default: 120s).
+            timeout (int | None, optional): the timeout in seconds for the
+                long-polling request. If None, uses the instance-level
+                ``command_timeout`` (default: 30s). Since this method uses
+                long polling, a longer timeout (e.g. 120s) is recommended
+                to avoid premature disconnections.
 
         Returns:
             UpdateList: List of status updates received from the server.
@@ -333,6 +342,7 @@ class CameDomoticAPI:
         *,
         websession: aiohttp.ClientSession | None = None,
         close_websession_on_disposal: bool = False,
+        command_timeout: int = _DEFAULT_COMMAND_TIMEOUT,
     ) -> CameDomoticAPI:
         """Create a CameDomoticAPI object.
 
@@ -346,6 +356,8 @@ class CameDomoticAPI:
                 session will be closed when the CameDomoticAPI object is disposed. If
                 the websession is not provided, this argument is ignored and the session
                 will always be closed.
+            command_timeout (int, optional): the default timeout in seconds
+                for all commands sent to the server (default: 30s).
 
         Returns:
             CameDomoticAPI: The CameDomoticAPI object.
@@ -367,9 +379,10 @@ class CameDomoticAPI:
                 close_websession_on_disposal=(
                     close_websession_on_disposal if websession else True
                 ),
+                command_timeout=command_timeout,
             )
         except Exception:
             if not websession:
                 await session.close()
             raise
-        return cls(auth)
+        return cls(auth, command_timeout=command_timeout)

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -251,11 +251,19 @@ class CameDomoticAPI:
                 sensors.append(AnalogSensor(sensor_data))
         return sensors
 
-    async def async_get_updates(self) -> UpdateList:
-        """Get the list of status updates from the server.
+    async def async_get_updates(self, timeout: int = 120) -> UpdateList:
+        """Get status updates from the server using long polling.
+
+        This method performs a long-polling request: it blocks until the server
+        sends one or more real-time status updates (e.g., a light turned on, a
+        scenario activated), then returns them all at once.
+
+        Args:
+            timeout (int, optional): the timeout in seconds for the
+                long-polling request (default: 120s).
 
         Returns:
-            UpdateList: List of status updates.
+            UpdateList: List of status updates received from the server.
 
         Raises:
             CameDomoticAuthError: If the authentication fails.
@@ -266,7 +274,9 @@ class CameDomoticAPI:
             "cmd_name": _CommandName.STATUS_UPDATE.value,
         }
         json_response = await self.auth.async_send_command(
-            payload, response_command=_CommandNameResponse.STATUS_UPDATE.value
+            payload,
+            response_command=_CommandNameResponse.STATUS_UPDATE.value,
+            timeout=timeout,
         )
         return UpdateList((json_response or {}).get("result", []))
 

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -37,6 +37,9 @@ ACK_ERROR_CODES = {
 # Authentication-related error codes that should raise CameDomoticAuthError
 AUTH_ERROR_CODES = {1, 3}
 
+# Default timeout in seconds for commands sent to the CAME server.
+_DEFAULT_COMMAND_TIMEOUT: int = 30
+
 
 def get_ack_error_message(ack_code: int) -> str:
     """Get human-readable message for ACK error code.

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -475,6 +475,36 @@ each batch of updates as it arrives:
     to run the polling loop alongside other logic, wrap it in
     ``asyncio.create_task()``.
 
+Configuring timeouts
+^^^^^^^^^^^^^^^^^^^^
+
+All commands sent to the CAME server use a default timeout of **30 seconds**,
+configurable via the ``command_timeout`` parameter when creating the API
+instance:
+
+.. code-block:: python
+
+    # Set a custom timeout of 15 seconds for all commands
+    async with await CameDomoticAPI.async_create(
+        "192.168.x.x", "username", "password", command_timeout=15
+    ) as api:
+        lights = await api.async_get_lights()  # uses 15s timeout
+
+By default, ``async_get_updates()`` also uses ``command_timeout``. However,
+since this method uses **long polling** (the server holds the connection open
+until updates are available), a longer timeout is **strongly recommended** to
+avoid premature disconnections:
+
+.. code-block:: python
+
+    # Recommended: set a longer timeout for long-polling requests
+    updates = await api.async_get_updates(timeout=120)
+
+.. note::
+    If no ``timeout`` is passed to ``async_get_updates()``, the instance-level
+    ``command_timeout`` is used (default: 30s). For most real-time monitoring
+    use cases, a timeout of **60–120 seconds** is recommended.
+
 Getting typed updates
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -29,6 +29,7 @@ from cryptography.fernet import Fernet
 
 from aiocamedomotic import Auth
 from aiocamedomotic.auth import handle_came_domotic_errors
+from aiocamedomotic.const import _DEFAULT_COMMAND_TIMEOUT
 from aiocamedomotic.errors import (
     CameDomoticAuthError,
     CameDomoticServerError,
@@ -287,7 +288,7 @@ class TestAuthSendCommand:
                     "http://192.168.x.x/domo/",
                     data={"command": json.dumps(expected_request_payload)},
                     headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
-                    timeout=aiohttp.ClientTimeout(total=10),
+                    timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
                 )
 
     @freezegun.freeze_time("2020-01-01")
@@ -342,7 +343,7 @@ class TestAuthSendCommand:
                     "http://192.168.x.x/domo/",
                     data={"command": json.dumps(expected_request_payload)},
                     headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
-                    timeout=aiohttp.ClientTimeout(total=10),
+                    timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
                 )
 
     async def test_failure(self, auth_instance):
@@ -377,7 +378,7 @@ class TestAuthSendCommand:
                     "http://192.168.x.x/domo/",
                     data={"command": json.dumps(expected_request_payload)},
                     headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
-                    timeout=aiohttp.ClientTimeout(total=10),
+                    timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
                 )
 
     async def test_timeout(self, auth_instance):
@@ -412,7 +413,7 @@ class TestAuthSendCommand:
                     "http://192.168.x.x/domo/",
                     data={"command": json.dumps(expected_request_payload)},
                     headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
-                    timeout=aiohttp.ClientTimeout(total=10),
+                    timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
                 )
 
     @patch.object(
@@ -458,7 +459,7 @@ class TestAuthSendCommand:
                 "http://192.168.x.x/domo/",
                 data={"command": json.dumps(full_payload)},
                 headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
-                timeout=aiohttp.ClientTimeout(total=10),
+                timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
             )
             mock_raise_for_status_and_ack.assert_called_once()
             assert auth_instance.cseq == 0

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -846,6 +846,21 @@ class TestAPIUpdates:
 
         assert isinstance(result, UpdateList)
         mock_send_command.assert_called_once()
+        _, kwargs = mock_send_command.call_args
+        assert kwargs["timeout"] == 120
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_updates_custom_timeout(
+        self, mock_send_command, auth_instance
+    ):
+        """Test that a custom timeout is passed to async_send_command."""
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {}
+
+        await api.async_get_updates(timeout=60)
+
+        _, kwargs = mock_send_command.call_args
+        assert kwargs["timeout"] == 60
 
     @patch.object(
         Auth,

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aiocamedomotic import Auth, CameDomoticAPI
+from aiocamedomotic.const import _DEFAULT_COMMAND_TIMEOUT
 from aiocamedomotic.errors import (
     CameDomoticAuthError,
     CameDomoticError,
@@ -50,6 +51,11 @@ class TestAPIInit:
     async def test_init(self, auth_instance):
         api = CameDomoticAPI(auth_instance)
         assert api.auth == auth_instance
+        assert api.auth.command_timeout == _DEFAULT_COMMAND_TIMEOUT
+
+    async def test_init_custom_command_timeout(self, auth_instance):
+        api = CameDomoticAPI(auth_instance, command_timeout=15)
+        assert api.auth.command_timeout == 15
 
     @patch.object(Auth, "async_dispose")
     async def test_aexit_calls_async_dispose(self, mock_async_dispose, auth_instance):
@@ -119,6 +125,7 @@ class TestAPIInit:
             "username",
             "password",
             close_websession_on_disposal=True,
+            command_timeout=_DEFAULT_COMMAND_TIMEOUT,
         )
         assert api.auth == mock_auth
 
@@ -847,7 +854,7 @@ class TestAPIUpdates:
         assert isinstance(result, UpdateList)
         mock_send_command.assert_called_once()
         _, kwargs = mock_send_command.call_args
-        assert kwargs["timeout"] == 120
+        assert kwargs["timeout"] is None
 
     @patch.object(Auth, "async_send_command")
     async def test_async_get_updates_custom_timeout(
@@ -857,10 +864,10 @@ class TestAPIUpdates:
         api = CameDomoticAPI(auth_instance)
         mock_send_command.return_value = {}
 
-        await api.async_get_updates(timeout=60)
+        await api.async_get_updates(timeout=120)
 
         _, kwargs = mock_send_command.call_args
-        assert kwargs["timeout"] == 60
+        assert kwargs["timeout"] == 120
 
     @patch.object(
         Auth,


### PR DESCRIPTION
## Summary
- Add a `_DEFAULT_COMMAND_TIMEOUT` constant (30s) in `const.py` to replace hardcoded timeout values
- Add an instance-level `command_timeout` parameter to `CameDomoticAPI` and `Auth` (default: 30s) that applies to all commands automatically
- `async_get_updates()` accepts an optional per-call `timeout` override (defaults to `command_timeout`); a longer value (e.g. 120s) is recommended for long polling
- Document timeout configuration in `usage_examples.rst` with examples for both instance-level and per-call usage

## Test plan
- [x] All 297 tests pass (12 skipped: real server tests)
- [x] New tests: `test_init_custom_command_timeout`, updated `test_async_create_all_params`
- [x] Updated `TestAPIUpdates` tests to verify default (`None` fallback) and custom timeout behavior
- [x] Auth tests updated to use `_DEFAULT_COMMAND_TIMEOUT` constant in assertions
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, bandit, codespell, pytest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-instance default command timeout and per-call timeout override for long-polling updates, letting users control request timeouts more precisely.

* **Documentation**
  * Added guidance and examples for configuring timeouts and recommended ranges for real-time monitoring.

* **Tests**
  * Expanded tests to verify default and custom timeout behaviors for update and command operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->