### PR TITLE
docs: update LLM documentation files

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2733,7 +2733,7 @@ In case of special needs, consider requesting the implementation of the desired
 feature in the CAME Domotic Unofficial library, or forking the library and implement
 the feature yourself.
 
-#### *class* aiocamedomotic.auth.Auth(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = True)
+#### *class* aiocamedomotic.auth.Auth(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = False)
 
 Class to make authenticated requests to the CAME Domotic API server.
 
@@ -2742,7 +2742,7 @@ This class is not meant to be used directly, but through the `CameDomoticAPI`
 class. To create an instance of this class, use the factory method
 `async_create`.
 
-##### *async classmethod* async_create(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = True, command_timeout: int = 30) → [Auth](#aiocamedomotic.auth.Auth)
+##### *async classmethod* async_create(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = False, command_timeout: int = 30) → [Auth](#aiocamedomotic.auth.Auth)
 
 Create an Auth instance.
 
@@ -2752,7 +2752,7 @@ Create an Auth instance.
   * **username** (*str*) – the username to use for the authentication.
   * **password** (*str*) – the password to use for the authentication.
   * **close_websession_on_disposal** (*bool* *,* *optional*) – whether to close the
-    websession when disposing the Auth instance (default: True).
+    websession when disposing the Auth instance (default: False).
   * **command_timeout** (*int* *,* *optional*) – the default timeout in seconds
     for commands sent to the server (default: 30s).
 * **Raises:**


### PR DESCRIPTION
Automated update of `llms.txt` and `llms-full.txt` triggered by changes
to source code or documentation.

These files are auto-generated by `scripts/build_llms_docs.py` from the
Sphinx documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `close_websession_on_disposal` parameter now defaults to `False` instead of `True`. Websessions will no longer be automatically closed on disposal unless explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->