### PR TITLE
Fix unnecessary logging for None digital input status

### DIFF
--- a/aiocamedomotic/models/digital_input.py
+++ b/aiocamedomotic/models/digital_input.py
@@ -109,15 +109,18 @@ class DigitalInput(CameEntity):
         absent from the server response (some digital inputs do not
         report a status until their first state change).
         """
+        raw_status = self.raw_data.get("status")
+        if raw_status is None:
+            return DigitalInputStatus.UNKNOWN
         try:
-            return DigitalInputStatus(self.raw_data["status"])
-        except (ValueError, KeyError):
-            LOGGER.debug(
+            return DigitalInputStatus(raw_status)
+        except ValueError:
+            LOGGER.warning(
                 "Unknown digital input status '%s' encountered for "
                 "digital input '%s' (ID: %s). "
                 "Returning DigitalInputStatus.UNKNOWN. Please report this "
                 "to the library developers.",
-                self.raw_data.get("status"),
+                raw_status,
                 self.name,
                 self.act_id,
             )


### PR DESCRIPTION
## Summary
- Skip logging when digital input status is `None` (missing from server response), as this is an expected case
- Only log a warning for truly unexpected status values

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no log output when status is None
- [ ] Confirm warning is logged for unexpected non-None values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved error handling and code organization for digital input status processing to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->