### PR TITLE
fix: re-install package from workspace path in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "aiocamedomotic library development",
   "context": "..",
   "dockerFile": "../Dockerfile.dev",
-  "postCreateCommand": "pre-commit install && pre-commit install --hook-type pre-push",
+  "postCreateCommand": "pip install -e /workspaces/aiocamedomotic && pre-commit install && pre-commit install --hook-type pre-push",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- Fix editable install path mismatch in devcontainer: the Dockerfile installs from `/usr/src/aiocamedomotic` but the workspace is mounted at `/workspaces/aiocamedomotic`, causing pytest coverage to report 0%
- Add `pip install -e` from the workspace path in `postCreateCommand` so the editable install points to the correct location after container creation

## Test plan
- [x] Verify `pytest --cov=aiocamedomotic --cov-fail-under=90` passes with correct coverage after running `postCreateCommand`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment setup to automatically install the package in editable mode and configure pre-commit hooks during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->