### PR TITLE
feat: add credential-free autodiscovery helper

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -28,7 +28,7 @@ from importlib.metadata import PackageNotFoundError, version
 from .auth import Auth  # noqa: F401
 from .came_domotic_api import CameDomoticAPI  # noqa: F401
 from .const import CAME_MAC_PREFIXES  # noqa: F401
-from .utils import LOGGER
+from .utils import LOGGER, async_is_came_endpoint  # noqa: F401
 
 # Get the package version
 try:

--- a/aiocamedomotic/utils.py
+++ b/aiocamedomotic/utils.py
@@ -20,7 +20,57 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
+import aiohttp
+
 LOGGER = logging.getLogger(__package__)
+
+
+async def async_is_came_endpoint(
+    host: str,
+    websession: aiohttp.ClientSession | None = None,
+    timeout: int = 10,
+) -> bool:
+    """Check whether a host exposes the CAME Domotic API endpoint.
+
+    Performs a credential-free HTTP GET on the CAME API URL to determine
+    if the host is a CAME ETI/Domo server. Suitable for network
+    autodiscovery alongside :data:`~aiocamedomotic.const.CAME_MAC_PREFIXES`.
+
+    Args:
+        host: IP address or hostname of the device to check
+            (e.g., ``"192.168.1.100"``, ``"came-server.local"``).
+        websession: Optional :class:`aiohttp.ClientSession` to reuse. When
+            provided, the caller retains ownership and the session will **not**
+            be closed by this function. When omitted, a temporary session is
+            created and closed automatically.
+        timeout: HTTP request timeout in seconds (default: 10).
+
+    Returns:
+        ``True`` if the host responds with HTTP 200 on the CAME API endpoint,
+        ``False`` otherwise (network error, timeout, wrong status, etc.).
+    """
+    endpoint_url = f"http://{host}/domo/"
+    LOGGER.debug("Checking CAME endpoint at '%s'", endpoint_url)
+
+    own_session = websession is None
+    session = websession or aiohttp.ClientSession()
+
+    try:
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        async with session.get(endpoint_url, timeout=client_timeout) as resp:
+            if resp.status == 200:
+                LOGGER.debug("CAME endpoint confirmed at '%s'", endpoint_url)
+                return True
+            LOGGER.debug(
+                "Host at '%s' responded with HTTP %s", endpoint_url, resp.status
+            )
+            return False
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.debug("CAME endpoint check failed for '%s': %s", endpoint_url, exc)
+        return False
+    finally:
+        if own_session:
+            await session.close()
 
 
 class EntityValidator:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -60,6 +60,12 @@ Constants
    :members: CAME_MAC_PREFIXES, DeviceType, UpdateIndicator
 
 
+Utilities
+---------
+
+.. autofunction:: aiocamedomotic.utils.async_is_came_endpoint
+
+
 Errors
 ------
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -119,20 +119,20 @@ Verifying the CAME API endpoint
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A matching MAC prefix alone does not guarantee the device is a CAME Domotic
-server. To confirm, attempt to connect and retrieve the server information:
+server. To confirm, use :func:`~aiocamedomotic.utils.async_is_came_endpoint`
+to check whether the host exposes the CAME API endpoint. This check does
+**not** require credentials, making it suitable for autodiscovery:
 
 .. code-block:: python
 
-    from aiocamedomotic import CameDomoticAPI, CAME_MAC_PREFIXES
-    from aiocamedomotic.errors import CameDomoticError
+    from aiocamedomotic import CAME_MAC_PREFIXES, async_is_came_endpoint
 
-    async def async_verify_came_server(
-        host: str, mac_address: str, username: str, password: str
-    ) -> bool:
-        """Verify that a device is a CAME Domotic server.
+    async def async_discover_came_server(host: str, mac_address: str) -> bool:
+        """Check if a network device is a CAME Domotic server.
 
-        First checks the MAC prefix, then confirms by retrieving
-        server information from the CAME API.
+        No credentials are needed: the function only verifies that the
+        MAC address belongs to a known CAME/BPT manufacturer and that
+        the host exposes the expected API endpoint.
         """
         # Step 1: Quick MAC prefix check
         mac_upper = mac_address.upper()
@@ -140,19 +140,7 @@ server. To confirm, attempt to connect and retrieve the server information:
             return False
 
         # Step 2: Verify the device exposes a valid CAME API endpoint
-        try:
-            async with await CameDomoticAPI.async_create(
-                host, username, password
-            ) as api:
-                server_info = await api.async_get_server_info()
-                print(
-                    f"Confirmed CAME server at {host}: "
-                    f"keycode={server_info.keycode}, "
-                    f"version={server_info.swver}"
-                )
-                return True
-        except CameDomoticError:
-            return False
+        return await async_is_came_endpoint(host)
 
 
 Initializing the API client

--- a/tests/aiocamedomotic/test_utils.py
+++ b/tests/aiocamedomotic/test_utils.py
@@ -1,0 +1,176 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import aiohttp
+
+from aiocamedomotic.utils import async_is_came_endpoint
+
+
+class TestAsyncIsCameEndpoint:
+    """Tests for the async_is_came_endpoint helper."""
+
+    async def test_returns_true_on_http_200(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 200
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is True
+                mock_get.assert_called_once_with(
+                    "http://192.168.1.100/domo/",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                )
+
+    async def test_returns_false_on_http_404(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 404
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is False
+
+    async def test_returns_false_on_http_500(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 500
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is False
+
+    async def test_returns_false_on_timeout(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get", side_effect=TimeoutError()):
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is False
+
+    async def test_returns_false_on_client_error(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get", side_effect=aiohttp.ClientError()):
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is False
+
+    async def test_returns_false_on_os_error(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(
+                session, "get", side_effect=OSError("Network unreachable")
+            ):
+                result = await async_is_came_endpoint(
+                    "192.168.1.100", websession=session
+                )
+
+                assert result is False
+
+    async def test_creates_and_closes_own_session(self):
+        mock_response = Mock()
+        mock_response.status = 200
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.get.return_value.__aenter__.return_value = mock_response
+
+        with patch("aiocamedomotic.utils.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value = mock_session
+
+            result = await async_is_came_endpoint("192.168.1.100")
+
+            assert result is True
+            mock_cls.assert_called_once()
+            mock_session.close.assert_awaited_once()
+
+    async def test_does_not_close_provided_session(self):
+        mock_response = Mock()
+        mock_response.status = 200
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.get.return_value.__aenter__.return_value = mock_response
+
+        result = await async_is_came_endpoint("192.168.1.100", websession=mock_session)
+
+        assert result is True
+        mock_session.close.assert_not_awaited()
+
+    async def test_custom_timeout(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 200
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                await async_is_came_endpoint(
+                    "192.168.1.100", websession=session, timeout=5
+                )
+
+                mock_get.assert_called_once_with(
+                    "http://192.168.1.100/domo/",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                )
+
+    async def test_url_construction(self):
+        async with aiohttp.ClientSession() as session:
+            with patch.object(session, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.status = 200
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                await async_is_came_endpoint("came-server.local", websession=session)
+
+                mock_get.assert_called_once_with(
+                    "http://came-server.local/domo/",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                )
+
+    async def test_closes_own_session_on_error(self):
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.get.side_effect = aiohttp.ClientError()
+
+        with patch("aiocamedomotic.utils.aiohttp.ClientSession") as mock_cls:
+            mock_cls.return_value = mock_session
+
+            result = await async_is_came_endpoint("192.168.1.100")
+
+            assert result is False
+            mock_session.close.assert_awaited_once()
+
+    async def test_importable_from_package(self):
+        from aiocamedomotic import (  # pylint: disable=import-outside-toplevel
+            async_is_came_endpoint as imported_func,
+        )
+
+        assert callable(imported_func)


### PR DESCRIPTION
## Summary
- Add `async_is_came_endpoint()` helper in `utils.py` that performs a credential-free HTTP GET on the CAME API URL to check if a host is a CAME ETI/Domo server
- Fix autodiscovery documentation in `usage_examples.rst` which incorrectly required username/password at discovery time
- Add "Utilities" section to `api_reference.rst` for the new function
- Add comprehensive tests (12 cases) in `test_utils.py`

## Test plan
- [x] All 313 existing tests pass
- [x] 12 new tests cover: HTTP 200, 404, 500, timeout, connection error, OS error, session lifecycle (own vs provided), custom timeout, URL construction, package importability
- [x] pylint clean (only pre-existing R0903 on EntityValidator)
- [x] mypy clean
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential-free server discovery functionality for automated endpoint detection
  * Introduced data validation utility for input verification
  
* **Documentation**
  * Updated usage examples with simplified, credential-free setup workflow
  * Expanded API reference documentation

* **Tests**
  * Added comprehensive test coverage for new endpoint verification functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->