### PR TITLE
Fix auth tests hanging on teardown due to real logout requests

### DIFF
--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -40,7 +40,12 @@ async def auth_instance_not_logged_in() -> AsyncGenerator[Auth, None]:
                 session, "192.168.x.x", "username", "password"
             ) as auth:
                 yield auth
-                await auth.async_dispose()
+                # Invalidate the session before the context manager exits
+                # to prevent async_dispose() from attempting a real logout
+                # request to the fake host, which would hang on DNS resolution.
+                auth.__dict__.pop("is_session_valid", None)
+                auth.client_id = ""
+                auth.session_expiration_timestamp = 0
 
 
 @pytest.fixture
@@ -54,6 +59,14 @@ async def auth_instance() -> AsyncGenerator[Auth, None]:
                 auth.keep_alive_timeout_sec = 900  # 15min
                 auth.session_expiration_timestamp = time.monotonic() + 3600  # 1h
                 yield auth
+                # Invalidate the session before the context manager exits
+                # to prevent async_dispose() from attempting a real logout
+                # request to the fake host, which would hang on DNS resolution.
+                # Also remove any instance-level is_session_valid mock that
+                # tests may have set, so the real method sees the reset values.
+                auth.__dict__.pop("is_session_valid", None)
+                auth.client_id = ""
+                auth.session_expiration_timestamp = 0
 
 
 # endregion

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -1063,7 +1063,7 @@ class TestAuthDispose:
 
     @patch.object(ClientSession, "close", new_callable=AsyncMock)
     @patch.object(Auth, "async_logout", new_callable=AsyncMock)
-    async def test_no_websession_close(self, mock_logout, mock_close, auth_instance):
+    async def test_no_websession_close(self, _mock_logout, mock_close, auth_instance):
         auth_instance.close_websession_on_disposal = False
         await auth_instance.async_dispose()
         mock_close.assert_not_called()

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -639,10 +639,6 @@ class TestAuthValidateHost:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    auth.client_id = "test_client_id"
-                    auth.keep_alive_timeout_sec = 900
-                    auth.session_expiration_timestamp = time.monotonic() + 3600
-
                     previous_calls = mock_get.call_count
 
                     await auth.async_validate_host()
@@ -661,9 +657,7 @@ class TestAuthValidateHost:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    auth.client_id = "test_client_id"
-                    auth.keep_alive_timeout_sec = 900
-                    auth.session_expiration_timestamp = time.monotonic() + 3600
+                    pass
 
                 mock_response.status = 404
 
@@ -685,9 +679,7 @@ class TestAuthValidateHost:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    auth.client_id = "test_client_id"
-                    auth.keep_alive_timeout_sec = 900
-                    auth.session_expiration_timestamp = time.monotonic() + 3600
+                    pass
 
                 mock_get.side_effect = aiohttp.ClientError()
 
@@ -709,9 +701,7 @@ class TestAuthValidateHost:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    auth.client_id = "test_client_id"
-                    auth.keep_alive_timeout_sec = 900
-                    auth.session_expiration_timestamp = time.monotonic() + 3600
+                    pass
 
                 mock_get.side_effect = aiohttp.ServerTimeoutError()
 
@@ -733,9 +723,7 @@ class TestAuthValidateHost:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    auth.client_id = "test_client_id"
-                    auth.keep_alive_timeout_sec = 900
-                    auth.session_expiration_timestamp = time.monotonic() + 3600
+                    pass
 
                 mock_get.side_effect = TimeoutError()
 
@@ -1074,7 +1062,8 @@ class TestAuthDispose:
         mock_close.assert_called_once()
 
     @patch.object(ClientSession, "close", new_callable=AsyncMock)
-    async def test_no_websession_close(self, mock_close, auth_instance):
+    @patch.object(Auth, "async_logout", new_callable=AsyncMock)
+    async def test_no_websession_close(self, mock_logout, mock_close, auth_instance):
         auth_instance.close_websession_on_disposal = False
         await auth_instance.async_dispose()
         mock_close.assert_not_called()


### PR DESCRIPTION
The auth test fixtures and several TestAuthValidateHost tests were setting
valid session state (client_id, session_expiration_timestamp) on Auth
instances backed by a fake host (192.168.x.x). When the async context
manager exited, async_dispose() saw a valid session and attempted a real
async_logout() HTTP request, which blocked on DNS resolution for ~30s.

Fixes:
- auth_instance/auth_instance_not_logged_in fixtures: invalidate session
  state after yield (clear client_id, session_expiration_timestamp, and
  remove any instance-level is_session_valid mock) so teardown skips logout
- TestAuthValidateHost tests: remove unnecessary session state setup that
  was irrelevant to host validation but triggered the hanging logout
- TestAuthDispose.test_no_websession_close: add async_logout mock since
  the test is about websession close behavior, not logout

https://claude.ai/code/session_01JP1h6CH3mJJdievRETbWx8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test fixture isolation to prevent unintended network requests during async test cleanup.
  * Strengthened mocking around authentication logout to ensure reliable, non-networked test behavior and reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->