### PR TITLE
Update log formatter to HA-style output

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -41,10 +41,13 @@ except PackageNotFoundError:
 # region Logging
 
 # Configure the package logger
+
+
 _formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s - "
-    "%(module)s:%(lineno)d (%(funcName)s)"
+    fmt="%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
+_formatter.default_msec_format = "%s.%03d"
 _console_handler = logging.StreamHandler(sys.stdout)
 _console_handler.setFormatter(_formatter)
 LOGGER.addHandler(_console_handler)

--- a/tests/aiocamedomotic/test_init.py
+++ b/tests/aiocamedomotic/test_init.py
@@ -95,6 +95,10 @@ def test_logger_formatter():
     assert "%(name)s" in format_string
     assert "%(levelname)s" in format_string
     assert "%(message)s" in format_string
-    assert "%(module)s" in format_string
-    assert "%(lineno)d" in format_string
-    assert "%(funcName)s" in format_string
+
+    # Check date format includes milliseconds with dot separator
+    assert formatter.datefmt == "%Y-%m-%d %H:%M:%S"
+    assert formatter.default_msec_format == "%s.%03d"
+
+    # Check thread name is included in the format
+    assert "%(threadName)s" in format_string


### PR DESCRIPTION
## Summary
- Change log format to `YYYY-MM-DD HH:MM:SS.mmm LEVEL (ThreadName) [logger] message`
- Use dot-separated milliseconds instead of comma
- Include thread name in all log lines
- Update tests to match new format

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logging format to be thread-aware. The logger now displays timestamp, log level, thread name, logger name, and message instead of module and line number details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->