### PR TITLE
Add auth security hardening and update roadmap for v1.5

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ reflects our commitment to making home automation more accessible and manageable
 This roadmap is subject to change based on community feedback and ongoing development
 insights. We look forward to growing this library together with our users and contributors.
 
-## Current Features (Version 1.4)
+## Current Features (Version 1.5)
 
 - **Session management**: Automated handling of login, logout, and keep-alive processes
   for the API, with automatic session recovery.
@@ -32,6 +32,9 @@ insights. We look forward to growing this library together with our users and co
 - **Thermoregulation (read-only)**: List thermoregulation zones with their current state,
   retrieve temperature, setpoint, mode, and season for each zone. Expose top-level analog
   sensor readings (temperature, humidity, pressure) from the thermo response.
+- **Digital inputs (read-only)**: List binary sensors (door contacts, motion sensors, etc.)
+  via `digitalin_list_req`. Each digital input exposes its current state and attributes.
+  Real-time updates are supported via `DigitalInputUpdate`.
 - **Real-time updates with typed classes**: Long-polling support with typed update objects
   (`LightUpdate`, `OpeningUpdate`, `ThermoZoneUpdate`, `ScenarioUpdate`,
   `DigitalInputUpdate`, `PlantUpdate`). `UpdateList` provides filtering by device type,
@@ -50,14 +53,14 @@ Domotic plant and can be tested against a real server. Features that are only kn
 reverse-engineered sources (without real traffic verification) are listed separately
 under [Future considerations](#future-considerations).
 
-### Version 1.5 — Energy meters
+### Version 1.6 — Energy meters
 
 - **Meter listing**: List all energy meters with their current readings.
 - **Instant power**: Expose real-time power consumption via `meter_instant_power_ind`.
 - **Energy statistics**: Query historical consumption data (`energy_stat_req`) for
   monitoring and dashboard integration.
 
-### Version 1.6 — Load control (read-only)
+### Version 1.7 — Load control (read-only)
 
 - **Load control meters**: List load control meters with their current state
   (`loadsctrl_meter_list_req`).
@@ -82,9 +85,6 @@ considered for future development once real-world testing is possible:
 
 - **Relays (generic switches)**: List and control generic relay actuators. The API is
   documented but no real traffic has been observed.
-- **Digital inputs**: List binary sensors (door contacts, motion sensors, etc.) via
-  `digitalin_list_req`. Update parsing is already implemented (`DigitalInputUpdate`),
-  but a device model class and list command are not yet available.
 - **User management**: Add, delete, and change passwords for users on the CAME server.
 - **Scenario management**: Create and delete scenarios (beyond the current list/activate).
 - **Audio system**: Sound zone and source management (entirely unverified).
@@ -93,7 +93,7 @@ considered for future development once real-world testing is possible:
 - **Maps**: Floor plan/map retrieval (entirely unverified).
 - **Status updates management**: Automatic long-polling loop with event callbacks,
   push-based state synchronization, and automatic `plant_update_ind` handling for full
-  cache invalidation. Typed update classes and filtering are already available (v1.4);
+  cache invalidation. Typed update classes and filtering are already available (v1.5);
   this item covers the higher-level automation layer on top.
 - **Infrastructure improvements**: Automated keep-alive scheduling, per-actuator scope
   queries, and connection resilience improvements.

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -119,6 +119,18 @@ def handle_came_domotic_errors(func: _F) -> _F:
 class Auth:
     """Class to make authenticated requests to the CAME Domotic API server.
 
+    Security features:
+
+    - **Credential protection** — username and password are encrypted in memory
+      using Fernet symmetric encryption with a runtime-generated key. Credentials
+      are explicitly cleared on disposal and as a safety net on garbage collection.
+    - **Response size limit** — server responses larger than
+      ``_MAX_RESPONSE_SIZE_BYTES`` (5 MB) are rejected to prevent memory
+      exhaustion from a compromised server.
+    - **Content-Type validation** — JSON responses are validated against the
+      expected ``application/json`` Content-Type, with a fallback to permissive
+      parsing for backward compatibility.
+
     Note:
         This class is not meant to be used directly, but through the ``CameDomoticAPI``
         class. To create an instance of this class, use the factory method
@@ -127,6 +139,13 @@ class Auth:
 
     # Default timeout "safe zone" for session expiration
     _DEFAULT_SAFE_ZONE_SEC: int = 30
+
+    # Maximum allowed response size in bytes (5 MB).
+    # This protects against memory exhaustion from a compromised or
+    # misbehaving server that could send an arbitrarily large response.
+    # Normal CAME API responses are small JSON payloads (a few KB at most),
+    # so 5 MB is an extremely generous upper bound.
+    _MAX_RESPONSE_SIZE_BYTES: int = 5 * 1024 * 1024
     _DEFAULT_HTTP_HEADERS: dict[str, str] = {
         "User-Agent": f"aiocamedomotic/{_LIBRARY_VERSION}",
         "Accept": "application/json, text/plain, */*",  # Desumed from pycame library
@@ -282,6 +301,35 @@ class Auth:
     ) -> None:
         await self.async_dispose()
 
+    def __del__(self) -> None:
+        """Best-effort cleanup of sensitive credentials on garbage collection.
+
+        This method is called by the Python garbage collector when the ``Auth``
+        instance has no remaining references. It nullifies any credentials that
+        were not already cleared by :meth:`async_dispose`.
+
+        .. note::
+            This is a **safety net**, not a substitute for calling
+            :meth:`async_dispose` or using the ``async with`` context manager.
+            Python does not guarantee that ``__del__`` will be called in all
+            scenarios (e.g., interpreter shutdown). Always prefer explicit
+            disposal via :meth:`async_dispose`.
+        """
+        # Use getattr() because __del__ can be called on partially-initialized
+        # instances (e.g., if __init__ raised an exception partway through).
+        if any(
+            getattr(self, attr, None) is not None
+            for attr in ("cipher_suite", "username", "password")
+        ):
+            LOGGER.debug(
+                "Auth.__del__: clearing credentials not cleaned up by "
+                "async_dispose (host=%s)",
+                getattr(self, "host", "<unknown>"),
+            )
+            self.cipher_suite = None
+            self.username = None
+            self.password = None
+
     # endregion
 
     def get_endpoint_url(self) -> str:
@@ -406,16 +454,8 @@ class Auth:
                 )
                 LOGGER.debug("Session refreshed, cseq=%d", self.cseq)
 
-            # Parse JSON response
-            try:
-                json_response = await response.json(content_type=None)
-            except json.JSONDecodeError as e:
-                LOGGER.error(
-                    "Failed to decode JSON response for command '%s'", cmd_name
-                )
-                raise CameDomoticServerError(
-                    "Error decoding the response to JSON"
-                ) from e
+            # Parse JSON response with size and content-type safeguards
+            json_response = await Auth._safe_read_json(response)
 
             resp_cmd_name = json_response.get("cmd_name")
             if response_command is not None and resp_cmd_name != response_command:
@@ -667,6 +707,63 @@ class Auth:
 
     # region Utilities
 
+    @staticmethod
+    async def _safe_read_json(response: aiohttp.ClientResponse) -> dict[str, Any]:
+        """Read and parse a JSON response with security safeguards.
+
+        This method applies two protections before parsing the response body:
+
+        1. **Response size limit** — the raw body is read incrementally and
+           rejected if it exceeds ``_MAX_RESPONSE_SIZE_BYTES`` (5 MB). This
+           prevents a compromised or misbehaving server from exhausting memory
+           with an arbitrarily large payload.
+
+        2. **Content-Type validation** — the response is first parsed expecting
+           ``application/json``. If the server sends a different Content-Type
+           header, parsing falls back to accepting any content type for
+           backward compatibility and a warning is logged.
+
+        Args:
+            response: The aiohttp response to read.
+
+        Returns:
+            The parsed JSON body as a dictionary.
+
+        Raises:
+            CameDomoticServerError: if the response exceeds the size limit or
+                if the body cannot be decoded as valid JSON.
+        """
+        # --- 1. Response size guard ---
+        raw_body = await response.content.read(Auth._MAX_RESPONSE_SIZE_BYTES + 1)
+        if len(raw_body) > Auth._MAX_RESPONSE_SIZE_BYTES:
+            LOGGER.warning(
+                "Response body exceeds the maximum allowed size of %d bytes, "
+                "rejecting response",
+                Auth._MAX_RESPONSE_SIZE_BYTES,
+            )
+            raise CameDomoticServerError(
+                f"Response body exceeds the maximum allowed size "
+                f"of {Auth._MAX_RESPONSE_SIZE_BYTES} bytes"
+            )
+        LOGGER.debug("Response body size: %d bytes", len(raw_body))
+
+        # --- 2. Content-Type validation with silent fallback ---
+        content_type = response.content_type
+        if content_type and content_type != "application/json":
+            LOGGER.warning(
+                "Unexpected Content-Type '%s' in server response "
+                "(expected 'application/json'), falling back to "
+                "permissive parsing",
+                content_type,
+            )
+
+        # --- 3. JSON parsing ---
+        try:
+            return json.loads(raw_body)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            LOGGER.error("Failed to decode response body as JSON")
+            raise CameDomoticServerError("Error decoding the response to JSON") from e
+
     def is_session_valid(self) -> bool:
         """Check whether the session is still valid or not."""
         # Notice that self.session_expiration_timestamp already include the safe zone
@@ -696,10 +793,7 @@ class Auth:
                 f"Exception raised for HTTP status: {response.status}"
             ) from e
 
-        try:
-            resp_json = await response.json(content_type=None)
-        except json.JSONDecodeError as e:
-            raise CameDomoticServerError("Error decoding the response to JSON") from e
+        resp_json = await Auth._safe_read_json(response)
 
         ack_reason = resp_json.get("sl_data_ack_reason")
 

--- a/aiocamedomotic/models/digital_input.py
+++ b/aiocamedomotic/models/digital_input.py
@@ -112,7 +112,7 @@ class DigitalInput(CameEntity):
         try:
             return DigitalInputStatus(self.raw_data["status"])
         except (ValueError, KeyError):
-            LOGGER.warning(
+            LOGGER.debug(
                 "Unknown digital input status '%s' encountered for "
                 "digital input '%s' (ID: %s). "
                 "Returning DigitalInputStatus.UNKNOWN. Please report this "

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -42,6 +42,25 @@ from aiocamedomotic.errors import (
 )
 
 
+def _set_mock_response_json(mock_response: AsyncMock, data: dict) -> None:
+    """Configure a mock aiohttp response to return JSON data via content.read().
+
+    This sets up the ``content.read`` attribute so that ``Auth._safe_read_json``
+    can read the response body as raw bytes and parse it as JSON.
+    """
+    raw = json.dumps(data).encode()
+    mock_response.content = AsyncMock()
+    mock_response.content.read = AsyncMock(return_value=raw)
+    mock_response.content_type = "application/json"
+
+
+def _set_mock_response_read_error(mock_response: AsyncMock) -> None:
+    """Configure a mock response so that JSON parsing fails (invalid body)."""
+    mock_response.content = AsyncMock()
+    mock_response.content.read = AsyncMock(return_value=b"not valid json")
+    mock_response.content_type = "application/json"
+
+
 class TestHandleCameDomoticErrorsDecorator:
     """Tests for the handle_came_domotic_errors decorator."""
 
@@ -249,10 +268,11 @@ class TestAuthSendCommand:
 
     @freezegun.freeze_time("2020-01-01")
     async def test_success(self, auth_instance):
+        expected_data = {"sl_data_ack_reason": 0}
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": 0}
+        _set_mock_response_json(mock_response, expected_data)
 
         auth_instance.keep_alive_timeout_sec = 900
 
@@ -270,7 +290,7 @@ class TestAuthSendCommand:
 
                 response = await auth_instance.async_send_command(payload)
 
-                assert response == mock_response.json.return_value
+                assert response == expected_data
                 assert auth_instance.cseq == 1
                 assert (
                     auth_instance.session_expiration_timestamp
@@ -301,7 +321,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": 1}
+        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 1})
 
         auth_instance.keep_alive_timeout_sec = 900
 
@@ -506,7 +526,7 @@ class TestAuthSendCommand:
             mock_response = AsyncMock()
             mock_response.status = 200
             mock_response.raise_for_status = Mock()
-            mock_response.json.return_value = {"sl_data_ack_reason": ack_code}
+            _set_mock_response_json(mock_response, {"sl_data_ack_reason": ack_code})
             mock_post.return_value = mock_response
 
             with pytest.raises(
@@ -536,7 +556,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": ack_code}
+        _set_mock_response_json(mock_response, {"sl_data_ack_reason": ack_code})
         mock_post.return_value = mock_response
 
         with pytest.raises(CameDomoticServerError):
@@ -561,7 +581,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": 3}
+        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 3})
         mock_post.return_value = mock_response
 
         with pytest.raises(
@@ -574,10 +594,10 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {
-            "sl_data_ack_reason": 0,
-            "cmd_name": "wrong_cmd",
-        }
+        _set_mock_response_json(
+            mock_response,
+            {"sl_data_ack_reason": 0, "cmd_name": "wrong_cmd"},
+        )
 
         payload = {"command": "test_command"}
 
@@ -620,7 +640,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        _set_mock_response_read_error(mock_response)
 
         with pytest.raises(CameDomoticServerError):
             await Auth.async_raise_for_status_and_ack(mock_response)
@@ -828,11 +848,14 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            mock_response.json.return_value = {
-                "sl_data_ack_reason": 1,
-                "sl_client_id": "bad_client_id",
-                "sl_keep_alive_timeout_sec": 900,
-            }
+            _set_mock_response_json(
+                mock_response,
+                {
+                    "sl_data_ack_reason": 1,
+                    "sl_client_id": "bad_client_id",
+                    "sl_keep_alive_timeout_sec": 900,
+                },
+            )
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -847,7 +870,7 @@ class TestAuthLogin:
         ) as mock_send_command:
             mock_response = AsyncMock()
             mock_response.status = 200
-            mock_response.json.side_effect = json.JSONDecodeError("Error", "", 0)
+            _set_mock_response_read_error(mock_response)
             mock_send_command.return_value = mock_response
 
             with pytest.raises(CameDomoticAuthError):
@@ -865,11 +888,14 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            mock_response.json.return_value = {
-                "sl_data_ack_reason": 3,
-                "sl_client_id": "client_id",
-                "sl_keep_alive_timeout_sec": 900,
-            }
+            _set_mock_response_json(
+                mock_response,
+                {
+                    "sl_data_ack_reason": 3,
+                    "sl_client_id": "client_id",
+                    "sl_keep_alive_timeout_sec": 900,
+                },
+            )
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -891,11 +917,14 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            mock_response.json.return_value = {
-                "sl_data_ack_reason": 4,  # "Error occurred in JSON Syntax."
-                "sl_client_id": "client_id",
-                "sl_keep_alive_timeout_sec": 900,
-            }
+            _set_mock_response_json(
+                mock_response,
+                {
+                    "sl_data_ack_reason": 4,  # "Error occurred in JSON Syntax."
+                    "sl_client_id": "client_id",
+                    "sl_keep_alive_timeout_sec": 900,
+                },
+            )
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -1192,7 +1221,7 @@ class TestSessionRecovery:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": 7}
+        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 7})
 
         auth_instance.client_id = "old_client_id"
 
@@ -1215,7 +1244,7 @@ class TestSessionRecovery:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        mock_response.json.return_value = {"sl_data_ack_reason": 8}
+        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 8})
 
         auth_instance.client_id = "old_client_id"
 
@@ -1311,3 +1340,142 @@ class TestKeepAliveClamping:
                 auth_instance_not_logged_in.keep_alive_timeout_sec
                 == _KEEP_ALIVE_MAX_SEC
             )
+
+
+class TestSafeReadJson:
+    """Tests for the Auth._safe_read_json security helper."""
+
+    async def test_normal_json_response(self):
+        """A normal-sized JSON response with correct content type is parsed."""
+        payload = {"cmd_name": "test", "status": "ok"}
+        raw = json.dumps(payload).encode()
+
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "application/json"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=raw)
+
+        result = await Auth._safe_read_json(mock_response)
+        assert result == payload
+
+    async def test_response_exceeds_max_size(self):
+        """A response exceeding _MAX_RESPONSE_SIZE_BYTES is rejected."""
+        oversized_body = b"x" * (Auth._MAX_RESPONSE_SIZE_BYTES + 1)
+
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=oversized_body)
+
+        with pytest.raises(CameDomoticServerError, match="maximum allowed size"):
+            await Auth._safe_read_json(mock_response)
+
+    async def test_response_at_exact_max_size(self):
+        """A response exactly at the size limit is accepted."""
+        payload = {"data": "a" * (Auth._MAX_RESPONSE_SIZE_BYTES - 20)}
+        raw = json.dumps(payload).encode()
+        # Ensure it fits within the limit
+        assert len(raw) <= Auth._MAX_RESPONSE_SIZE_BYTES
+
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "application/json"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=raw)
+
+        result = await Auth._safe_read_json(mock_response)
+        assert result["data"] == payload["data"]
+
+    async def test_unexpected_content_type_falls_back(self):
+        """An unexpected Content-Type triggers a warning but still parses."""
+        payload = {"cmd_name": "test"}
+        raw = json.dumps(payload).encode()
+
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "text/html"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=raw)
+
+        result = await Auth._safe_read_json(mock_response)
+        assert result == payload
+
+    async def test_unexpected_content_type_logs_warning(self, caplog):
+        """An unexpected Content-Type logs a warning."""
+        payload = {"cmd_name": "test"}
+        raw = json.dumps(payload).encode()
+
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "text/plain"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=raw)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            await Auth._safe_read_json(mock_response)
+
+        assert any("Unexpected Content-Type" in msg for msg in caplog.messages)
+
+    async def test_invalid_json_raises_error(self):
+        """Invalid JSON content raises CameDomoticServerError."""
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "application/json"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=b"not valid json{{{")
+
+        with pytest.raises(CameDomoticServerError, match="decoding the response"):
+            await Auth._safe_read_json(mock_response)
+
+    async def test_empty_response_raises_error(self):
+        """An empty response body raises CameDomoticServerError."""
+        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+        mock_response.content_type = "application/json"
+        mock_response.content = AsyncMock()
+        mock_response.content.read = AsyncMock(return_value=b"")
+
+        with pytest.raises(CameDomoticServerError, match="decoding the response"):
+            await Auth._safe_read_json(mock_response)
+
+
+class TestAuthDel:
+    """Tests for the Auth.__del__ credential cleanup safety net."""
+
+    def test_del_clears_uncleaned_credentials(self):
+        """__del__ clears credentials that were not cleaned by async_dispose."""
+        session = Mock()
+        auth = Auth(session, "192.168.1.1", "user", "password")
+
+        # Verify credentials are set
+        assert auth.cipher_suite is not None
+        assert auth.username is not None
+        assert auth.password is not None
+
+        # Simulate garbage collection without prior disposal
+        auth.__del__()
+
+        assert auth.cipher_suite is None
+        assert auth.username is None
+        assert auth.password is None
+
+    def test_del_safe_after_dispose(self):
+        """__del__ is safe to call when credentials are already cleared."""
+        session = Mock()
+        auth = Auth(session, "192.168.1.1", "user", "password")
+
+        # Simulate prior disposal
+        auth.cipher_suite = None
+        auth.username = None
+        auth.password = None
+
+        # Should not raise
+        auth.__del__()
+
+        assert auth.cipher_suite is None
+        assert auth.username is None
+        assert auth.password is None
+
+    def test_del_safe_on_partial_init(self):
+        """__del__ handles partially-initialized instances gracefully."""
+        auth = object.__new__(Auth)
+        # Don't call __init__ — simulates a partial initialization failure
+
+        # Should not raise even without any attributes set
+        auth.__del__()


### PR DESCRIPTION
## Summary

- Add `Auth._safe_read_json` helper with response size limits (5 MB) and Content-Type validation to protect against memory exhaustion from compromised servers
- Add `Auth.__del__` safety net for credential cleanup on garbage collection
- Update ROADMAP to reflect digital input support shipped in v1.5 and adjust future version numbering
- Downgrade unknown digital input status log from warning to debug

## Test plan

- [x] All 90 existing auth tests pass
- [x] New `TestSafeReadJson` tests cover: normal responses, oversized responses, exact size limit, unexpected content types, invalid JSON, empty responses
- [x] New `TestAuthDel` tests cover: uncleaned credentials, already-disposed instances, partially-initialized instances
- [x] Pre-commit hooks pass (ruff, mypy, bandit, codespell)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Digital inputs (read-only) now available as a supported feature with real-time update capabilities.

* **Documentation**
  * Roadmap updated with versioning reflecting current and planned features, including energy meters and load control.

* **Improvements**
  * Enhanced security with response size validation, safe JSON parsing, and automatic credential cleanup mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->