### PR TITLE
actions: auto-merge LLM docs PR after creation

### DIFF
--- a/.github/workflows/build-llms-docs.yml
+++ b/.github/workflows/build-llms-docs.yml
@@ -72,7 +72,7 @@ jobs:
           git add llms.txt llms-full.txt
           git commit -m "docs: update llms.txt and llms-full.txt"
           git push origin "$BRANCH_NAME"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "docs: update LLM documentation files" \
             --body "$(cat <<'EOF'
           Automated update of `llms.txt` and `llms-full.txt` triggered by changes
@@ -83,6 +83,7 @@ jobs:
           EOF
           )" \
             --base main \
-            --head "$BRANCH_NAME"
+            --head "$BRANCH_NAME")
+          gh pr merge "$PR_URL" --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -45,6 +45,11 @@ and controlling devices, and monitoring real-time changes. For a minimal
             CameDomoticServerError,
         )
 
+        async with await CameDomoticAPI.async_create(
+            "192.168.x.x", "username", "password"
+        ) as api:
+            ...
+
 
 Connecting to the server
 ------------------------


### PR DESCRIPTION
## Summary

- Enables auto-merge on the PR created by the `build-llms-docs` workflow
- Once all required status checks pass, the PR is squash-merged automatically with no manual intervention needed

## Test plan

- [ ] Trigger the `Build LLM documentation` workflow manually via `workflow_dispatch`
- [ ] Verify a PR is created and auto-merge is enabled on it
- [ ] Verify the PR is merged automatically once checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the documentation build workflow to automatically merge pull requests after creation, reducing manual steps in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->