### PR TITLE
feat: add CAME MAC address OUI prefixes for device autodiscovery

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -27,6 +27,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from .auth import Auth  # noqa: F401
 from .came_domotic_api import CameDomoticAPI  # noqa: F401
+from .const import CAME_MAC_PREFIXES  # noqa: F401
 from .utils import LOGGER
 
 # Get the package version

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -37,6 +37,10 @@ ACK_ERROR_CODES = {
 # Authentication-related error codes that should raise CameDomoticAuthError
 AUTH_ERROR_CODES = {1, 3}
 
+# Known MAC address OUI prefixes for CAME Domotic devices (BPT S.p.A.)
+# These can be used for network autodiscovery of CAME ETI/Domo servers.
+CAME_MAC_PREFIXES: tuple[str, ...] = ("00:1C:B2",)
+
 # Default timeout in seconds for commands sent to the CAME server.
 _DEFAULT_COMMAND_TIMEOUT: int = 30
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -57,7 +57,7 @@ Constants
 ---------
 
 .. automodule:: aiocamedomotic.const
-   :members: DeviceType, UpdateIndicator
+   :members: CAME_MAC_PREFIXES, DeviceType, UpdateIndicator
 
 
 Errors

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -87,6 +87,74 @@ To properly handle potential errors, you can add these imports:
         CameDomoticServerError, # Server-side error
     )
 
+Device autodiscovery
+--------------------
+
+The library exposes known MAC address OUI (Organizationally Unique Identifier)
+prefixes for CAME Domotic devices via the ``CAME_MAC_PREFIXES`` constant. This
+can be used as a first step to identify potential CAME ETI/Domo servers on the
+local network.
+
+Checking the MAC address prefix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``CAME_MAC_PREFIXES`` to quickly filter network devices that may be CAME
+Domotic servers:
+
+.. code-block:: python
+
+    from aiocamedomotic import CAME_MAC_PREFIXES
+
+    def is_came_mac(mac_address: str) -> bool:
+        """Check if a MAC address belongs to a known CAME/BPT manufacturer."""
+        mac_upper = mac_address.upper()
+        return any(mac_upper.startswith(prefix) for prefix in CAME_MAC_PREFIXES)
+
+    # Example: filter discovered devices on the network
+    discovered_mac = "00:1C:B2:71:1B:82"
+    if is_came_mac(discovered_mac):
+        print(f"{discovered_mac} looks like a CAME device")
+
+Verifying the CAME API endpoint
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A matching MAC prefix alone does not guarantee the device is a CAME Domotic
+server. To confirm, attempt to connect and retrieve the server information:
+
+.. code-block:: python
+
+    from aiocamedomotic import CameDomoticAPI, CAME_MAC_PREFIXES
+    from aiocamedomotic.errors import CameDomoticError
+
+    async def async_verify_came_server(
+        host: str, mac_address: str, username: str, password: str
+    ) -> bool:
+        """Verify that a device is a CAME Domotic server.
+
+        First checks the MAC prefix, then confirms by retrieving
+        server information from the CAME API.
+        """
+        # Step 1: Quick MAC prefix check
+        mac_upper = mac_address.upper()
+        if not any(mac_upper.startswith(prefix) for prefix in CAME_MAC_PREFIXES):
+            return False
+
+        # Step 2: Verify the device exposes a valid CAME API endpoint
+        try:
+            async with await CameDomoticAPI.async_create(
+                host, username, password
+            ) as api:
+                server_info = await api.async_get_server_info()
+                print(
+                    f"Confirmed CAME server at {host}: "
+                    f"keycode={server_info.keycode}, "
+                    f"version={server_info.swver}"
+                )
+                return True
+        except CameDomoticError:
+            return False
+
+
 Initializing the API client
 ---------------------------
 

--- a/tests/aiocamedomotic/test_config.ini.example
+++ b/tests/aiocamedomotic/test_config.ini.example
@@ -2,6 +2,7 @@
 host = YOUR_SERVER_IP_OR_HOSTNAME
 username = YOUR_USERNAME
 password = YOUR_PASSWORD
+mac_address = YOUR_SERVER_MAC_ADDRESS
 
 [test_devices]
 # Example: Define specific device names or IDs your tests might use

--- a/tests/aiocamedomotic/test_const.py
+++ b/tests/aiocamedomotic/test_const.py
@@ -142,3 +142,39 @@ def test_all_auth_codes_in_ack_codes():
 
     for auth_code in AUTH_ERROR_CODES:
         assert auth_code in ACK_ERROR_CODES
+
+
+def test_came_mac_prefixes_type():
+    """Test that CAME_MAC_PREFIXES is a tuple of strings."""
+    from aiocamedomotic.const import CAME_MAC_PREFIXES
+
+    assert isinstance(CAME_MAC_PREFIXES, tuple)
+    assert len(CAME_MAC_PREFIXES) > 0
+    for prefix in CAME_MAC_PREFIXES:
+        assert isinstance(prefix, str)
+
+
+def test_came_mac_prefixes_format():
+    """Test that each prefix matches the XX:XX:XX OUI format."""
+    import re
+
+    from aiocamedomotic.const import CAME_MAC_PREFIXES
+
+    oui_pattern = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}$")
+    for prefix in CAME_MAC_PREFIXES:
+        assert oui_pattern.match(prefix), f"Invalid OUI format: {prefix}"
+
+
+def test_came_mac_prefixes_contains_bpt():
+    """Test that the known BPT S.p.A. OUI prefix is present."""
+    from aiocamedomotic.const import CAME_MAC_PREFIXES
+
+    assert "00:1C:B2" in CAME_MAC_PREFIXES
+
+
+def test_came_mac_prefixes_importable_from_package():
+    """Test that CAME_MAC_PREFIXES is importable from the top-level package."""
+    from aiocamedomotic import CAME_MAC_PREFIXES
+
+    assert isinstance(CAME_MAC_PREFIXES, tuple)
+    assert "00:1C:B2" in CAME_MAC_PREFIXES

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -27,7 +27,8 @@ import asyncio
 
 import pytest
 
-from aiocamedomotic import CameDomoticAPI
+from aiocamedomotic import CAME_MAC_PREFIXES, CameDomoticAPI
+from aiocamedomotic.errors import CameDomoticError
 from aiocamedomotic.models import (
     DigitalInputUpdate,
     LightStatus,
@@ -407,3 +408,41 @@ async def test_listen_for_updates(api_instance_real: CameDomoticAPI):
         f"\nDone — collected {total_updates} update(s) "
         f"across {max_api_calls} API call(s)."
     )
+
+
+async def test_autodiscovery(real_server_config):
+    """Tests the two-step autodiscovery: MAC prefix check + API verification."""
+    mac_address = real_server_config["came_server"].get("mac_address", "")
+    if not mac_address:
+        pytest.skip(
+            "mac_address not configured in test_config.ini, "
+            "skipping autodiscovery test."
+        )
+        return
+
+    host = real_server_config["came_server"]["host"]
+    username = real_server_config["came_server"]["username"]
+    password = real_server_config["came_server"]["password"]
+
+    # Step 1: Check the MAC prefix
+    mac_upper = mac_address.upper()
+    mac_matches = any(mac_upper.startswith(prefix) for prefix in CAME_MAC_PREFIXES)
+    print(f"\nMAC address: {mac_address}")
+    print(f"Matches CAME prefix: {mac_matches}")
+    assert mac_matches, (
+        f"MAC address {mac_address} does not match any known CAME prefix "
+        f"({', '.join(CAME_MAC_PREFIXES)})"
+    )
+
+    # Step 2: Verify the device exposes a valid CAME API endpoint
+    try:
+        async with await CameDomoticAPI.async_create(host, username, password) as api:
+            server_info = await api.async_get_server_info()
+            print(
+                f"Confirmed CAME server at {host}: "
+                f"keycode={server_info.keycode}, "
+                f"version={server_info.swver}"
+            )
+            assert server_info.keycode, "Server keycode should not be empty"
+    except CameDomoticError as err:
+        pytest.fail(f"CAME API verification failed: {err}")


### PR DESCRIPTION
## Summary
- Add `CAME_MAC_PREFIXES` constant (BPT S.p.A. OUI `00:1C:B2`) for network-level identification of CAME ETI/Domo servers
- Add documentation with usage examples for MAC prefix checking and API endpoint verification
- Add unit tests and real-server autodiscovery test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device autodiscovery capability to identify CAME Domotic servers by MAC address prefix recognition.

* **Documentation**
  * Added comprehensive autodiscovery usage examples, including MAC address validation and server verification procedures.

* **Tests**
  * Added test coverage for the new autodiscovery functionality and MAC address validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->