### PR TITLE
Add milliseconds to log formatter timestamp

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -45,7 +45,6 @@ except PackageNotFoundError:
 
 _formatter = logging.Formatter(
     fmt="%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
 )
 _formatter.default_msec_format = "%s.%03d"
 _console_handler = logging.StreamHandler(sys.stdout)

--- a/tests/aiocamedomotic/test_init.py
+++ b/tests/aiocamedomotic/test_init.py
@@ -97,7 +97,7 @@ def test_logger_formatter():
     assert "%(message)s" in format_string
 
     # Check date format includes milliseconds with dot separator
-    assert formatter.datefmt == "%Y-%m-%d %H:%M:%S"
+    assert formatter.datefmt is None
     assert formatter.default_msec_format == "%s.%03d"
 
     # Check thread name is included in the format


### PR DESCRIPTION
## Summary
- Remove custom `datefmt` so `default_msec_format` takes effect, producing timestamps with milliseconds (e.g., `2026-03-10 22:07:46.117`)
- Update test assertion to match the new `datefmt=None` configuration

## Test plan
- [x] `test_logger_formatter` passes with updated assertion
- [x] All 334 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration to use default date formatting instead of a custom format specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->