### PR TITLE
Add digital input (binary sensor) support

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -32,6 +32,7 @@ from .const import (
 )
 from .models import (
     AnalogSensor,
+    DigitalInput,
     Floor,
     Light,
     Opening,
@@ -318,6 +319,36 @@ class CameDomoticAPI:
             " (includes plant update)" if updates.has_plant_update else "",
         )
         return updates
+
+    async def async_get_digital_inputs(self) -> list[DigitalInput]:
+        """Get the list of all digital input devices defined on the server.
+
+        Digital inputs are read-only binary sensors (e.g. physical buttons,
+        contact sensors). They report their state but cannot be controlled.
+
+        Returns:
+            list[DigitalInput]: List of digital inputs.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching digital inputs list")
+        payload = {
+            "cmd_name": _CommandName.DIGITALIN_LIST.value,
+            "topologic_scope": _TopologicScope.PLANT.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.DIGITALIN_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        digitalin_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d digital input(s)", len(digitalin_list))
+        return [
+            DigitalInput(digitalin_data, self.auth) for digitalin_data in digitalin_list
+        ]
 
     async def async_get_openings(self) -> list[Opening]:
         """Get the list of all opening devices defined on the server.

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 
 from ..const import DeviceType, UpdateIndicator  # noqa: F401
 from .base import CameEntity, Floor, Room, ServerInfo, User  # noqa: F401
+from .digital_input import (  # noqa: F401
+    DigitalInput,
+    DigitalInputStatus,
+    DigitalInputType,
+)
 from .light import Light, LightStatus, LightType  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
@@ -49,6 +54,9 @@ __all__ = [
     "CameEntity",
     "DeviceType",
     "DeviceUpdate",
+    "DigitalInput",
+    "DigitalInputStatus",
+    "DigitalInputType",
     "DigitalInputUpdate",
     "Floor",
     "Light",
@@ -76,5 +84,3 @@ __all__ = [
     "get_update_device_type",
     "parse_update",
 ]
-
-# Digital inputs

--- a/aiocamedomotic/models/digital_input.py
+++ b/aiocamedomotic/models/digital_input.py
@@ -1,0 +1,158 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic digital input (binary sensor) entity models.
+
+This module implements the classes for working with digital inputs in a CAME
+Domotic system. Digital inputs represent read-only binary sensors such as
+physical buttons, contact sensors, and similar devices. They provide properties
+to access device attributes but do not support control commands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ..auth import Auth
+from ..utils import (
+    LOGGER,
+    EntityValidator,
+)
+from .base import CameEntity
+
+
+class DigitalInputStatus(Enum):
+    """Status of a digital input.
+
+    Allowed values are:
+        - ACTIVE (0): the input is active (e.g. a button is pressed)
+        - IDLE (1): the input is idle (e.g. a button is not pressed)
+    """
+
+    ACTIVE = 0
+    IDLE = 1
+    UNKNOWN = -1
+
+
+class DigitalInputType(Enum):
+    """Type of a digital input.
+
+    Allowed values are:
+        - STATUS (1): standard status input
+    """
+
+    STATUS = 1
+    UNKNOWN = -1
+
+
+@dataclass
+class DigitalInput(CameEntity):
+    """
+    Digital input (binary sensor) entity in the CameDomotic API.
+
+    Digital inputs are read-only devices that report their binary state
+    (ACTIVE/IDLE). They cannot be controlled remotely.
+
+    Raises:
+        ValueError: If ``name`` or ``act_id`` keys are missing from the
+            input data or the auth argument is not an instance of the
+            expected ``Auth`` class.
+    """
+
+    raw_data: dict[str, Any]
+    auth: Auth
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def act_id(self) -> int:
+        """ID of the digital input."""
+        return self.raw_data["act_id"]
+
+    @property
+    def name(self) -> str:
+        """Name of the digital input."""
+        return self.raw_data["name"]
+
+    @property
+    def status(self) -> DigitalInputStatus:
+        """Status of the digital input: ACTIVE (0) or IDLE (1).
+
+        ``ACTIVE`` means the input is triggered (e.g. a button is being
+        pressed). ``IDLE`` means the input is in its normal resting state.
+
+        Returns ``DigitalInputStatus.UNKNOWN`` when the status field is
+        absent from the server response (some digital inputs do not
+        report a status until their first state change).
+        """
+        try:
+            return DigitalInputStatus(self.raw_data["status"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown digital input status '%s' encountered for "
+                "digital input '%s' (ID: %s). "
+                "Returning DigitalInputStatus.UNKNOWN. Please report this "
+                "to the library developers.",
+                self.raw_data.get("status"),
+                self.name,
+                self.act_id,
+            )
+            return DigitalInputStatus.UNKNOWN
+
+    @property
+    def type(self) -> DigitalInputType:
+        """Type of the digital input.
+
+        Returns ``DigitalInputType.UNKNOWN`` when the type value is not
+        recognized.
+        """
+        try:
+            return DigitalInputType(self.raw_data["type"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown digital input type '%s' encountered for "
+                "digital input '%s' (ID: %s). "
+                "Returning DigitalInputType.UNKNOWN. Please report this "
+                "to the library developers.",
+                self.raw_data.get("type"),
+                self.name,
+                self.act_id,
+            )
+            return DigitalInputType.UNKNOWN
+
+    @property
+    def addr(self) -> int:
+        """Address of the digital input."""
+        return self.raw_data.get("addr", 0)
+
+    @property
+    def utc_time(self) -> int:
+        """UTC timestamp of the last event (Unix epoch seconds).
+
+        Returns ``0`` if the digital input has never been triggered.
+        """
+        return self.raw_data.get("utc_time", 0)

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -50,6 +50,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.thermo_zone
    :members:
 
+.. automodule:: aiocamedomotic.models.digital_input
+   :members:
+
 .. automodule:: aiocamedomotic.models.update
    :members:
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -31,11 +31,11 @@ and controlling devices, and monitoring real-time changes. For a minimal
 
         from aiocamedomotic import CameDomoticAPI
         from aiocamedomotic.models import (
-            DeviceType, LightStatus, LightType, OpeningStatus,
-            ScenarioStatus, ThermoZoneMode, ThermoZoneSeason,
-            ThermoZoneStatus, DeviceUpdate, LightUpdate,
-            OpeningUpdate, ThermoZoneUpdate, ScenarioUpdate,
-            DigitalInputUpdate, PlantUpdate,
+            DeviceType, DigitalInputStatus, LightStatus, LightType,
+            OpeningStatus, ScenarioStatus, ThermoZoneMode,
+            ThermoZoneSeason, ThermoZoneStatus, DeviceUpdate,
+            LightUpdate, OpeningUpdate, ThermoZoneUpdate,
+            ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
         )
         from aiocamedomotic.errors import (
             CameDomoticError,
@@ -223,6 +223,9 @@ You can use the features list to decide which device APIs to call:
     if "scenarios" in server_info.features:
         scenarios = await api.async_get_scenarios()
 
+    if "digitalin" in server_info.features:
+        digital_inputs = await api.async_get_digital_inputs()
+
 Floors and rooms
 ^^^^^^^^^^^^^^^^
 
@@ -406,6 +409,48 @@ Example output:
     Name: Indoor Humidity, Value: 55, Unit: %
     Name: Barometric Pressure, Value: 1013, Unit: hPa
 
+Digital inputs (binary sensors)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Digital inputs are read-only binary sensors such as physical buttons or
+contact sensors. They report their state (ACTIVE/IDLE) but cannot be
+controlled remotely. ``ACTIVE`` means the input is triggered (e.g. a button
+is being pressed); ``IDLE`` means the input is in its normal resting state.
+
+.. code-block:: python
+
+    from aiocamedomotic.models import DigitalInputStatus
+
+    digital_inputs = await api.async_get_digital_inputs()
+
+    for di in digital_inputs:
+        print(
+            f"ID: {di.act_id}, Name: {di.name}, "
+            f"Status: {di.status}, Address: {di.addr}"
+        )
+
+Example output:
+
+.. code-block:: text
+
+    ID: 0, Name: digitalin_PvGCT, Status: DigitalInputStatus.UNKNOWN, Address: 200
+    ID: 1, Name: digitalin_BuTbB, Status: DigitalInputStatus.IDLE, Address: 201
+
+**Finding a specific digital input:**
+
+.. code-block:: python
+
+    # By ID
+    button = next((di for di in digital_inputs if di.act_id == 1), None)
+
+    # By name
+    sensor = next((di for di in digital_inputs if di.name == "Front Door"), None)
+
+.. note::
+    Some digital inputs do not report a ``status`` until their first state
+    change. In that case, ``status`` returns ``DigitalInputStatus.UNKNOWN``.
+
+
 Monitoring real-time updates
 ----------------------------
 
@@ -534,6 +579,7 @@ happens, all locally cached device lists must be discarded and re-fetched:
         scenarios = await api.async_get_scenarios()
         thermo_zones = await api.async_get_thermo_zones()
         sensors = await api.async_get_analog_sensors()
+        digital_inputs = await api.async_get_digital_inputs()
 
 .. note::
     Plant updates are relatively rare. They typically occur when an installer

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -281,4 +281,35 @@ def analog_sensor_data_humidity():
     }
 
 
+@pytest.fixture
+def digital_input_data_with_status():
+    """Mock data for a digital input that reports a status."""
+    return {
+        "ack": 0,
+        "act_id": 1,
+        "addr": 201,
+        "name": "digitalin_BuTbB",
+        "radio_node_id": "00000000",
+        "rf_radio_link_quality": 0,
+        "status": 1,
+        "type": 1,
+        "utc_time": 1708366780,
+    }
+
+
+@pytest.fixture
+def digital_input_data_without_status():
+    """Mock data for a digital input that does not report a status."""
+    return {
+        "ack": 1,
+        "act_id": 0,
+        "addr": 200,
+        "name": "digitalin_PvGCT",
+        "radio_node_id": "00000000",
+        "rf_radio_link_quality": 0,
+        "type": 1,
+        "utc_time": 0,
+    }
+
+
 # endregion

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -29,6 +29,7 @@ from aiocamedomotic.errors import (
 )
 from aiocamedomotic.models import (
     AnalogSensor,
+    DigitalInput,
     Floor,
     Light,
     Opening,
@@ -40,6 +41,7 @@ from aiocamedomotic.models import (
     User,
 )
 from tests.aiocamedomotic.mocked_responses import (
+    DIGITALIN_LIST_RESP,
     FEATURE_LIST_RESP,
     LIGHT_LIST_RESP,
     SCENARIOS_LIST_RESP,
@@ -1152,3 +1154,103 @@ class TestAPIAnalogSensors:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_analog_sensors()
+
+
+class TestAPIDigitalInputs:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = DIGITALIN_LIST_RESP
+
+        digital_inputs = await api.async_get_digital_inputs()
+        assert len(digital_inputs) == len(DIGITALIN_LIST_RESP["array"])
+        assert isinstance(digital_inputs[0], DigitalInput)
+        assert isinstance(digital_inputs[1], DigitalInput)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "digitalin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        digital_inputs = await api.async_get_digital_inputs()
+        assert len(digital_inputs) == 0
+        assert isinstance(digital_inputs, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "digitalin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        digital_inputs = await api.async_get_digital_inputs()
+        assert len(digital_inputs) == 0
+        assert isinstance(digital_inputs, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs_null_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "digitalin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        digital_inputs = await api.async_get_digital_inputs()
+        assert digital_inputs == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs_missing_act_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "name": "digitalin_test",
+                    "type": 1,
+                    "addr": 200,
+                }
+            ],
+            "cmd_name": "digitalin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            await api.async_get_digital_inputs()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_digital_inputs_missing_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "act_id": 0,
+                    "type": 1,
+                    "addr": 200,
+                }
+            ],
+            "cmd_name": "digitalin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            await api.async_get_digital_inputs()

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -34,6 +34,9 @@ from aiocamedomotic.errors import CameDomoticAuthError
 from aiocamedomotic.models import (
     AnalogSensor,
     DeviceUpdate,
+    DigitalInput,
+    DigitalInputStatus,
+    DigitalInputType,
     DigitalInputUpdate,
     Floor,
     Light,
@@ -2064,3 +2067,61 @@ class TestAnalogSensor:
         assert sensor.act_id == 200
         assert sensor.value == 0.0
         assert sensor.unit == ""
+
+
+class TestDigitalInput:
+    def test_init_with_status(self, auth_instance, digital_input_data_with_status):
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+        assert di.act_id == 1
+        assert di.name == "digitalin_BuTbB"
+        assert di.status == DigitalInputStatus.IDLE
+        assert di.type == DigitalInputType.STATUS
+        assert di.addr == 201
+        assert di.utc_time == 1708366780
+
+    def test_init_without_status(
+        self, auth_instance, digital_input_data_without_status
+    ):
+        di = DigitalInput(digital_input_data_without_status, auth_instance)
+        assert di.act_id == 0
+        assert di.name == "digitalin_PvGCT"
+        assert di.status == DigitalInputStatus.UNKNOWN
+        assert di.addr == 200
+        assert di.utc_time == 0
+
+    def test_status_active(self, auth_instance, digital_input_data_with_status):
+        digital_input_data_with_status["status"] = 0
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+        assert di.status == DigitalInputStatus.ACTIVE
+
+    def test_unknown_status_value(self, auth_instance, digital_input_data_with_status):
+        digital_input_data_with_status["status"] = 99
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+        assert di.status == DigitalInputStatus.UNKNOWN
+
+    def test_unknown_type_value(self, auth_instance, digital_input_data_with_status):
+        digital_input_data_with_status["type"] = 99
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+        assert di.type == DigitalInputType.UNKNOWN
+
+    def test_missing_name_raises(self, auth_instance):
+        data = {"act_id": 0, "type": 1}
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            DigitalInput(data, auth_instance)
+
+    def test_missing_act_id_raises(self, auth_instance):
+        data = {"name": "test", "type": 1}
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            DigitalInput(data, auth_instance)
+
+    def test_invalid_auth_raises(self, digital_input_data_with_status):
+        with pytest.raises(ValueError, match="'auth' must be an instance of Auth"):
+            DigitalInput(digital_input_data_with_status, "not_an_auth")
+
+    def test_optional_fields_defaults(self, auth_instance):
+        data = {"act_id": 5, "name": "Minimal Input"}
+        di = DigitalInput(data, auth_instance)
+        assert di.addr == 0
+        assert di.utc_time == 0
+        assert di.status == DigitalInputStatus.UNKNOWN
+        assert di.type == DigitalInputType.UNKNOWN

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -271,6 +271,27 @@ async def test_async_get_analog_sensors(api_instance_real: CameDomoticAPI):
     assert sensors is not None, "Failed to get analog sensors"
 
 
+async def test_async_get_digital_inputs(api_instance_real: CameDomoticAPI):
+    """Tests fetching all digital inputs from the server."""
+    print("\nFetching all digital inputs...")
+    digital_inputs = await api_instance_real.async_get_digital_inputs()
+    if not digital_inputs:
+        print("No digital inputs found on the server.")
+        return
+
+    print(f"Found {len(digital_inputs)} digital input(s):")
+    for di in digital_inputs:
+        print(
+            f"  ID: {di.act_id}"
+            f" - Name: {di.name}"
+            f" - Status: {di.status.name}"
+            f" - Type: {di.type.name}"
+            f" - Address: {di.addr}"
+            f" - UTC time: {di.utc_time}"
+        )
+    assert digital_inputs is not None, "Failed to get digital inputs"
+
+
 async def test_async_dimmable_light(api_instance_real: CameDomoticAPI):
     light_name = "Led porta finestra sala"
     lights = await api_instance_real.async_get_lights()


### PR DESCRIPTION
## Summary
- Add `DigitalInput` model for read-only binary sensors (buttons, contact sensors) with ACTIVE/IDLE state tracking
- Add `async_get_digital_inputs()` API method to fetch digital inputs from the server
- Add comprehensive unit tests for model and API layer, including edge cases
- Update documentation with usage examples and API reference

## Test plan
- [x] All new unit tests pass (`TestDigitalInput`, `TestAPIDigitalInputs`)
- [x] All pre-commit hooks pass (ruff, mypy, bandit, etc.)
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added digital input (binary sensor) support to the API with a new method to fetch devices from the server.
  * Digital inputs now provide comprehensive status tracking and type information for monitoring real-time updates.

* **Documentation**
  * Updated API reference and usage examples to document digital input integration, retrieval patterns, and state monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->