### PR TITLE
fix: mask MAC address in test output to prevent clear-text logging

### DIFF
--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -427,10 +427,10 @@ async def test_autodiscovery(real_server_config):
     # Step 1: Check the MAC prefix
     mac_upper = mac_address.upper()
     mac_matches = any(mac_upper.startswith(prefix) for prefix in CAME_MAC_PREFIXES)
-    print(f"\nMAC address: {mac_address}")
+    print(f"\nMAC address: {mac_upper[:8]}:**:**:**")
     print(f"Matches CAME prefix: {mac_matches}")
     assert mac_matches, (
-        f"MAC address {mac_address} does not match any known CAME prefix "
+        f"MAC address {mac_upper[:8]}:**:**:** does not match any known CAME prefix "
         f"({', '.join(CAME_MAC_PREFIXES)})"
     )
 


### PR DESCRIPTION
## Summary
- Mask the device-specific portion of MAC addresses in test print output and assertion messages, showing only the vendor prefix (first 8 chars)
- Resolves CodeQL alert #8 (clear-text logging of sensitive information)

## Test plan
- [ ] Verify CodeQL alert #8 is resolved after merge
- [ ] Run `pytest tests/aiocamedomotic/test_real.py` against a real server to confirm output still shows useful prefix info