### PR TITLE
actions: use PAT to trigger required checks on auto-created PRs

### DIFF
--- a/.github/workflows/build-llms-docs.yml
+++ b/.github/workflows/build-llms-docs.yml
@@ -86,4 +86,4 @@ jobs:
             --head "$BRANCH_NAME")
           gh pr merge "$PR_URL" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
+          token: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -231,7 +232,7 @@ jobs:
       - name: Generate release notes from previous tag
         id: release_notes
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}
         run: |
           CURRENT_TAG="${{ needs.build.outputs.version }}"
           # Find the previous version tag (excluding current)


### PR DESCRIPTION
Use `WORKFLOW_MERGE_PR_PAT` instead of `GITHUB_TOKEN` when pushing branches and creating PRs from workflows, so that the `pull_request` event is fired and required status checks are triggered automatically.

Affected workflows:
- `build-publish.yml`: checkout and PR creation/merge steps
- `build-llms-docs.yml`: PR creation/merge step