### PR TITLE
fix: change Auth.close_websession_on_disposal default to False

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -143,7 +143,7 @@ class Auth:
         username: str,
         password: str,
         *,
-        close_websession_on_disposal: bool = True,
+        close_websession_on_disposal: bool = False,
         command_timeout: int = _DEFAULT_COMMAND_TIMEOUT,
     ) -> Auth:
         """Create an Auth instance.
@@ -154,7 +154,7 @@ class Auth:
             username (str): the username to use for the authentication.
             password (str): the password to use for the authentication.
             close_websession_on_disposal (bool, optional): whether to close the
-                websession when disposing the Auth instance (default: True).
+                websession when disposing the Auth instance (default: False).
             command_timeout (int, optional): the default timeout in seconds
                 for commands sent to the server (default: 30s).
 
@@ -207,7 +207,7 @@ class Auth:
         username: str,
         password: str,
         *,
-        close_websession_on_disposal: bool = True,
+        close_websession_on_disposal: bool = False,
     ) -> None:
         """Initialize the Auth instance.
 
@@ -216,8 +216,8 @@ class Auth:
             host (str): the host of the CAME Domotic server.
             username (str): the username to use for the authentication.
             password (str): the password to use for the authentication.
-            close_websession_on_disposal (bool, optional, default True): whether to
-                close the websession when disposing the Auth instance (default: True).
+            close_websession_on_disposal (bool, optional, default False): whether to
+                close the websession when disposing the Auth instance (default: False).
 
         Note:
             The session is not logged in until the first request is made.

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -138,7 +138,7 @@ class TestAuthInit:
         assert auth.client_id == ""
         assert auth.keep_alive_timeout_sec == 0
         assert auth.cseq == 0
-        assert auth.close_websession_on_disposal is True
+        assert auth.close_websession_on_disposal is False
         assert isinstance(auth._lock, asyncio.Lock)  # pylint: disable=protected-access
         assert isinstance(auth.cipher_suite, Fernet)
 
@@ -1041,6 +1041,7 @@ class TestAuthDispose:
     async def test_valid_session_successful_logout(
         self, mock_logout, mock_is_session_valid, mock_close, auth_instance
     ):
+        auth_instance.close_websession_on_disposal = True
         await auth_instance.async_dispose()
         mock_is_session_valid.assert_called_once()
         mock_logout.assert_called_once()
@@ -1054,6 +1055,7 @@ class TestAuthDispose:
     async def test_valid_session_unsuccessful_logout(
         self, mock_logout, mock_is_session_valid, mock_close, auth_instance
     ):
+        auth_instance.close_websession_on_disposal = True
         await auth_instance.async_dispose()
         mock_is_session_valid.assert_called_once()
         mock_logout.assert_called_once()
@@ -1065,6 +1067,7 @@ class TestAuthDispose:
     async def test_invalid_session(
         self, mock_logout, mock_is_session_valid, mock_close, auth_instance
     ):
+        auth_instance.close_websession_on_disposal = True
         await auth_instance.async_dispose()
         mock_is_session_valid.assert_called_once()
         mock_logout.assert_not_called()


### PR DESCRIPTION
## Summary
- Changes `Auth.__init__` and `Auth.async_create` default for `close_websession_on_disposal` from `True` to `False`
- Aligns `Auth` with `CameDomoticAPI.async_create` (already defaulted to `False`) and the general contract that an externally-provided session is owned by the caller
- Updates the three `TestAuthDispose` tests to explicitly set `close_websession_on_disposal = True` when testing the "session gets closed" code path

## Test plan
- [ ] `pytest tests/aiocamedomotic/test_auth.py -v` — all pass
- [ ] `pytest tests/aiocamedomotic/test_came_domotic_api.py -v` — all pass
- [ ] Full suite: `pytest --cov=aiocamedomotic --cov-report=term-missing`