### PR TITLE
docs: clarify close_websession_on_disposal behavior and session ownership

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -467,10 +467,22 @@ class CameDomoticAPI:
             password (str): The password to use for the API.
             websession (aiohttp.ClientSession, optional): The aiohttp session to use for
                 the API. If not provided, a new aiohttp.ClientSession will be created.
-            close_websession_on_disposal (bool, default False): If True, the aiohttp
-                session will be closed when the CameDomoticAPI object is disposed. If
-                the websession is not provided, this argument is ignored and the session
-                will always be closed.
+            close_websession_on_disposal (bool, default False): Controls whether the
+                aiohttp session is closed when this object is disposed.
+
+                - ``False`` (default): the session is **preserved** on disposal. Use
+                  this when the caller owns the session and reuses it elsewhere — which
+                  is the typical case in Home Assistant and other frameworks that
+                  maintain a single long-lived ``aiohttp.ClientSession`` shared across
+                  multiple integrations. Closing it here would break every other
+                  component that relies on it.
+                - ``True``: the session is closed on disposal. Use this only when you
+                  explicitly want this object to take ownership of the provided session
+                  and close it when done.
+
+                .. note::
+                    When no ``websession`` is provided, this argument is ignored: the
+                    internally created session is always closed on disposal.
             command_timeout (int, optional): the default timeout in seconds
                 for all commands sent to the server (default: 30s).
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -91,8 +91,26 @@ pass it via the ``websession`` parameter:
     async with await CameDomoticAPI.async_create(
         "192.168.x.x", "username", "password",
         websession=my_existing_session,
+        close_websession_on_disposal=False,
     ) as api:
         ...
+
+.. important:: **Session ownership — read this carefully if you pass a** ``websession``.
+
+    The ``close_websession_on_disposal`` parameter controls whether the HTTP session is
+    closed when the ``CameDomoticAPI`` object is disposed (i.e. on exit from the
+    ``async with`` block).
+
+    - ``False`` **(default — use this when passing a shared session)**: the session is
+      preserved on disposal. This is almost always what you want in Home Assistant and
+      similar frameworks, where a single long-lived ``aiohttp.ClientSession`` is shared
+      across many integrations. Closing it here would silently break every other
+      component that depends on it.
+    - ``True``: the session is closed on disposal. Only use this if you explicitly
+      want this object to take ownership of the provided session.
+
+    When **no** ``websession`` is provided, this flag is irrelevant: the internally
+    created session is always closed on disposal.
 
 Handling connection errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- Expanded the `close_websession_on_disposal` docstring in `CameDomoticAPI.async_create()` to clearly explain the `False`/`True` semantics, with an explicit callout for Home Assistant integrations where destroying a shared session would break other components.
- Added `close_websession_on_disposal=False` explicitly to all `async_create` code snippets in the usage examples, so readers always see the parameter and are prompted to think about session ownership.
- Added a prominent `.. important::` warning block in the "Using an existing HTTP session" section of `usage_examples.rst` detailing the pitfall and correct usage.

## Test plan

- [x] All existing tests pass (`pytest`)
- [x] Documentation builds without errors (`sphinx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded parameter documentation to clarify session lifecycle management behavior.
  * Added detailed guidance on when to preserve vs. close HTTP sessions when using the library.
  * Included new section in usage examples explaining session ownership and disposal behavior.
  * Clarified that internally created sessions are always cleaned up on disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->