### PR TITLE
fix: read docs version dynamically from pyproject.toml

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,14 +9,27 @@
 import os
 import sys
 
-module_path = os.path.abspath("../../")
-print(module_path)
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib
+
+_conf_dir = os.path.dirname(os.path.abspath(__file__))
+module_path = os.path.abspath(os.path.join(_conf_dir, "..", ".."))
 sys.path.insert(0, module_path)
+
+# Read version from pyproject.toml
+_pyproject_path = os.path.join(module_path, "pyproject.toml")
+with open(_pyproject_path, "rb") as f:
+    _pyproject = tomllib.load(f)
+release = _pyproject["tool"]["poetry"]["version"]
 
 project = "aiocamedomotic"
 copyright = "2024, CAME Domotic Unofficial team"
 author = "fredericks1982"
-release = "1.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
## Summary
- Fix ReadTheDocs showing outdated version (1.1 instead of 1.4.2)
- Sphinx `conf.py` now reads the version from `pyproject.toml` dynamically using `tomllib`
- Version will stay in sync automatically on future releases

## Test plan
- [x] Sphinx build succeeds locally
- [ ] Verify ReadTheDocs rebuilds with correct version after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to dynamically extract version information from project metadata, improving maintainability and ensuring consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->