### PR TITLE
chore: add tmux and fix terminal config in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,11 +38,11 @@
         "editor.formatOnType": true,
         "files.trimTrailingWhitespace": true,
         "terminal.integrated.profiles.linux": {
-          "zsh": {
-            "path": "/usr/bin/zsh"
+          "bash": {
+            "path": "/bin/bash"
           }
         },
-        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.defaultProfile.linux": "bash",
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
         }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,7 +17,8 @@ RUN apk update && \
         npm \
         coreutils \
         github-cli \
-        ripgrep
+        ripgrep \
+        tmux
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /usr/src


### PR DESCRIPTION
## Summary
- Add `tmux` to the devcontainer Dockerfile for terminal multiplexing support
- Fix terminal profile in devcontainer.json to use `bash` instead of `zsh` (zsh is not installed in the Alpine-based image)

## Test plan
- [x] Verify devcontainer builds successfully
- [x] Verify terminal opens with bash
- [x] All existing tests pass (313 passed, 13 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to use bash as the default terminal shell.
  * Added tmux to development container dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->