### PR TITLE
Simplify JSON response parsing in Auth

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -124,12 +124,6 @@ class Auth:
     - **Credential protection** — username and password are encrypted in memory
       using Fernet symmetric encryption with a runtime-generated key. Credentials
       are explicitly cleared on disposal and as a safety net on garbage collection.
-    - **Response size limit** — server responses larger than
-      ``_MAX_RESPONSE_SIZE_BYTES`` (5 MB) are rejected to prevent memory
-      exhaustion from a compromised server.
-    - **Content-Type validation** — JSON responses are validated against the
-      expected ``application/json`` Content-Type, with a fallback to permissive
-      parsing for backward compatibility.
 
     Note:
         This class is not meant to be used directly, but through the ``CameDomoticAPI``
@@ -140,12 +134,6 @@ class Auth:
     # Default timeout "safe zone" for session expiration
     _DEFAULT_SAFE_ZONE_SEC: int = 30
 
-    # Maximum allowed response size in bytes (5 MB).
-    # This protects against memory exhaustion from a compromised or
-    # misbehaving server that could send an arbitrarily large response.
-    # Normal CAME API responses are small JSON payloads (a few KB at most),
-    # so 5 MB is an extremely generous upper bound.
-    _MAX_RESPONSE_SIZE_BYTES: int = 5 * 1024 * 1024
     _DEFAULT_HTTP_HEADERS: dict[str, str] = {
         "User-Agent": f"aiocamedomotic/{_LIBRARY_VERSION}",
         "Accept": "application/json, text/plain, */*",  # Desumed from pycame library
@@ -454,8 +442,16 @@ class Auth:
                 )
                 LOGGER.debug("Session refreshed, cseq=%d", self.cseq)
 
-            # Parse JSON response with size and content-type safeguards
-            json_response = await Auth._safe_read_json(response)
+            # Parse JSON response
+            try:
+                json_response = await response.json(content_type=None)
+            except json.JSONDecodeError as e:
+                LOGGER.error(
+                    "Failed to decode JSON response for command '%s'", cmd_name
+                )
+                raise CameDomoticServerError(
+                    "Error decoding the response to JSON"
+                ) from e
 
             resp_cmd_name = json_response.get("cmd_name")
             if response_command is not None and resp_cmd_name != response_command:
@@ -707,63 +703,6 @@ class Auth:
 
     # region Utilities
 
-    @staticmethod
-    async def _safe_read_json(response: aiohttp.ClientResponse) -> dict[str, Any]:
-        """Read and parse a JSON response with security safeguards.
-
-        This method applies two protections before parsing the response body:
-
-        1. **Response size limit** — the raw body is read incrementally and
-           rejected if it exceeds ``_MAX_RESPONSE_SIZE_BYTES`` (5 MB). This
-           prevents a compromised or misbehaving server from exhausting memory
-           with an arbitrarily large payload.
-
-        2. **Content-Type validation** — the response is first parsed expecting
-           ``application/json``. If the server sends a different Content-Type
-           header, parsing falls back to accepting any content type for
-           backward compatibility and a warning is logged.
-
-        Args:
-            response: The aiohttp response to read.
-
-        Returns:
-            The parsed JSON body as a dictionary.
-
-        Raises:
-            CameDomoticServerError: if the response exceeds the size limit or
-                if the body cannot be decoded as valid JSON.
-        """
-        # --- 1. Response size guard ---
-        raw_body = await response.content.read(Auth._MAX_RESPONSE_SIZE_BYTES + 1)
-        if len(raw_body) > Auth._MAX_RESPONSE_SIZE_BYTES:
-            LOGGER.warning(
-                "Response body exceeds the maximum allowed size of %d bytes, "
-                "rejecting response",
-                Auth._MAX_RESPONSE_SIZE_BYTES,
-            )
-            raise CameDomoticServerError(
-                f"Response body exceeds the maximum allowed size "
-                f"of {Auth._MAX_RESPONSE_SIZE_BYTES} bytes"
-            )
-        LOGGER.debug("Response body size: %d bytes", len(raw_body))
-
-        # --- 2. Content-Type validation with silent fallback ---
-        content_type = response.content_type
-        if content_type and content_type != "application/json":
-            LOGGER.warning(
-                "Unexpected Content-Type '%s' in server response "
-                "(expected 'application/json'), falling back to "
-                "permissive parsing",
-                content_type,
-            )
-
-        # --- 3. JSON parsing ---
-        try:
-            return json.loads(raw_body)
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            LOGGER.error("Failed to decode response body as JSON")
-            raise CameDomoticServerError("Error decoding the response to JSON") from e
-
     def is_session_valid(self) -> bool:
         """Check whether the session is still valid or not."""
         # Notice that self.session_expiration_timestamp already include the safe zone
@@ -793,7 +732,10 @@ class Auth:
                 f"Exception raised for HTTP status: {response.status}"
             ) from e
 
-        resp_json = await Auth._safe_read_json(response)
+        try:
+            resp_json = await response.json(content_type=None)
+        except json.JSONDecodeError as e:
+            raise CameDomoticServerError("Error decoding the response to JSON") from e
 
         ack_reason = resp_json.get("sl_data_ack_reason")
 

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -42,25 +42,6 @@ from aiocamedomotic.errors import (
 )
 
 
-def _set_mock_response_json(mock_response: AsyncMock, data: dict) -> None:
-    """Configure a mock aiohttp response to return JSON data via content.read().
-
-    This sets up the ``content.read`` attribute so that ``Auth._safe_read_json``
-    can read the response body as raw bytes and parse it as JSON.
-    """
-    raw = json.dumps(data).encode()
-    mock_response.content = AsyncMock()
-    mock_response.content.read = AsyncMock(return_value=raw)
-    mock_response.content_type = "application/json"
-
-
-def _set_mock_response_read_error(mock_response: AsyncMock) -> None:
-    """Configure a mock response so that JSON parsing fails (invalid body)."""
-    mock_response.content = AsyncMock()
-    mock_response.content.read = AsyncMock(return_value=b"not valid json")
-    mock_response.content_type = "application/json"
-
-
 class TestHandleCameDomoticErrorsDecorator:
     """Tests for the handle_came_domotic_errors decorator."""
 
@@ -268,11 +249,10 @@ class TestAuthSendCommand:
 
     @freezegun.freeze_time("2020-01-01")
     async def test_success(self, auth_instance):
-        expected_data = {"sl_data_ack_reason": 0}
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, expected_data)
+        mock_response.json.return_value = {"sl_data_ack_reason": 0}
 
         auth_instance.keep_alive_timeout_sec = 900
 
@@ -290,7 +270,7 @@ class TestAuthSendCommand:
 
                 response = await auth_instance.async_send_command(payload)
 
-                assert response == expected_data
+                assert response == mock_response.json.return_value
                 assert auth_instance.cseq == 1
                 assert (
                     auth_instance.session_expiration_timestamp
@@ -321,7 +301,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 1})
+        mock_response.json.return_value = {"sl_data_ack_reason": 1}
 
         auth_instance.keep_alive_timeout_sec = 900
 
@@ -526,7 +506,7 @@ class TestAuthSendCommand:
             mock_response = AsyncMock()
             mock_response.status = 200
             mock_response.raise_for_status = Mock()
-            _set_mock_response_json(mock_response, {"sl_data_ack_reason": ack_code})
+            mock_response.json.return_value = {"sl_data_ack_reason": ack_code}
             mock_post.return_value = mock_response
 
             with pytest.raises(
@@ -556,7 +536,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, {"sl_data_ack_reason": ack_code})
+        mock_response.json.return_value = {"sl_data_ack_reason": ack_code}
         mock_post.return_value = mock_response
 
         with pytest.raises(CameDomoticServerError):
@@ -581,7 +561,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 3})
+        mock_response.json.return_value = {"sl_data_ack_reason": 3}
         mock_post.return_value = mock_response
 
         with pytest.raises(
@@ -594,10 +574,10 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(
-            mock_response,
-            {"sl_data_ack_reason": 0, "cmd_name": "wrong_cmd"},
-        )
+        mock_response.json.return_value = {
+            "sl_data_ack_reason": 0,
+            "cmd_name": "wrong_cmd",
+        }
 
         payload = {"command": "test_command"}
 
@@ -640,7 +620,7 @@ class TestAuthSendCommand:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_read_error(mock_response)
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
 
         with pytest.raises(CameDomoticServerError):
             await Auth.async_raise_for_status_and_ack(mock_response)
@@ -848,14 +828,11 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            _set_mock_response_json(
-                mock_response,
-                {
-                    "sl_data_ack_reason": 1,
-                    "sl_client_id": "bad_client_id",
-                    "sl_keep_alive_timeout_sec": 900,
-                },
-            )
+            mock_response.json.return_value = {
+                "sl_data_ack_reason": 1,
+                "sl_client_id": "bad_client_id",
+                "sl_keep_alive_timeout_sec": 900,
+            }
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -870,7 +847,7 @@ class TestAuthLogin:
         ) as mock_send_command:
             mock_response = AsyncMock()
             mock_response.status = 200
-            _set_mock_response_read_error(mock_response)
+            mock_response.json.side_effect = json.JSONDecodeError("Error", "", 0)
             mock_send_command.return_value = mock_response
 
             with pytest.raises(CameDomoticAuthError):
@@ -888,14 +865,11 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            _set_mock_response_json(
-                mock_response,
-                {
-                    "sl_data_ack_reason": 3,
-                    "sl_client_id": "client_id",
-                    "sl_keep_alive_timeout_sec": 900,
-                },
-            )
+            mock_response.json.return_value = {
+                "sl_data_ack_reason": 3,
+                "sl_client_id": "client_id",
+                "sl_keep_alive_timeout_sec": 900,
+            }
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -917,14 +891,11 @@ class TestAuthLogin:
         ):
             mock_response = AsyncMock()
             mock_response.status = 200
-            _set_mock_response_json(
-                mock_response,
-                {
-                    "sl_data_ack_reason": 4,  # "Error occurred in JSON Syntax."
-                    "sl_client_id": "client_id",
-                    "sl_keep_alive_timeout_sec": 900,
-                },
-            )
+            mock_response.json.return_value = {
+                "sl_data_ack_reason": 4,  # "Error occurred in JSON Syntax."
+                "sl_client_id": "client_id",
+                "sl_keep_alive_timeout_sec": 900,
+            }
             mock_send_command.return_value = mock_response
 
             mock_is_session_valid.assert_not_called()
@@ -1221,7 +1192,7 @@ class TestSessionRecovery:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 7})
+        mock_response.json.return_value = {"sl_data_ack_reason": 7}
 
         auth_instance.client_id = "old_client_id"
 
@@ -1244,7 +1215,7 @@ class TestSessionRecovery:
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.raise_for_status = Mock()
-        _set_mock_response_json(mock_response, {"sl_data_ack_reason": 8})
+        mock_response.json.return_value = {"sl_data_ack_reason": 8}
 
         auth_instance.client_id = "old_client_id"
 
@@ -1340,142 +1311,3 @@ class TestKeepAliveClamping:
                 auth_instance_not_logged_in.keep_alive_timeout_sec
                 == _KEEP_ALIVE_MAX_SEC
             )
-
-
-class TestSafeReadJson:
-    """Tests for the Auth._safe_read_json security helper."""
-
-    async def test_normal_json_response(self):
-        """A normal-sized JSON response with correct content type is parsed."""
-        payload = {"cmd_name": "test", "status": "ok"}
-        raw = json.dumps(payload).encode()
-
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "application/json"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=raw)
-
-        result = await Auth._safe_read_json(mock_response)
-        assert result == payload
-
-    async def test_response_exceeds_max_size(self):
-        """A response exceeding _MAX_RESPONSE_SIZE_BYTES is rejected."""
-        oversized_body = b"x" * (Auth._MAX_RESPONSE_SIZE_BYTES + 1)
-
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=oversized_body)
-
-        with pytest.raises(CameDomoticServerError, match="maximum allowed size"):
-            await Auth._safe_read_json(mock_response)
-
-    async def test_response_at_exact_max_size(self):
-        """A response exactly at the size limit is accepted."""
-        payload = {"data": "a" * (Auth._MAX_RESPONSE_SIZE_BYTES - 20)}
-        raw = json.dumps(payload).encode()
-        # Ensure it fits within the limit
-        assert len(raw) <= Auth._MAX_RESPONSE_SIZE_BYTES
-
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "application/json"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=raw)
-
-        result = await Auth._safe_read_json(mock_response)
-        assert result["data"] == payload["data"]
-
-    async def test_unexpected_content_type_falls_back(self):
-        """An unexpected Content-Type triggers a warning but still parses."""
-        payload = {"cmd_name": "test"}
-        raw = json.dumps(payload).encode()
-
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "text/html"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=raw)
-
-        result = await Auth._safe_read_json(mock_response)
-        assert result == payload
-
-    async def test_unexpected_content_type_logs_warning(self, caplog):
-        """An unexpected Content-Type logs a warning."""
-        payload = {"cmd_name": "test"}
-        raw = json.dumps(payload).encode()
-
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "text/plain"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=raw)
-
-        import logging
-
-        with caplog.at_level(logging.WARNING):
-            await Auth._safe_read_json(mock_response)
-
-        assert any("Unexpected Content-Type" in msg for msg in caplog.messages)
-
-    async def test_invalid_json_raises_error(self):
-        """Invalid JSON content raises CameDomoticServerError."""
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "application/json"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=b"not valid json{{{")
-
-        with pytest.raises(CameDomoticServerError, match="decoding the response"):
-            await Auth._safe_read_json(mock_response)
-
-    async def test_empty_response_raises_error(self):
-        """An empty response body raises CameDomoticServerError."""
-        mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-        mock_response.content_type = "application/json"
-        mock_response.content = AsyncMock()
-        mock_response.content.read = AsyncMock(return_value=b"")
-
-        with pytest.raises(CameDomoticServerError, match="decoding the response"):
-            await Auth._safe_read_json(mock_response)
-
-
-class TestAuthDel:
-    """Tests for the Auth.__del__ credential cleanup safety net."""
-
-    def test_del_clears_uncleaned_credentials(self):
-        """__del__ clears credentials that were not cleaned by async_dispose."""
-        session = Mock()
-        auth = Auth(session, "192.168.1.1", "user", "password")
-
-        # Verify credentials are set
-        assert auth.cipher_suite is not None
-        assert auth.username is not None
-        assert auth.password is not None
-
-        # Simulate garbage collection without prior disposal
-        auth.__del__()
-
-        assert auth.cipher_suite is None
-        assert auth.username is None
-        assert auth.password is None
-
-    def test_del_safe_after_dispose(self):
-        """__del__ is safe to call when credentials are already cleared."""
-        session = Mock()
-        auth = Auth(session, "192.168.1.1", "user", "password")
-
-        # Simulate prior disposal
-        auth.cipher_suite = None
-        auth.username = None
-        auth.password = None
-
-        # Should not raise
-        auth.__del__()
-
-        assert auth.cipher_suite is None
-        assert auth.username is None
-        assert auth.password is None
-
-    def test_del_safe_on_partial_init(self):
-        """__del__ handles partially-initialized instances gracefully."""
-        auth = object.__new__(Auth)
-        # Don't call __init__ — simulates a partial initialization failure
-
-        # Should not raise even without any attributes set
-        auth.__del__()


### PR DESCRIPTION
## Summary
- Remove `_safe_read_json` helper and its response size limit / content-type validation logic
- Replace with direct `response.json(content_type=None)` calls
- Remove associated test class `TestSafeReadJson` and helper functions

## Test plan
- [x] All existing tests pass with updated mock patterns
- [x] Pre-commit hooks (ruff, mypy, bandit, pytest) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal JSON parsing and error handling in authentication module for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->