### PR TITLE
feat: add unique_id, CameDomoticServerTimeoutError, and library improvements

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -28,6 +28,7 @@ from importlib.metadata import PackageNotFoundError, version
 from .auth import Auth  # noqa: F401
 from .came_domotic_api import CameDomoticAPI  # noqa: F401
 from .const import CAME_MAC_PREFIXES  # noqa: F401
+from .errors import CameDomoticServerTimeoutError  # noqa: F401
 from .utils import LOGGER, async_is_came_endpoint  # noqa: F401
 
 # Get the package version

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -41,7 +41,12 @@ from urllib.parse import urlsplit
 import aiohttp
 from cryptography.fernet import Fernet
 
-from .const import _DEFAULT_COMMAND_TIMEOUT, _CommandType
+from .const import (
+    _DEFAULT_COMMAND_TIMEOUT,
+    _KEEP_ALIVE_MAX_SEC,
+    _KEEP_ALIVE_MIN_SEC,
+    _CommandType,
+)
 
 # Get package version to avoid circular imports
 try:
@@ -52,6 +57,7 @@ from .errors import (
     CameDomoticAuthError,
     CameDomoticServerError,
     CameDomoticServerNotFoundError,
+    CameDomoticServerTimeoutError,
 )
 from .utils import LOGGER
 
@@ -87,7 +93,7 @@ def handle_came_domotic_errors(func: _F) -> _F:
         except aiohttp.ServerTimeoutError as e:
             # Handle timeouts specifically
             LOGGER.error("Timeout in %s: %s", func.__name__, e)
-            raise CameDomoticServerError(
+            raise CameDomoticServerTimeoutError(
                 f"HTTP POST resulted in a timeout error ({e})"
             ) from e
         except aiohttp.ClientError as e:
@@ -298,7 +304,9 @@ class Auth:
         """
         async with self._lock:
             if not self.is_session_valid():
-                LOGGER.debug("Session expired or invalid, performing login")
+                LOGGER.debug(
+                    "Session expired or not yet established, triggering re-login"
+                )
                 await self._async_perform_login()
             return self.client_id
 
@@ -557,7 +565,18 @@ class Auth:
 
             # ACK is ok, store the login data
             self.client_id = data.get("sl_client_id", "")
-            self.keep_alive_timeout_sec = data.get("sl_keep_alive_timeout_sec", 0)
+            raw_timeout: int = data.get("sl_keep_alive_timeout_sec", 0)
+            # Clamp server-supplied keep-alive to a safe range.
+            # A value of 0 would trigger re-login on every command (re-login storm).
+            # A very large value would allow sessions to drift without renewal.
+            self.keep_alive_timeout_sec = max(
+                _KEEP_ALIVE_MIN_SEC, min(raw_timeout, _KEEP_ALIVE_MAX_SEC)
+            )
+            LOGGER.debug(
+                "Keep-alive timeout set to %d s (server sent %d s)",
+                self.keep_alive_timeout_sec,
+                raw_timeout,
+            )
             self.session_expiration_timestamp = time.monotonic() + max(
                 0, self.keep_alive_timeout_sec - Auth._DEFAULT_SAFE_ZONE_SEC
             )
@@ -692,7 +711,7 @@ class Auth:
         self,
     ) -> tuple[bytes | None, bytes | None, str, float, int, int]:
         """Backup the current authentication credentials."""
-        return (
+        result = (
             self.username,
             self.password,
             self.client_id,
@@ -700,6 +719,8 @@ class Auth:
             self.keep_alive_timeout_sec,
             self.cseq,
         )
+        LOGGER.debug("Auth credentials backed up")
+        return result
 
     def restore_auth_credentials(
         self,
@@ -718,6 +739,7 @@ class Auth:
             self.keep_alive_timeout_sec,
             self.cseq,
         ) = backup_state
+        LOGGER.debug("Auth credentials restored from backup")
 
     def update_auth_credentials(self, username: str, password: str) -> None:
         """Update the authentication credentials.
@@ -736,6 +758,6 @@ class Auth:
         # Invalidate the (previous) session, since the credentials have changed
         self.session_expiration_timestamp = time.monotonic() - 3600
         self.client_id = ""
-        LOGGER.debug("Auth credentials updated, previous session invalidated")
+        LOGGER.info("Auth credentials updated, session invalidated")
 
     # endregion

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -61,9 +61,20 @@ class CameDomoticAPI:
         """
         self.auth = auth
         self.auth.command_timeout = command_timeout
+        self._server_info_cache: ServerInfo | None = None
         LOGGER.debug(
             "CameDomoticAPI initialized (command_timeout=%ds)", command_timeout
         )
+
+    @property
+    def server_info(self) -> ServerInfo | None:
+        """Cached server information, or ``None`` if not yet fetched.
+
+        This property makes no API call. Call :meth:`async_get_server_info` to
+        populate it. All ``async_get_*()`` device list methods populate it
+        automatically before returning entities.
+        """
+        return self._server_info_cache
 
     async def __aenter__(self) -> CameDomoticAPI:
         return self
@@ -112,6 +123,9 @@ class CameDomoticAPI:
         Provides info about the server (keycode, software version, etc.) and the list of
         features supported by the CAME Domotic server.
 
+        If ``server_info`` is already cached, returns it immediately without making an
+        API call.
+
         Returns:
             ServerInfo: Server information.
 
@@ -119,6 +133,9 @@ class CameDomoticAPI:
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
         """
+
+        if self._server_info_cache is not None:
+            return self._server_info_cache
 
         LOGGER.debug("Fetching server info")
         payload = {
@@ -135,7 +152,7 @@ class CameDomoticAPI:
             json_response.get("swver"),
             json_response.get("list"),
         )
-        return ServerInfo(
+        server_info = ServerInfo(
             keycode=json_response.get("keycode"),  # type: ignore[arg-type]
             swver=json_response.get("swver"),
             type=json_response.get("type"),
@@ -143,6 +160,9 @@ class CameDomoticAPI:
             serial=json_response.get("serial"),  # type: ignore[arg-type]
             features=json_response.get("list"),  # type: ignore[arg-type]
         )
+        self._server_info_cache = server_info
+        LOGGER.debug("Server info cached for host '%s'", self.auth.host)
+        return server_info
 
     async def async_get_floors(self) -> list[Floor]:
         """Get the list of all the floors defined on the server.
@@ -208,6 +228,13 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching lights list")
+        try:
+            await self.async_get_server_info()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Could not fetch server info for lights; unique_id unavailable"
+            )
+
         payload = {
             "cmd_name": _CommandName.LIGHT_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -218,9 +245,14 @@ class CameDomoticAPI:
         )
 
         # Defaults to an empty list if the key is missing from the response JSON
-        lights_list = json_response.get("array", [])
-        LOGGER.info("Retrieved %d light(s)", len(lights_list))
-        return [Light(light, self.auth) for light in lights_list]
+        lights_list = json_response.get("array", []) or []
+        lights = []
+        for light_data in lights_list:
+            light = Light(light_data, self.auth)
+            light.server_info = self.server_info
+            lights.append(light)
+        LOGGER.info("Retrieved %d light(s)", len(lights))
+        return lights
 
     async def async_get_thermo_zones(self) -> list[ThermoZone]:
         """Get the list of all thermoregulation zones defined on the server.
@@ -234,6 +266,14 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching thermoregulation zones")
+        try:
+            await self.async_get_server_info()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Could not fetch server info for thermo zones; "
+                "unique_id will not be available"
+            )
+
         payload = {
             "cmd_name": _CommandName.THERMO_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -244,9 +284,14 @@ class CameDomoticAPI:
         )
 
         # Defaults to an empty list if the key is missing from the response JSON
-        zones_list = json_response.get("array", [])
-        LOGGER.info("Retrieved %d thermo zone(s)", len(zones_list))
-        return [ThermoZone(zone, self.auth) for zone in zones_list]
+        zones_list = json_response.get("array", []) or []
+        zones = []
+        for zone_data in zones_list:
+            zone = ThermoZone(zone_data, self.auth)
+            zone.server_info = self.server_info
+            zones.append(zone)
+        LOGGER.info("Retrieved %d thermo zone(s)", len(zones))
+        return zones
 
     async def async_get_analog_sensors(self) -> list[AnalogSensor]:
         """Get analog sensor readings from the thermoregulation system.
@@ -263,6 +308,14 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching analog sensors")
+        try:
+            await self.async_get_server_info()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Could not fetch server info for analog sensors; "
+                "unique_id will not be available"
+            )
+
         payload = {
             "cmd_name": _CommandName.THERMO_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -276,7 +329,9 @@ class CameDomoticAPI:
         for key in ("temperature", "humidity", "pressure"):
             sensor_data = json_response.get(key)
             if sensor_data and isinstance(sensor_data, dict):
-                sensors.append(AnalogSensor(sensor_data))
+                sensor = AnalogSensor(sensor_data)
+                sensor.server_info = self.server_info
+                sensors.append(sensor)
         LOGGER.info("Retrieved %d analog sensor(s)", len(sensors))
         return sensors
 
@@ -330,6 +385,14 @@ class CameDomoticAPI:
             CameDomoticServerError: If the server returns an error.
         """
         LOGGER.debug("Fetching openings list")
+        try:
+            await self.async_get_server_info()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Could not fetch server info for openings; "
+                "unique_id will not be available"
+            )
+
         payload = {
             "cmd_name": _CommandName.OPENINGS_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -339,9 +402,14 @@ class CameDomoticAPI:
             payload, response_command=_CommandNameResponse.OPENINGS_LIST.value
         )
 
-        openings_data = json_response.get("array", [])
-        LOGGER.info("Retrieved %d opening(s)", len(openings_data))
-        return [Opening(opening_data, self.auth) for opening_data in openings_data]
+        openings_data = json_response.get("array", []) or []
+        openings = []
+        for opening_data in openings_data:
+            opening = Opening(opening_data, self.auth)
+            opening.server_info = self.server_info
+            openings.append(opening)
+        LOGGER.info("Retrieved %d opening(s)", len(openings))
+        return openings
 
     async def async_get_scenarios(self) -> list[Scenario]:
         """Get the list of all scenarios defined on the server.
@@ -354,6 +422,14 @@ class CameDomoticAPI:
             CameDomoticServerError: If the server returns an error.
         """
         LOGGER.debug("Fetching scenarios list")
+        try:
+            await self.async_get_server_info()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Could not fetch server info for scenarios; "
+                "unique_id will not be available"
+            )
+
         payload = {
             "cmd_name": _CommandName.SCENARIOS_LIST.value,
         }
@@ -363,9 +439,14 @@ class CameDomoticAPI:
         )
 
         # Defaults to an empty list if the key is missing from the response JSON
-        scenarios_list = json_response.get("array", [])
-        LOGGER.info("Retrieved %d scenario(s)", len(scenarios_list))
-        return [Scenario(data, self.auth) for data in scenarios_list]
+        scenarios_list = json_response.get("array", []) or []
+        scenarios = []
+        for scenario_data in scenarios_list:
+            scenario = Scenario(scenario_data, self.auth)
+            scenario.server_info = self.server_info
+            scenarios.append(scenario)
+        LOGGER.info("Retrieved %d scenario(s)", len(scenarios))
+        return scenarios
 
     @classmethod
     async def async_create(

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -44,6 +44,11 @@ CAME_MAC_PREFIXES: tuple[str, ...] = ("00:1C:B2",)
 # Default timeout in seconds for commands sent to the CAME server.
 _DEFAULT_COMMAND_TIMEOUT: int = 30
 
+# Bounds for the server-supplied keep-alive timeout (applied in auth.py).
+# Prevents re-login storms on zero/very-low values and runaway sessions on huge values.
+_KEEP_ALIVE_MIN_SEC: int = 30
+_KEEP_ALIVE_MAX_SEC: int = 3600
+
 
 def get_ack_error_message(ack_code: int) -> str:
     """Get human-readable message for ACK error code.

--- a/aiocamedomotic/errors.py
+++ b/aiocamedomotic/errors.py
@@ -14,6 +14,16 @@
 
 """
 This module contains the exceptions that can be raised by the CAME Domotic API.
+
+Exception hierarchy and suggested Home Assistant mapping:
+
+- :exc:`CameDomoticServerNotFoundError` → ``ConfigEntryNotReady``
+  (host unreachable, transient)
+- :exc:`CameDomoticAuthError` → ``ConfigEntryAuthFailed``
+  (bad credentials, permanent — triggers reauth flow)
+- :exc:`CameDomoticServerTimeoutError` → ``ConfigEntryNotReady``
+  (request timeout, transient)
+- :exc:`CameDomoticServerError` (other ACK codes) → log and re-raise
 """
 
 from __future__ import annotations
@@ -74,3 +84,22 @@ class CameDomoticServerError(CameDomoticError):
             exc = CameDomoticServerError(message)
         exc.ack_code = ack_code
         return exc
+
+
+class CameDomoticServerTimeoutError(CameDomoticServerError):
+    """Raised when a request to the CAME Domotic server times out.
+
+    This exception indicates a transient failure. When using this library with
+    Home Assistant, it should be mapped to ``ConfigEntryNotReady`` to allow the
+    integration to retry with exponential backoff.
+
+    See also the exception hierarchy mapping for Home Assistant integrations:
+
+    - :exc:`CameDomoticServerNotFoundError` → ``ConfigEntryNotReady``
+      (host unreachable, transient)
+    - :exc:`CameDomoticAuthError` → ``ConfigEntryAuthFailed``
+      (bad credentials, permanent — triggers reauth flow)
+    - :exc:`CameDomoticServerTimeoutError` → ``ConfigEntryNotReady``
+      (request timeout, transient)
+    - :exc:`CameDomoticServerError` (other ACK codes) → log and re-raise
+    """

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -36,6 +36,17 @@ from ..utils import (
 class CameEntity:
     """Base class for all the CAME entities."""
 
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this entity, suitable for use as a
+        Home Assistant entity unique ID. Returns ``None`` if ``server_info``
+        has not been set (e.g. if ``async_get_server_info()`` was never called
+        or failed). When using this library via ``CameDomoticAPI``,
+        ``server_info`` is automatically populated by all ``async_get_*()``
+        device list methods.
+        """
+        return None
+
 
 @dataclass
 class User(CameEntity):

--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -34,7 +34,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity
+from .base import CameEntity, ServerInfo
 
 
 class LightStatus(Enum):
@@ -49,6 +49,7 @@ class LightStatus(Enum):
     OFF = 0
     ON = 1
     AUTO = 4
+    UNKNOWN = -1
 
 
 class LightType(Enum):
@@ -79,14 +80,26 @@ class Light(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
+    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
-        EntityValidator.validate_data(self.raw_data, required_keys=["name", "act_id"])
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
         # Basic type-safety on the auth argument
         if not isinstance(self.auth, Auth):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
+
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this light entity."""
+        if self.server_info is None:
+            return None
+        return f"{self.server_info.keycode}_light_{self.act_id}"
 
     @property
     def act_id(self) -> int:
@@ -111,7 +124,18 @@ class Light(CameEntity):
     @property
     def status(self) -> LightStatus:
         """Status of the light. Allowed values are OFF (0), ON (1) and AUTO (4)."""
-        return LightStatus(self.raw_data["status"])
+        try:
+            return LightStatus(self.raw_data["status"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown light status '%s' encountered for light '%s' (ID: %s). "
+                "Returning LightStatus.UNKNOWN. Please report this "
+                "to the library developers.",
+                self.raw_data.get("status"),
+                self.name,
+                self.act_id,
+            )
+            return LightStatus.UNKNOWN
 
     @property
     def type(self) -> LightType:

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -33,7 +33,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity
+from .base import CameEntity, ServerInfo
 
 
 class OpeningStatus(Enum):
@@ -85,16 +85,26 @@ class Opening(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
+    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
-            self.raw_data, required_keys=["name", "open_act_id", "close_act_id"]
+            self.raw_data,
+            required_keys=["name", "open_act_id", "close_act_id"],
+            typed_keys={"open_act_id": int, "close_act_id": int},
         )
         # Basic type-safety on the auth argument
         if not isinstance(self.auth, Auth):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
+
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this opening entity."""
+        if self.server_info is None:
+            return None
+        return f"{self.server_info.keycode}_opening_{self.open_act_id}"
 
     @property
     def name(self) -> str:

--- a/aiocamedomotic/models/scenario.py
+++ b/aiocamedomotic/models/scenario.py
@@ -33,7 +33,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity
+from .base import CameEntity, ServerInfo
 
 
 class ScenarioStatus(Enum):
@@ -66,14 +66,26 @@ class Scenario(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
+    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
-        EntityValidator.validate_data(self.raw_data, required_keys=["name", "id"])
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "id"],
+            typed_keys={"id": int},
+        )
         # Basic type-safety on the auth argument
         if not isinstance(self.auth, Auth):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
+
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this scenario entity."""
+        if self.server_info is None:
+            return None
+        return f"{self.server_info.keycode}_scenario_{self.id}"
 
     @property
     def id(self) -> int:

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -32,7 +32,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity
+from .base import CameEntity, ServerInfo
 
 
 class ThermoZoneStatus(Enum):
@@ -99,13 +99,25 @@ class ThermoZone(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
+    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
-        EntityValidator.validate_data(self.raw_data, required_keys=["name", "act_id"])
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
         if not isinstance(self.auth, Auth):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
+
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this thermoregulation zone entity."""
+        if self.server_info is None:
+            return None
+        return f"{self.server_info.keycode}_thermo_zone_{self.act_id}"
 
     @property
     def act_id(self) -> int:
@@ -228,9 +240,21 @@ class AnalogSensor(CameEntity):
     """
 
     raw_data: dict[str, Any]
+    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
-        EntityValidator.validate_data(self.raw_data, required_keys=["name", "act_id"])
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
+
+    @property
+    def unique_id(self) -> str | None:
+        """Stable unique identifier for this analog sensor entity."""
+        if self.server_info is None:
+            return None
+        return f"{self.server_info.keycode}_analog_sensor_{self.act_id}"
 
     @property
     def act_id(self) -> int:

--- a/aiocamedomotic/utils.py
+++ b/aiocamedomotic/utils.py
@@ -77,16 +77,25 @@ class EntityValidator:
     """Mixin class to validate the CAME entities."""
 
     @staticmethod
-    def validate_data(data: Any, required_keys: Sequence[str]) -> None:
+    def validate_data(
+        data: Any,
+        required_keys: Sequence[str],
+        typed_keys: dict[str, type] | None = None,
+    ) -> None:
         """
         Validates the necessary data fields in the provided dictionary.
 
         Args:
             data (dict): The data dictionary to validate.
             required_keys (list): A list of keys that must be present in the data.
+            typed_keys (dict, optional): Mapping of key to expected type. For each
+                entry, the value at that key must be an instance of the expected type.
+                Keys in ``typed_keys`` should also appear in ``required_keys`` to
+                ensure they are present before type-checking.
 
         Raises:
-            ValueError: If any required key is missing from the data.
+            ValueError: If the data is not a dict, any required key is missing,
+                or any typed key has a value of the wrong type.
         """
         if not isinstance(data, dict):
             LOGGER.debug(
@@ -100,3 +109,17 @@ class EntityValidator:
             raise ValueError(
                 f"Data is missing required keys: {', '.join(missing_keys)}"
             )
+
+        if typed_keys:
+            for key, expected_type in typed_keys.items():
+                if key in data and not isinstance(data[key], expected_type):
+                    LOGGER.debug(
+                        "Validation failed: key '%s' expected %s, got %s",
+                        key,
+                        expected_type.__name__,
+                        type(data[key]).__name__,
+                    )
+                    raise ValueError(
+                        f"Key '{key}' expected {expected_type.__name__}, "
+                        f"got {type(data[key]).__name__}"
+                    )

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -33,6 +33,7 @@ Entity models
 
 .. automodule:: aiocamedomotic.models
    :members:
+   :noindex:
 
 .. automodule:: aiocamedomotic.models.base
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ exclude_patterns = exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
+
 
 # -- Options for Markdown output -----------------------------------------------
 markdown_anchor_sections = True

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -81,11 +81,17 @@ To properly handle potential errors, you can add these imports:
 .. code-block:: python
 
     from aiocamedomotic.errors import (
-        CameDomoticError, # Base error raised by the library
-        CameDomoticServerNotFoundError, # Server not reachable (wrong IP/hostname?)
-        CameDomoticAuthError, # Authentication failure (wrong credentials?)
-        CameDomoticServerError, # Server-side error
+        CameDomoticError,                # Base error raised by the library
+        CameDomoticServerNotFoundError,  # Server not reachable (wrong IP/hostname?)
+        CameDomoticAuthError,            # Authentication failure (wrong credentials?)
+        CameDomoticServerTimeoutError,   # Request timed out (transient, retry later)
+        CameDomoticServerError,          # Other server-side error
     )
+
+.. note::
+    ``CameDomoticServerTimeoutError`` is a subclass of ``CameDomoticServerError``
+    and signals a **transient** failure. Catching it separately lets you distinguish
+    retryable timeouts from permanent errors.
 
 Initializing the API client
 ---------------------------
@@ -442,6 +448,36 @@ Example output for analog sensors:
     Name: Barometric Pressure, Value: 1013, Unit: hPa
 
 
+Entity unique IDs
+-----------------
+
+Every device entity exposes a ``unique_id`` property that returns a stable,
+globally unique string identifier suitable for use as a persistent key (e.g.
+as an entity ID in Home Assistant):
+
+.. code-block:: python
+
+    lights = await api.async_get_lights()
+
+    for light in lights:
+        print(f"unique_id: {light.unique_id}, name: {light.name}")
+
+Example output:
+
+.. code-block:: text
+
+    unique_id: 0000FFFF9999AAAA_light_1, name: Living Room Chandelier
+    unique_id: 0000FFFF9999AAAA_light_2, name: Hallway Night Light
+
+The ``unique_id`` follows the pattern ``{server_keycode}_{entity_type}_{device_id}``
+and is available on all device entities: ``Light``, ``Opening``, ``Scenario``,
+``ThermoZone``, and ``AnalogSensor``.
+
+.. note::
+    ``unique_id`` returns ``None`` if server info could not be retrieved during
+    the entity list fetch. Guard against ``None`` when using it as a persistent key.
+
+
 Real-time updates
 -----------------
 
@@ -619,6 +655,7 @@ You can check for this using the ``has_plant_update`` property:
         openings = await api.async_get_openings()
         scenarios = await api.async_get_scenarios()
         thermo_zones = await api.async_get_thermo_zones()
+        sensors = await api.async_get_analog_sensors()
 
 .. note::
     Plant updates are relatively rare. They typically occur when an installer

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -29,11 +29,16 @@ from cryptography.fernet import Fernet
 
 from aiocamedomotic import Auth
 from aiocamedomotic.auth import handle_came_domotic_errors
-from aiocamedomotic.const import _DEFAULT_COMMAND_TIMEOUT
+from aiocamedomotic.const import (
+    _DEFAULT_COMMAND_TIMEOUT,
+    _KEEP_ALIVE_MAX_SEC,
+    _KEEP_ALIVE_MIN_SEC,
+)
 from aiocamedomotic.errors import (
     CameDomoticAuthError,
     CameDomoticServerError,
     CameDomoticServerNotFoundError,
+    CameDomoticServerTimeoutError,
 )
 
 
@@ -58,7 +63,7 @@ class TestHandleCameDomoticErrorsDecorator:
         async def dummy():
             raise aiohttp.ServerTimeoutError("timed out")
 
-        with pytest.raises(CameDomoticServerError, match="timeout"):
+        with pytest.raises(CameDomoticServerTimeoutError, match="timeout"):
             await dummy()
 
     async def test_client_error(self):
@@ -1175,3 +1180,131 @@ class TestAuthConcurrency:
         assert all(task.done() for task in tasks), (
             "All tasks should complete successfully"
         )
+
+
+class TestSessionRecovery:
+    """Tests verifying session invalidation and re-login behaviour."""
+
+    async def test_session_invalidated_on_ack_7(self, auth_instance):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 7}
+
+        auth_instance.client_id = "old_client_id"
+
+        with patch.object(
+            auth_instance.websession, "post", new_callable=AsyncMock
+        ) as mock_post:
+            mock_post.return_value = mock_response
+
+            with patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id:
+                mock_get_client_id.return_value = "old_client_id"
+
+                with pytest.raises(CameDomoticServerError):
+                    await auth_instance.async_send_command({})
+
+        assert auth_instance.client_id == ""
+
+    async def test_session_invalidated_on_ack_8(self, auth_instance):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 8}
+
+        auth_instance.client_id = "old_client_id"
+
+        with patch.object(
+            auth_instance.websession, "post", new_callable=AsyncMock
+        ) as mock_post:
+            mock_post.return_value = mock_response
+
+            with patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id:
+                mock_get_client_id.return_value = "old_client_id"
+
+                with pytest.raises(CameDomoticServerError):
+                    await auth_instance.async_send_command({})
+
+        assert auth_instance.client_id == ""
+
+    async def test_relogin_after_session_expiry(self, auth_instance):
+        auth_instance.session_expiration_timestamp = time.monotonic() - 3600
+        auth_instance.client_id = ""
+
+        with patch.object(
+            auth_instance, "_async_perform_login", new_callable=AsyncMock
+        ) as mock_login:
+
+            async def set_logged_in():
+                auth_instance.client_id = "refreshed_client"
+                auth_instance.session_expiration_timestamp = time.monotonic() + 3600
+
+            mock_login.side_effect = set_logged_in
+
+            result = await auth_instance.async_get_valid_client_id()
+
+        mock_login.assert_called_once()
+        assert result == "refreshed_client"
+
+    async def test_concurrent_commands_single_relogin(self, auth_instance):
+        auth_instance.session_expiration_timestamp = time.monotonic() - 3600
+        auth_instance.client_id = ""
+
+        async def set_logged_in():
+            auth_instance.client_id = "refreshed_client"
+            auth_instance.session_expiration_timestamp = time.monotonic() + 3600
+
+        with patch.object(
+            auth_instance, "_async_perform_login", new_callable=AsyncMock
+        ) as mock_login:
+            mock_login.side_effect = set_logged_in
+
+            results = await asyncio.gather(
+                auth_instance.async_get_valid_client_id(),
+                auth_instance.async_get_valid_client_id(),
+            )
+
+        assert mock_login.call_count == 1
+        assert all(r == "refreshed_client" for r in results)
+
+
+class TestKeepAliveClamping:
+    """Tests for server-supplied keep-alive timeout clamping."""
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_keep_alive_clamped_low(self, auth_instance_not_logged_in: Auth):
+        with (
+            patch.object(Auth, "async_send_command") as mock_send_command,
+            patch.object(Auth, "is_session_valid", return_value=False),
+        ):
+            mock_send_command.return_value = {
+                "sl_data_ack_reason": 0,
+                "sl_client_id": "test_client_id",
+                "sl_keep_alive_timeout_sec": 0,
+            }
+            await auth_instance_not_logged_in.async_login()
+            assert (
+                auth_instance_not_logged_in.keep_alive_timeout_sec
+                == _KEEP_ALIVE_MIN_SEC
+            )
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_keep_alive_clamped_high(self, auth_instance_not_logged_in: Auth):
+        with (
+            patch.object(Auth, "async_send_command") as mock_send_command,
+            patch.object(Auth, "is_session_valid", return_value=False),
+        ):
+            mock_send_command.return_value = {
+                "sl_data_ack_reason": 0,
+                "sl_client_id": "test_client_id",
+                "sl_keep_alive_timeout_sec": 99999,
+            }
+            await auth_instance_not_logged_in.async_login()
+            assert (
+                auth_instance_not_logged_in.keep_alive_timeout_sec
+                == _KEEP_ALIVE_MAX_SEC
+            )

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -479,6 +479,19 @@ class TestAPILights:
         assert isinstance(lights, list)
 
     @patch.object(Auth, "async_send_command")
+    async def test_async_get_lights_null_array(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "light_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        lights = await api.async_get_lights()
+        assert lights == []
+
+    @patch.object(Auth, "async_send_command")
     async def test_async_get_lights_missing_act_id(
         self, mock_send_command, auth_instance
     ):

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -1143,6 +1143,17 @@ class TestLight:
         assert light.type == LightType(light_data_dimmable["type"])
         assert light.perc == light_data_dimmable["perc"]
 
+    def test_unique_id_without_server_info(self, light_data_on_off, auth_instance):
+        light = Light(light_data_on_off, auth_instance)
+        assert light.unique_id is None
+
+    def test_unique_id_with_server_info(self, light_data_on_off, auth_instance):
+        light = Light(light_data_on_off, auth_instance)
+        light.server_info = ServerInfo(
+            keycode="ABC123", serial="SN001", features=["lights"]
+        )
+        assert light.unique_id == f"ABC123_light_{light_data_on_off['act_id']}"
+
     def test_unknown_type(self, auth_instance):
         unknown_light_data = {
             "act_id": 1,
@@ -1389,8 +1400,18 @@ class TestLight:
 
         light = Light(light_data, auth_instance)
 
-        with pytest.raises(ValueError):
-            status = light.status  # noqa: F841
+        assert light.status == LightStatus.UNKNOWN
+
+    def test_invalid_act_id_type(self, auth_instance):
+        light_data = {
+            "act_id": "not_an_int",
+            "name": "Test Light",
+            "status": 1,
+            "type": "STEP_STEP",
+        }
+
+        with pytest.raises(ValueError, match="Key 'act_id' expected int, got str"):
+            Light(light_data, auth_instance)
 
     def test_auth_type_validation(self):
         light_data = {
@@ -1454,6 +1475,23 @@ class TestOpening:
     def test_type_enum(self):
         assert OpeningType.SHUTTER.value == 0
         assert OpeningType.UNKNOWN.value == -1
+
+    def test_unique_id_without_server_info(
+        self, opening_data_shutter_stopped, auth_instance
+    ):
+        opening = Opening(opening_data_shutter_stopped, auth_instance)
+        assert opening.unique_id is None
+
+    def test_unique_id_with_server_info(
+        self, opening_data_shutter_stopped, auth_instance
+    ):
+        opening = Opening(opening_data_shutter_stopped, auth_instance)
+        opening.server_info = ServerInfo(
+            keycode="ABC123", serial="SN001", features=["openings"]
+        )
+        assert opening.unique_id == (
+            f"ABC123_opening_{opening_data_shutter_stopped['open_act_id']}"
+        )
 
     def test_unknown_type(self, auth_instance):
         unknown_opening_data = {
@@ -1796,6 +1834,17 @@ class TestScenario:
         with pytest.raises(ValueError):
             Scenario({"id": 1}, auth_instance)
 
+    def test_unique_id_without_server_info(self, scenario_data_off, auth_instance):
+        scenario = Scenario(scenario_data_off, auth_instance)
+        assert scenario.unique_id is None
+
+    def test_unique_id_with_server_info(self, scenario_data_off, auth_instance):
+        scenario = Scenario(scenario_data_off, auth_instance)
+        scenario.server_info = ServerInfo(
+            keycode="ABC123", serial="SN001", features=["scenarios"]
+        )
+        assert scenario.unique_id == f"ABC123_scenario_{scenario_data_off['id']}"
+
     def test_properties(self, scenario_data_on, auth_instance):
         scenario = Scenario(scenario_data_on, auth_instance)
         assert scenario.id == scenario_data_on["id"]
@@ -1908,6 +1957,24 @@ class TestThermoZone:
         zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
         assert zone.raw_data == thermo_zone_data_winter_auto
         assert zone.auth == auth_instance
+
+    def test_unique_id_without_server_info(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        assert zone.unique_id is None
+
+    def test_unique_id_with_server_info(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        zone.server_info = ServerInfo(
+            keycode="ABC123", serial="SN001", features=["thermoregulation"]
+        )
+        assert (
+            zone.unique_id
+            == f"ABC123_thermo_zone_{thermo_zone_data_winter_auto['act_id']}"
+        )
 
     def test_properties_winter_auto(self, thermo_zone_data_winter_auto, auth_instance):
         zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
@@ -2036,6 +2103,20 @@ class TestAnalogSensor:
         assert sensor.name == "Indoor Humidity"
         assert sensor.value == 55.0
         assert sensor.unit == "%"
+
+    def test_unique_id_without_server_info(self, analog_sensor_data_temperature):
+        sensor = AnalogSensor(analog_sensor_data_temperature)
+        assert sensor.unique_id is None
+
+    def test_unique_id_with_server_info(self, analog_sensor_data_temperature):
+        sensor = AnalogSensor(analog_sensor_data_temperature)
+        sensor.server_info = ServerInfo(
+            keycode="ABC123", serial="SN001", features=["thermoregulation"]
+        )
+        assert (
+            sensor.unique_id
+            == f"ABC123_analog_sensor_{analog_sensor_data_temperature['act_id']}"
+        )
 
     def test_missing_name(self):
         sensor_data = {"act_id": 100, "value": 215}


### PR DESCRIPTION
## Summary

- **Entity unique IDs**: All device entities (`Light`, `Opening`, `ThermoZone`, `Scenario`, `AnalogSensor`) now expose a stable `unique_id` property (`{keycode}_{type}_{device_id}`) for reliable HA entity identification. Server info is cached on `CameDomoticAPI` and automatically injected during entity list fetches.
- **`CameDomoticServerTimeoutError`**: New exported exception (subclass of `CameDomoticServerError`) for transient timeout failures, enabling callers to handle retryable errors separately from permanent ones.
- **Keep-alive clamping**: Server-reported keep-alive timeout is clamped to [30, 3600] seconds to guard against extreme values.
- **`EntityValidator` type checking**: `validate_data` now accepts `typed_keys` to enforce field types in all device model constructors.
- **Logging**: Improved credential lifecycle and session expiry log messages.
- **Tests**: 20 new tests covering session recovery, keep-alive clamping, timeout errors, malformed API responses, and `unique_id` on all entity types (99.16% coverage).
- **Docs**: Updated `usage_examples.rst` with `CameDomoticServerTimeoutError`, `unique_id` section, analog sensors in plant-update re-fetch; fixed 10 pre-existing Sphinx build warnings.

## Test plan

- [x] `pytest --cov=aiocamedomotic` — 331 passed, 13 skipped, 99.16% coverage
- [x] `mypy aiocamedomotic` — no issues
- [x] `pylint aiocamedomotic tests` — 9.66/10 (pre-existing warnings only)
- [x] `black .` — clean
- [x] `sphinx-build -E docs/source docs/build/html` — 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CameDomoticServerTimeoutError` for better handling of server timeout errors.
  * Introduced unique device identifiers for consistent entity tracking across sessions.
  * Server info caching to reduce redundant API calls.

* **Bug Fixes**
  * Implemented keep-alive timeout bounds to prevent session stability issues.
  * Improved graceful handling of unknown device status values.

* **Documentation**
  * Updated usage examples with timeout error handling and device identifier patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->