### PR TITLE
Delete update-version branch after PR merge

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -139,6 +139,11 @@ jobs:
           echo "::error::Timed out waiting for PR to be merged"
           exit 1
 
+      - name: Delete update-version branch
+        if: steps.create_pr.outcome == 'success'
+        run: |
+          git push origin --delete update-version || echo "Branch already deleted"
+
       - name: Checkout and push to main
         run: |
           git checkout main


### PR DESCRIPTION
## Summary
- Add explicit step to delete the `update-version` branch after the version bump PR is successfully merged
- Prevents the temporary branch from lingering on the remote

## Test plan
- [ ] Trigger the build-publish workflow and verify the `update-version` branch is deleted after merge