### PR TITLE
refactor: remove unique_id and server_info coupling

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -61,20 +61,9 @@ class CameDomoticAPI:
         """
         self.auth = auth
         self.auth.command_timeout = command_timeout
-        self._server_info_cache: ServerInfo | None = None
         LOGGER.debug(
             "CameDomoticAPI initialized (command_timeout=%ds)", command_timeout
         )
-
-    @property
-    def server_info(self) -> ServerInfo | None:
-        """Cached server information, or ``None`` if not yet fetched.
-
-        This property makes no API call. Call :meth:`async_get_server_info` to
-        populate it. All ``async_get_*()`` device list methods populate it
-        automatically before returning entities.
-        """
-        return self._server_info_cache
 
     async def __aenter__(self) -> CameDomoticAPI:
         return self
@@ -123,9 +112,6 @@ class CameDomoticAPI:
         Provides info about the server (keycode, software version, etc.) and the list of
         features supported by the CAME Domotic server.
 
-        If ``server_info`` is already cached, returns it immediately without making an
-        API call.
-
         Returns:
             ServerInfo: Server information.
 
@@ -133,9 +119,6 @@ class CameDomoticAPI:
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
         """
-
-        if self._server_info_cache is not None:
-            return self._server_info_cache
 
         LOGGER.debug("Fetching server info")
         payload = {
@@ -152,7 +135,7 @@ class CameDomoticAPI:
             json_response.get("swver"),
             json_response.get("list"),
         )
-        server_info = ServerInfo(
+        return ServerInfo(
             keycode=json_response.get("keycode"),  # type: ignore[arg-type]
             swver=json_response.get("swver"),
             type=json_response.get("type"),
@@ -160,9 +143,6 @@ class CameDomoticAPI:
             serial=json_response.get("serial"),  # type: ignore[arg-type]
             features=json_response.get("list"),  # type: ignore[arg-type]
         )
-        self._server_info_cache = server_info
-        LOGGER.debug("Server info cached for host '%s'", self.auth.host)
-        return server_info
 
     async def async_get_floors(self) -> list[Floor]:
         """Get the list of all the floors defined on the server.
@@ -228,13 +208,6 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching lights list")
-        try:
-            await self.async_get_server_info()
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.warning(
-                "Could not fetch server info for lights; unique_id unavailable"
-            )
-
         payload = {
             "cmd_name": _CommandName.LIGHT_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -246,13 +219,8 @@ class CameDomoticAPI:
 
         # Defaults to an empty list if the key is missing from the response JSON
         lights_list = json_response.get("array", []) or []
-        lights = []
-        for light_data in lights_list:
-            light = Light(light_data, self.auth)
-            light.server_info = self.server_info
-            lights.append(light)
-        LOGGER.info("Retrieved %d light(s)", len(lights))
-        return lights
+        LOGGER.info("Retrieved %d light(s)", len(lights_list))
+        return [Light(light_data, self.auth) for light_data in lights_list]
 
     async def async_get_thermo_zones(self) -> list[ThermoZone]:
         """Get the list of all thermoregulation zones defined on the server.
@@ -266,14 +234,6 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching thermoregulation zones")
-        try:
-            await self.async_get_server_info()
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.warning(
-                "Could not fetch server info for thermo zones; "
-                "unique_id will not be available"
-            )
-
         payload = {
             "cmd_name": _CommandName.THERMO_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -285,13 +245,8 @@ class CameDomoticAPI:
 
         # Defaults to an empty list if the key is missing from the response JSON
         zones_list = json_response.get("array", []) or []
-        zones = []
-        for zone_data in zones_list:
-            zone = ThermoZone(zone_data, self.auth)
-            zone.server_info = self.server_info
-            zones.append(zone)
-        LOGGER.info("Retrieved %d thermo zone(s)", len(zones))
-        return zones
+        LOGGER.info("Retrieved %d thermo zone(s)", len(zones_list))
+        return [ThermoZone(zone_data, self.auth) for zone_data in zones_list]
 
     async def async_get_analog_sensors(self) -> list[AnalogSensor]:
         """Get analog sensor readings from the thermoregulation system.
@@ -308,14 +263,6 @@ class CameDomoticAPI:
         """
 
         LOGGER.debug("Fetching analog sensors")
-        try:
-            await self.async_get_server_info()
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.warning(
-                "Could not fetch server info for analog sensors; "
-                "unique_id will not be available"
-            )
-
         payload = {
             "cmd_name": _CommandName.THERMO_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -329,9 +276,7 @@ class CameDomoticAPI:
         for key in ("temperature", "humidity", "pressure"):
             sensor_data = json_response.get(key)
             if sensor_data and isinstance(sensor_data, dict):
-                sensor = AnalogSensor(sensor_data)
-                sensor.server_info = self.server_info
-                sensors.append(sensor)
+                sensors.append(AnalogSensor(sensor_data))
         LOGGER.info("Retrieved %d analog sensor(s)", len(sensors))
         return sensors
 
@@ -385,14 +330,6 @@ class CameDomoticAPI:
             CameDomoticServerError: If the server returns an error.
         """
         LOGGER.debug("Fetching openings list")
-        try:
-            await self.async_get_server_info()
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.warning(
-                "Could not fetch server info for openings; "
-                "unique_id will not be available"
-            )
-
         payload = {
             "cmd_name": _CommandName.OPENINGS_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
@@ -403,13 +340,8 @@ class CameDomoticAPI:
         )
 
         openings_data = json_response.get("array", []) or []
-        openings = []
-        for opening_data in openings_data:
-            opening = Opening(opening_data, self.auth)
-            opening.server_info = self.server_info
-            openings.append(opening)
-        LOGGER.info("Retrieved %d opening(s)", len(openings))
-        return openings
+        LOGGER.info("Retrieved %d opening(s)", len(openings_data))
+        return [Opening(opening_data, self.auth) for opening_data in openings_data]
 
     async def async_get_scenarios(self) -> list[Scenario]:
         """Get the list of all scenarios defined on the server.
@@ -422,14 +354,6 @@ class CameDomoticAPI:
             CameDomoticServerError: If the server returns an error.
         """
         LOGGER.debug("Fetching scenarios list")
-        try:
-            await self.async_get_server_info()
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.warning(
-                "Could not fetch server info for scenarios; "
-                "unique_id will not be available"
-            )
-
         payload = {
             "cmd_name": _CommandName.SCENARIOS_LIST.value,
         }
@@ -440,13 +364,8 @@ class CameDomoticAPI:
 
         # Defaults to an empty list if the key is missing from the response JSON
         scenarios_list = json_response.get("array", []) or []
-        scenarios = []
-        for scenario_data in scenarios_list:
-            scenario = Scenario(scenario_data, self.auth)
-            scenario.server_info = self.server_info
-            scenarios.append(scenario)
-        LOGGER.info("Retrieved %d scenario(s)", len(scenarios))
-        return scenarios
+        LOGGER.info("Retrieved %d scenario(s)", len(scenarios_list))
+        return [Scenario(scenario_data, self.auth) for scenario_data in scenarios_list]
 
     @classmethod
     async def async_create(

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -36,17 +36,6 @@ from ..utils import (
 class CameEntity:
     """Base class for all the CAME entities."""
 
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this entity, suitable for use as a
-        Home Assistant entity unique ID. Returns ``None`` if ``server_info``
-        has not been set (e.g. if ``async_get_server_info()`` was never called
-        or failed). When using this library via ``CameDomoticAPI``,
-        ``server_info`` is automatically populated by all ``async_get_*()``
-        device list methods.
-        """
-        return None
-
 
 @dataclass
 class User(CameEntity):

--- a/aiocamedomotic/models/light.py
+++ b/aiocamedomotic/models/light.py
@@ -34,7 +34,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity, ServerInfo
+from .base import CameEntity
 
 
 class LightStatus(Enum):
@@ -80,7 +80,6 @@ class Light(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
-    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
@@ -93,13 +92,6 @@ class Light(CameEntity):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
-
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this light entity."""
-        if self.server_info is None:
-            return None
-        return f"{self.server_info.keycode}_light_{self.act_id}"
 
     @property
     def act_id(self) -> int:

--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -33,7 +33,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity, ServerInfo
+from .base import CameEntity
 
 
 class OpeningStatus(Enum):
@@ -85,7 +85,6 @@ class Opening(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
-    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
@@ -98,13 +97,6 @@ class Opening(CameEntity):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
-
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this opening entity."""
-        if self.server_info is None:
-            return None
-        return f"{self.server_info.keycode}_opening_{self.open_act_id}"
 
     @property
     def name(self) -> str:

--- a/aiocamedomotic/models/scenario.py
+++ b/aiocamedomotic/models/scenario.py
@@ -33,7 +33,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity, ServerInfo
+from .base import CameEntity
 
 
 class ScenarioStatus(Enum):
@@ -66,7 +66,6 @@ class Scenario(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
-    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
@@ -79,13 +78,6 @@ class Scenario(CameEntity):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
-
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this scenario entity."""
-        if self.server_info is None:
-            return None
-        return f"{self.server_info.keycode}_scenario_{self.id}"
 
     @property
     def id(self) -> int:

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -32,7 +32,7 @@ from ..utils import (
     LOGGER,
     EntityValidator,
 )
-from .base import CameEntity, ServerInfo
+from .base import CameEntity
 
 
 class ThermoZoneStatus(Enum):
@@ -99,7 +99,6 @@ class ThermoZone(CameEntity):
 
     raw_data: dict[str, Any]
     auth: Auth
-    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
@@ -111,13 +110,6 @@ class ThermoZone(CameEntity):
             raise ValueError(
                 f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
             )
-
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this thermoregulation zone entity."""
-        if self.server_info is None:
-            return None
-        return f"{self.server_info.keycode}_thermo_zone_{self.act_id}"
 
     @property
     def act_id(self) -> int:
@@ -240,7 +232,6 @@ class AnalogSensor(CameEntity):
     """
 
     raw_data: dict[str, Any]
-    server_info: ServerInfo | None = None
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(
@@ -248,13 +239,6 @@ class AnalogSensor(CameEntity):
             required_keys=["name", "act_id"],
             typed_keys={"act_id": int},
         )
-
-    @property
-    def unique_id(self) -> str | None:
-        """Stable unique identifier for this analog sensor entity."""
-        if self.server_info is None:
-            return None
-        return f"{self.server_info.keycode}_analog_sensor_{self.act_id}"
 
     @property
     def act_id(self) -> int:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -1143,17 +1143,6 @@ class TestLight:
         assert light.type == LightType(light_data_dimmable["type"])
         assert light.perc == light_data_dimmable["perc"]
 
-    def test_unique_id_without_server_info(self, light_data_on_off, auth_instance):
-        light = Light(light_data_on_off, auth_instance)
-        assert light.unique_id is None
-
-    def test_unique_id_with_server_info(self, light_data_on_off, auth_instance):
-        light = Light(light_data_on_off, auth_instance)
-        light.server_info = ServerInfo(
-            keycode="ABC123", serial="SN001", features=["lights"]
-        )
-        assert light.unique_id == f"ABC123_light_{light_data_on_off['act_id']}"
-
     def test_unknown_type(self, auth_instance):
         unknown_light_data = {
             "act_id": 1,
@@ -1475,23 +1464,6 @@ class TestOpening:
     def test_type_enum(self):
         assert OpeningType.SHUTTER.value == 0
         assert OpeningType.UNKNOWN.value == -1
-
-    def test_unique_id_without_server_info(
-        self, opening_data_shutter_stopped, auth_instance
-    ):
-        opening = Opening(opening_data_shutter_stopped, auth_instance)
-        assert opening.unique_id is None
-
-    def test_unique_id_with_server_info(
-        self, opening_data_shutter_stopped, auth_instance
-    ):
-        opening = Opening(opening_data_shutter_stopped, auth_instance)
-        opening.server_info = ServerInfo(
-            keycode="ABC123", serial="SN001", features=["openings"]
-        )
-        assert opening.unique_id == (
-            f"ABC123_opening_{opening_data_shutter_stopped['open_act_id']}"
-        )
 
     def test_unknown_type(self, auth_instance):
         unknown_opening_data = {
@@ -1834,17 +1806,6 @@ class TestScenario:
         with pytest.raises(ValueError):
             Scenario({"id": 1}, auth_instance)
 
-    def test_unique_id_without_server_info(self, scenario_data_off, auth_instance):
-        scenario = Scenario(scenario_data_off, auth_instance)
-        assert scenario.unique_id is None
-
-    def test_unique_id_with_server_info(self, scenario_data_off, auth_instance):
-        scenario = Scenario(scenario_data_off, auth_instance)
-        scenario.server_info = ServerInfo(
-            keycode="ABC123", serial="SN001", features=["scenarios"]
-        )
-        assert scenario.unique_id == f"ABC123_scenario_{scenario_data_off['id']}"
-
     def test_properties(self, scenario_data_on, auth_instance):
         scenario = Scenario(scenario_data_on, auth_instance)
         assert scenario.id == scenario_data_on["id"]
@@ -1957,24 +1918,6 @@ class TestThermoZone:
         zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
         assert zone.raw_data == thermo_zone_data_winter_auto
         assert zone.auth == auth_instance
-
-    def test_unique_id_without_server_info(
-        self, thermo_zone_data_winter_auto, auth_instance
-    ):
-        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
-        assert zone.unique_id is None
-
-    def test_unique_id_with_server_info(
-        self, thermo_zone_data_winter_auto, auth_instance
-    ):
-        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
-        zone.server_info = ServerInfo(
-            keycode="ABC123", serial="SN001", features=["thermoregulation"]
-        )
-        assert (
-            zone.unique_id
-            == f"ABC123_thermo_zone_{thermo_zone_data_winter_auto['act_id']}"
-        )
 
     def test_properties_winter_auto(self, thermo_zone_data_winter_auto, auth_instance):
         zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
@@ -2103,20 +2046,6 @@ class TestAnalogSensor:
         assert sensor.name == "Indoor Humidity"
         assert sensor.value == 55.0
         assert sensor.unit == "%"
-
-    def test_unique_id_without_server_info(self, analog_sensor_data_temperature):
-        sensor = AnalogSensor(analog_sensor_data_temperature)
-        assert sensor.unique_id is None
-
-    def test_unique_id_with_server_info(self, analog_sensor_data_temperature):
-        sensor = AnalogSensor(analog_sensor_data_temperature)
-        sensor.server_info = ServerInfo(
-            keycode="ABC123", serial="SN001", features=["thermoregulation"]
-        )
-        assert (
-            sensor.unique_id
-            == f"ABC123_analog_sensor_{analog_sensor_data_temperature['act_id']}"
-        )
 
     def test_missing_name(self):
         sensor_data = {"act_id": 100, "value": 215}


### PR DESCRIPTION
## Summary
- Remove `unique_id` property from `CameEntity` base class and all entity models (Light, Opening, Scenario, ThermoZone, AnalogSensor)
- Remove `server_info` field from all entity dataclasses
- Remove `async_get_server_info()` calls and `server_info` caching from all `async_get_<entity>()` methods in `CameDomoticAPI`, making them truly independent API wrappers
- Simplify entity construction to list comprehensions
- Remove 10 related unit tests

## Test plan
- [x] All 321 tests pass
- [x] mypy clean
- [x] pylint clean
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized device initialization and API efficiency by streamlining how device data is processed from responses.
  * Removed unique identifier properties from devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->