### PR TITLE
Add user management

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,3 +1,0 @@
-version: 2
-ignore-paths:
-  - tests/

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,3 @@
+version: 2
+ignore-paths:
+  - tests/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,14 +53,24 @@ Domotic plant and can be tested against a real server. Features that are only kn
 reverse-engineered sources (without real traffic verification) are listed separately
 under [Future considerations](#future-considerations).
 
-### Version 1.6 — Energy meters
+### Version 1.6 — Thermoregulation (control)
+
+- **Zone configuration**: Set target temperature, operating mode (OFF, MANUAL, AUTO,
+  JOLLY), and fan speed (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via
+  `thermo_zone_config_req`.
+- **Global season**: Switch between heating and cooling seasons (WINTER, SUMMER,
+  PLANT_OFF) for all zones via `thermo_season_req`.
+- **Extended zone properties**: Expose fan speed, dehumidifier state (enabled/setpoint),
+  and auxiliary temperature sensors (t1, t2, t3) on `ThermoZone` and `ThermoZoneUpdate`.
+
+### Version 1.7 — Energy meters
 
 - **Meter listing**: List all energy meters with their current readings.
 - **Instant power**: Expose real-time power consumption via `meter_instant_power_ind`.
 - **Energy statistics**: Query historical consumption data (`energy_stat_req`) for
   monitoring and dashboard integration.
 
-### Version 1.7 — Load control (read-only)
+### Version 1.8 — Load control (read-only)
 
 - **Load control meters**: List load control meters with their current state
   (`loadsctrl_meter_list_req`).
@@ -75,10 +85,6 @@ The following features are known from reverse-engineered sources (API_reference.
 API_MANUAL.md) but have not been verified with real traffic captures. They may be
 considered for future development once real-world testing is possible:
 
-- **Thermoregulation (control)**: Set target temperature for individual thermo zones,
-  switch between heating and cooling seasons (`thermo_season_req`), configure operating
-  mode, fan speed, and dehumidification, and get/set thermoregulation profiles with
-  extended info support.
 - **Load control (edit)**: Configure load control meter thresholds
   (`loadsctrl_meter_set_req`) and load control relay priorities
   (`loadsctrl_relay_set_req`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,8 +53,13 @@ Domotic plant and can be tested against a real server. Features that are only kn
 reverse-engineered sources (without real traffic verification) are listed separately
 under [Future considerations](#future-considerations).
 
-### Version 1.6 — Thermoregulation (control)
+### Version 1.6 — User management & Thermoregulation (control)
 
+- **Add/Delete user APIs**: Create and remove users on the CAME server via
+  `user_create_req` and `user_delete_req`.
+- **Change-password support**: Update user passwords via `user_passwd_change_req`.
+- **Real-server lifecycle tests**: End-to-end create → change-password → delete
+  test verified against a real CAME Domotic plant.
 - **Zone configuration**: Set target temperature, operating mode (OFF, MANUAL, AUTO,
   JOLLY), and fan speed (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via
   `thermo_zone_config_req`.
@@ -91,7 +96,6 @@ considered for future development once real-world testing is possible:
 
 - **Relays (generic switches)**: List and control generic relay actuators. The API is
   documented but no real traffic has been observed.
-- **User management**: Add, delete, and change passwords for users on the CAME server.
 - **Scenario management**: Create and delete scenarios (beyond the current list/activate).
 - **Audio system**: Sound zone and source management (entirely unverified).
 - **Cameras (TVCC)**: Camera listing (entirely unverified).

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -381,9 +381,14 @@ class Auth:
                 the remote CAME Domotic server.
         """
 
-        # For registration (login) requests, don't try to get a valid client_id
-        # as that would create a circular dependency/deadlock
-        if command_type == _CommandType.REGISTRATION_REQUEST.value:
+        # Registration and password-change requests don't require a valid session:
+        # registration would create a circular dependency, and password change
+        # authenticates via the current credentials directly (no session token
+        # is included in the real protocol payload for this command).
+        if command_type in (
+            _CommandType.REGISTRATION_REQUEST.value,
+            _CommandType.CHANGE_USER_PASSWORD_REQUEST.value,
+        ):
             client_id = ""
         else:
             client_id = await self.async_get_valid_client_id()
@@ -400,6 +405,11 @@ class Auth:
                 "sl_client_id": client_id,
                 "sl_cmd": command_type,
                 "sl_appl_msg_type": "domo",
+            }
+        elif command_type == _CommandType.CHANGE_USER_PASSWORD_REQUEST.value:
+            # Password-change requests must not include sl_client_id (real protocol).
+            request_payload = {
+                "sl_cmd": command_type,
             }
         else:
             request_payload = {
@@ -776,6 +786,46 @@ class Auth:
             self.cseq,
         ) = backup_state
         LOGGER.debug("Auth credentials restored from backup")
+
+    @property
+    def current_username(self) -> str | None:
+        """Return the decrypted username for the current session, or None.
+
+        Returns:
+            str | None: The plaintext username, or ``None`` if the cipher suite
+            has not been initialised (e.g. after ``async_dispose``).
+
+        Note:
+            Usernames are not secret — they appear in plaintext in all API
+            payloads. This property is intended for internal comparisons
+            (e.g. preventing deletion of the current user). Avoid logging
+            its return value unnecessarily.
+        """
+        if self.cipher_suite is None or self.username is None:
+            return None
+        return self.cipher_suite.decrypt(self.username).decode()
+
+    def _update_stored_password(self, new_password: str) -> None:
+        """Update only the stored password without invalidating the current session.
+
+        Unlike :meth:`update_auth_credentials`, this method does **not** reset
+        the session expiration or the client ID. It is intended for the specific
+        case where the currently authenticated user changes their own password:
+        the session remains valid and only the locally stored credential is
+        refreshed so that the next re-authentication uses the new password.
+
+        Args:
+            new_password (str): The new plaintext password to store.
+
+        Raises:
+            CameDomoticAuthError: If the cipher suite is not initialised.
+        """
+        if self.cipher_suite is None:
+            raise CameDomoticAuthError(
+                "Authentication credentials are not initialized."
+            )
+        self.password = self.cipher_suite.encrypt(new_password.encode())
+        LOGGER.debug("Stored password updated without session invalidation")
 
     def update_auth_credentials(self, username: str, password: str) -> None:
         """Update the authentication credentials.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -39,6 +39,7 @@ from .models import (
     Room,
     Scenario,
     ServerInfo,
+    TerminalGroup,
     ThermoZone,
     ThermoZoneSeason,
     UpdateList,
@@ -107,6 +108,73 @@ class CameDomoticAPI:
         users_list = json_response.get("sl_users_list", [])
         LOGGER.info("Retrieved %d user(s)", len(users_list))
         return [User(user, self.auth) for user in users_list]
+
+    async def async_get_terminal_groups(self) -> list[TerminalGroup]:
+        """Get the list of terminal groups defined on the server.
+
+        Terminal groups define the permission scope assigned to users at
+        creation time. Call this method before :meth:`async_add_user` to
+        discover the available group names on the server.
+
+        The ``group`` parameter of :meth:`async_add_user` accepts a group
+        **name** (e.g. ``"ETI/Domo"``), not its numeric ID. The special value
+        ``"*"`` (the default) may be used when fine-grained group assignment is
+        not required.
+
+        Returns:
+            list[TerminalGroup]: Available groups. Returns an empty list if
+            none are defined or the server response lacks the ``array`` key.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching terminal groups list")
+        json_response = await self.auth.async_send_command(
+            {"cmd_name": _CommandName.TERMINALS_GROUPS_LIST.value},
+            response_command=_CommandNameResponse.TERMINALS_GROUPS_LIST.value,
+        )
+        groups = json_response.get("array", [])
+        LOGGER.info("Retrieved %d terminal group(s)", len(groups))
+        return [TerminalGroup(g) for g in groups]
+
+    async def async_add_user(
+        self, username: str, password: str, group: str = "*"
+    ) -> User:
+        """Add a new user to the CAME Domotic server.
+
+        Args:
+            username (str): The login name for the new user.
+            password (str): The initial password for the new user.
+            group (str, optional): The **name** of the permission group to
+                assign to the new user (e.g. ``"ETI/Domo"``). Defaults to
+                ``"*"``. Use :meth:`async_get_terminal_groups` to retrieve
+                the available group names from the server.
+
+        Returns:
+            User: A ``User`` object representing the newly created user.
+
+        .. warning::
+            This operation is based on reverse-engineered API documentation and
+            has not been verified against a real CAME Domotic server. Behaviour
+            may differ across firmware versions.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Adding user '%s'", username)
+        await self.auth.async_send_command(
+            {},
+            command_type=_CommandType.ADD_USER_REQUEST.value,
+            additional_payload={
+                "sl_login": username,
+                "sl_pwd": password,
+                "sl_group": group,
+            },
+        )
+        LOGGER.info("User '%s' added", username)
+        return User({"name": username}, self.auth)
 
     async def async_get_server_info(self) -> ServerInfo:
         """Get the server information.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -40,6 +40,7 @@ from .models import (
     Scenario,
     ServerInfo,
     ThermoZone,
+    ThermoZoneSeason,
     UpdateList,
     User,
 )
@@ -280,6 +281,32 @@ class CameDomoticAPI:
                 sensors.append(AnalogSensor(sensor_data))
         LOGGER.info("Retrieved %d analog sensor(s)", len(sensors))
         return sensors
+
+    async def async_set_thermo_season(self, season: ThermoZoneSeason) -> None:
+        """Set the global thermoregulation season for all zones.
+
+        This is a plant-level command that changes the season for the
+        entire thermoregulation system.
+
+        Args:
+            season: The season to set. Valid values are ``WINTER``,
+                ``SUMMER``, and ``PLANT_OFF``.
+
+        Raises:
+            ValueError: If ``season`` is ``ThermoZoneSeason.UNKNOWN``.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if season == ThermoZoneSeason.UNKNOWN:
+            raise ValueError("Cannot set season to UNKNOWN")
+
+        LOGGER.debug("Setting global thermo season to '%s'", season.value)
+        payload = {
+            "cmd_name": _CommandName.THERMO_SEASON.value,
+            "season": season.value,
+        }
+        await self.auth.async_send_command(payload)
+        LOGGER.info("Global thermo season set to '%s'", season.value)
 
     async def async_get_updates(self, timeout: int | None = None) -> UpdateList:
         """Get status updates from the server using long polling.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -152,6 +152,8 @@ class _CommandName(Enum):
     LIGHT_SWITCH = "light_switch_req"
     OPENING_MOVE = "opening_move_req"
     SCENARIO_ACTIVATION = "scenario_activation_req"
+    THERMO_ZONE_CONFIG = "thermo_zone_config_req"
+    THERMO_SEASON = "thermo_season_req"
 
 
 class _CommandNameResponse(Enum):

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -132,7 +132,7 @@ class _CommandType(Enum):
     USERS_LIST_REQUEST = "sl_users_list_req"
     ADD_USER_REQUEST = "sl_add_user_req"
     DELETE_USER_REQUEST = "sl_del_user_req"
-    CHANGE_USER_PASSWORD_REQUEST = "sl_user_pwd_change_req"
+    CHANGE_USER_PASSWORD_REQUEST = "sl_user_pwd_change_req"  # nosec B105
 
 
 class _CommandName(Enum):

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -130,6 +130,9 @@ class _CommandType(Enum):
     KEEP_ALIVE_REQUEST = "sl_keep_alive_req"
     LOGOUT_REQUEST = "sl_logout_req"
     USERS_LIST_REQUEST = "sl_users_list_req"
+    ADD_USER_REQUEST = "sl_add_user_req"
+    DELETE_USER_REQUEST = "sl_del_user_req"
+    CHANGE_USER_PASSWORD_REQUEST = "sl_user_pwd_change_req"
 
 
 class _CommandName(Enum):
@@ -154,6 +157,7 @@ class _CommandName(Enum):
     SCENARIO_ACTIVATION = "scenario_activation_req"
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
     THERMO_SEASON = "thermo_season_req"
+    TERMINALS_GROUPS_LIST = "terminals_groups_list_req"
 
 
 class _CommandNameResponse(Enum):
@@ -170,6 +174,7 @@ class _CommandNameResponse(Enum):
     THERMO_LIST = "thermo_list_resp"
     METERS_LIST = "meters_list_resp"
     DIGITALIN_LIST = "digitalin_list_resp"
+    TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
     # Status
     STATUS_UPDATE = "status_update_resp"
     # Actions

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -32,6 +32,7 @@ from .scenario import Scenario, ScenarioStatus  # noqa: F401
 from .thermo_zone import (  # noqa: F401
     AnalogSensor,
     ThermoZone,
+    ThermoZoneFanSpeed,
     ThermoZoneMode,
     ThermoZoneSeason,
     ThermoZoneStatus,
@@ -74,6 +75,7 @@ __all__ = [
     "ScenarioUpdate",
     "ServerInfo",
     "ThermoZone",
+    "ThermoZoneFanSpeed",
     "ThermoZoneMode",
     "ThermoZoneSeason",
     "ThermoZoneStatus",

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -20,7 +20,7 @@ CAME Domotic API.
 from __future__ import annotations
 
 from ..const import DeviceType, UpdateIndicator  # noqa: F401
-from .base import CameEntity, Floor, Room, ServerInfo, User  # noqa: F401
+from .base import CameEntity, Floor, Room, ServerInfo, TerminalGroup, User  # noqa: F401
 from .digital_input import (  # noqa: F401
     DigitalInput,
     DigitalInputStatus,
@@ -74,6 +74,7 @@ __all__ = [
     "ScenarioStatus",
     "ScenarioUpdate",
     "ServerInfo",
+    "TerminalGroup",
     "ThermoZone",
     "ThermoZoneFanSpeed",
     "ThermoZoneMode",

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -26,7 +26,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..auth import Auth
-from ..errors import CameDomoticAuthError
+from ..const import _CommandType
+from ..errors import CameDomoticAuthError, CameDomoticServerError
 from ..utils import (
     LOGGER,
     EntityValidator,
@@ -86,6 +87,82 @@ class User(CameEntity):
             raise
 
         LOGGER.info("Successfully switched to user '%s'", self.name)
+
+    async def async_delete(self) -> None:
+        """Delete this user from the CAME Domotic server.
+
+        Sends a delete-user request to the server for the user identified by
+        this object's ``name`` property.
+
+        .. warning::
+            This operation is based on reverse-engineered API documentation and
+            has not been verified against a real CAME Domotic server. Behaviour
+            may differ across firmware versions.
+
+        Raises:
+            ValueError: If this user is the currently authenticated user.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if self.name == self.auth.current_username:
+            raise ValueError(
+                f"Cannot delete the currently authenticated user ('{self.name}')."
+            )
+        LOGGER.debug("Deleting user '%s'", self.name)
+        await self.auth.async_send_command(
+            {},
+            command_type=_CommandType.DELETE_USER_REQUEST.value,
+            additional_payload={"sl_login": self.name},
+        )
+        LOGGER.info("User '%s' deleted", self.name)
+
+    async def async_change_password(
+        self, current_password: str, new_password: str
+    ) -> None:
+        """Change the password of this user on the CAME Domotic server.
+
+        Args:
+            current_password (str): The user's current password.
+            new_password (str): The desired new password.
+
+        .. warning::
+            This operation is based on reverse-engineered API documentation and
+            has not been verified against a real CAME Domotic server. Behaviour
+            may differ across firmware versions.
+
+        Note:
+            If the changed user is the currently authenticated user, the stored
+            credentials are updated automatically in the active session — no
+            additional action is required.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error or the
+                password change is rejected (``sl_user_pwd_change_ack_reason``
+                is non-zero).
+        """
+        LOGGER.debug("Changing password for user '%s'", self.name)
+        json_response = await self.auth.async_send_command(
+            {},
+            command_type=_CommandType.CHANGE_USER_PASSWORD_REQUEST.value,
+            additional_payload={
+                "sl_login": self.name,
+                "sl_pwd": current_password,
+                "sl_new_pwd": new_password,
+            },
+        )
+        ack_reason = json_response.get("sl_user_pwd_change_ack_reason", 0)
+        if ack_reason != 0:
+            raise CameDomoticServerError(
+                f"Password change rejected by server "
+                f"(sl_user_pwd_change_ack_reason={ack_reason})"
+            )
+        if self.name == self.auth.current_username:
+            self.auth._update_stored_password(new_password)  # pylint: disable=protected-access
+            LOGGER.debug(
+                "Stored password updated in active session for user '%s'", self.name
+            )
+        LOGGER.info("Password changed for user '%s'", self.name)
 
     async def _attempt_login_as_current_user(self, password: str) -> None:
         """Attempt to login with the user details.
@@ -206,3 +283,32 @@ class Room(CameEntity):
     def floor_id(self) -> int:
         """ID of the floor this room belongs to."""
         return self.raw_data["floor_ind"]
+
+
+@dataclass
+class TerminalGroup(CameEntity):
+    """Terminal group in the CAME Domotic API.
+
+    Represents a user permission group (e.g. ``"ETI/Domo"``). Groups are
+    assigned to users at creation time via
+    :meth:`CameDomoticAPI.async_add_user`. Use
+    :meth:`CameDomoticAPI.async_get_terminal_groups` to retrieve the
+    available group names before creating a user.
+    """
+
+    raw_data: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data, required_keys=["group_name", "group_id"]
+        )
+
+    @property
+    def name(self) -> str:
+        """Name of the group (e.g. ``"ETI/Domo"``)."""
+        return self.raw_data["group_name"]
+
+    @property
+    def id(self) -> int:
+        """Numeric ID of the group."""
+        return self.raw_data["group_id"]

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -158,7 +158,8 @@ class User(CameEntity):
                 f"(sl_user_pwd_change_ack_reason={ack_reason})"
             )
         if self.name == self.auth.current_username:
-            self.auth._update_stored_password(new_password)  # pylint: disable=protected-access
+            # pylint: disable-next=protected-access
+            self.auth._update_stored_password(new_password)
             LOGGER.debug(
                 "Stored password updated in active session for user '%s'", self.name
             )

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -16,9 +16,11 @@
 CAME Domotic thermoregulation entity models.
 
 This module implements the classes for working with thermoregulation zones
-and analog sensors in a CAME Domotic system. It provides read-only access
-to zone state (temperature, setpoint, mode, season) and analog sensor
-readings (temperature, humidity, pressure).
+and analog sensors in a CAME Domotic system. It provides access to zone
+state (temperature, setpoint, mode, season, fan speed, dehumidifier) and
+analog sensor readings (temperature, humidity, pressure), as well as
+control methods to configure zone settings such as target temperature,
+operating mode, and fan speed.
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ from enum import Enum
 from typing import Any
 
 from ..auth import Auth
+from ..const import _CommandName
 from ..utils import (
     LOGGER,
     EntityValidator,
@@ -77,6 +80,25 @@ class ThermoZoneSeason(Enum):
     WINTER = "winter"
     SUMMER = "summer"
     UNKNOWN = "unknown"
+
+
+class ThermoZoneFanSpeed(Enum):
+    """Fan speed setting for a thermoregulation zone.
+
+    Allowed values are:
+        - OFF (0)
+        - SLOW (1)
+        - MEDIUM (2)
+        - FAST (3)
+        - AUTO (4)
+    """
+
+    OFF = 0
+    SLOW = 1
+    MEDIUM = 2
+    FAST = 3
+    AUTO = 4
+    UNKNOWN = -1
 
 
 @dataclass
@@ -211,6 +233,184 @@ class ThermoZone(CameEntity):
     def leaf(self) -> bool:
         """Whether this is an actual zone (leaf node) in the hierarchy."""
         return self.raw_data.get("leaf", True)
+
+    @property
+    def fan_speed(self) -> ThermoZoneFanSpeed:
+        """Fan speed setting for the thermoregulation zone.
+
+        Returns ``ThermoZoneFanSpeed.UNKNOWN`` for unrecognized values.
+        """
+        try:
+            return ThermoZoneFanSpeed(self.raw_data.get("fan_speed", -1))
+        except ValueError:
+            LOGGER.warning(
+                "Unknown thermo zone fan speed '%s' for zone '%s' (ID: %s). "
+                "Returning ThermoZoneFanSpeed.UNKNOWN. "
+                "Please report this to the library developers.",
+                self.raw_data.get("fan_speed"),
+                self.name,
+                self.act_id,
+            )
+            return ThermoZoneFanSpeed.UNKNOWN
+
+    @property
+    def dehumidifier_enabled(self) -> bool:
+        """Whether the dehumidifier is enabled for this zone."""
+        return bool(self.raw_data.get("dehumidifier", {}).get("enabled", 0))
+
+    @property
+    def dehumidifier_setpoint(self) -> float | None:
+        """Dehumidifier humidity setpoint in percent, or None if not set."""
+        val = self.raw_data.get("dehumidifier", {}).get("setpoint")
+        if val is None:
+            return None
+        return float(val)
+
+    @property
+    def t1(self) -> float | None:
+        """Temperature sensor 1 reading in degrees Celsius, or None."""
+        raw = self.raw_data.get("t1")
+        if raw is None:
+            return None
+        return raw / 10.0
+
+    @property
+    def t2(self) -> float | None:
+        """Temperature sensor 2 reading in degrees Celsius, or None."""
+        raw = self.raw_data.get("t2")
+        if raw is None:
+            return None
+        return raw / 10.0
+
+    @property
+    def t3(self) -> float | None:
+        """Temperature sensor 3 reading in degrees Celsius, or None."""
+        raw = self.raw_data.get("t3")
+        if raw is None:
+            return None
+        return raw / 10.0
+
+    async def async_set_config(
+        self,
+        mode: ThermoZoneMode,
+        set_point: float,
+        *,
+        season: ThermoZoneSeason | None = None,
+        fan_speed: ThermoZoneFanSpeed | None = None,
+    ) -> None:
+        """Configure the thermoregulation zone.
+
+        Args:
+            mode: Operating mode to set.
+            set_point: Target temperature in degrees Celsius.
+            season: Season setting (optional, requires extended info).
+            fan_speed: Fan speed setting (optional, requires extended info).
+
+        Raises:
+            ValueError: If ``mode``, ``season``, or ``fan_speed`` is
+                ``UNKNOWN``.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if mode == ThermoZoneMode.UNKNOWN:
+            raise ValueError("Cannot set mode to UNKNOWN")
+
+        if season is not None and season == ThermoZoneSeason.UNKNOWN:
+            raise ValueError("Cannot set season to UNKNOWN")
+
+        if fan_speed is not None and fan_speed == ThermoZoneFanSpeed.UNKNOWN:
+            raise ValueError("Cannot set fan_speed to UNKNOWN")
+
+        LOGGER.debug(
+            "Sending 'thermo_zone_config_req' command for zone '%s' (ID: %s)",
+            self.name,
+            self.act_id,
+        )
+        payload = self._prepare_thermo_config_payload(
+            mode, set_point, season, fan_speed
+        )
+        await self.auth.async_send_command(payload)
+
+        # Update the local state if the command succeeded
+        self.raw_data["mode"] = mode.value
+        self.raw_data["set_point"] = int(round(set_point * 10))
+        if season is not None:
+            self.raw_data["season"] = season.value
+        if fan_speed is not None:
+            self.raw_data["fan_speed"] = fan_speed.value
+
+        LOGGER.info(
+            "Zone '%s' (ID: %s) configured: mode=%s, set_point=%.1f°C%s%s",
+            self.name,
+            self.act_id,
+            mode.name,
+            set_point,
+            f", season={season.name}" if season is not None else "",
+            f", fan_speed={fan_speed.name}" if fan_speed is not None else "",
+        )
+
+    def _prepare_thermo_config_payload(
+        self,
+        mode: ThermoZoneMode,
+        set_point: float,
+        season: ThermoZoneSeason | None,
+        fan_speed: ThermoZoneFanSpeed | None,
+    ) -> dict[str, Any]:
+        """Prepare the payload for the zone config API call."""
+        payload: dict[str, Any] = {
+            "act_id": self.act_id,
+            "cmd_name": _CommandName.THERMO_ZONE_CONFIG.value,
+            "mode": mode.value,
+            "set_point": int(round(set_point * 10)),
+        }
+
+        needs_extended = season is not None or fan_speed is not None
+        payload["extended_infos"] = 1 if needs_extended else 0
+
+        if season is not None:
+            payload["season"] = season.value
+        if fan_speed is not None:
+            payload["fan_speed"] = fan_speed.value
+
+        return payload
+
+    async def async_set_temperature(self, temperature: float) -> None:
+        """Set the target temperature, keeping the current operating mode.
+
+        Args:
+            temperature: Target temperature in degrees Celsius.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self.async_set_config(mode=self.mode, set_point=temperature)
+
+    async def async_set_mode(self, mode: ThermoZoneMode) -> None:
+        """Set the operating mode, keeping the current target temperature.
+
+        Args:
+            mode: Operating mode to set.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self.async_set_config(mode=mode, set_point=self.set_point)
+
+    async def async_set_fan_speed(self, fan_speed: ThermoZoneFanSpeed) -> None:
+        """Set the fan speed, keeping the current mode and temperature.
+
+        Args:
+            fan_speed: Fan speed to set.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self.async_set_config(
+            mode=self.mode, set_point=self.set_point, fan_speed=fan_speed
+        )
 
 
 @dataclass

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -34,7 +34,12 @@ from .base import CameEntity
 from .light import LightStatus, LightType
 from .opening import OpeningStatus
 from .scenario import ScenarioStatus
-from .thermo_zone import ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus
+from .thermo_zone import (
+    ThermoZoneFanSpeed,
+    ThermoZoneMode,
+    ThermoZoneSeason,
+    ThermoZoneStatus,
+)
 
 
 def get_update_device_type(update: dict[str, Any]) -> DeviceType | None:
@@ -254,6 +259,45 @@ class ThermoZoneUpdate(DeviceUpdate):
             return ThermoZoneSeason(self.raw_data.get("season", "unknown"))
         except ValueError:
             return ThermoZoneSeason.UNKNOWN
+
+    @property
+    def fan_speed(self) -> ThermoZoneFanSpeed:
+        """Fan speed setting (OFF, SLOW, MEDIUM, FAST, AUTO)."""
+        try:
+            return ThermoZoneFanSpeed(self.raw_data.get("fan_speed", -1))
+        except ValueError:
+            return ThermoZoneFanSpeed.UNKNOWN
+
+    @property
+    def dehumidifier_enabled(self) -> bool:
+        """Whether the dehumidifier is enabled."""
+        return bool(self.raw_data.get("dehumidifier", {}).get("enabled", 0))
+
+    @property
+    def dehumidifier_setpoint(self) -> float | None:
+        """Dehumidifier humidity setpoint in percent, or None if not present."""
+        val = self.raw_data.get("dehumidifier", {}).get("setpoint")
+        if val is None:
+            return None
+        return float(val)
+
+    @property
+    def t1(self) -> float | None:
+        """Temperature sensor 1 reading in degrees Celsius."""
+        raw = self.raw_data.get("t1")
+        return raw / 10.0 if raw is not None else None
+
+    @property
+    def t2(self) -> float | None:
+        """Temperature sensor 2 reading in degrees Celsius."""
+        raw = self.raw_data.get("t2")
+        return raw / 10.0 if raw is not None else None
+
+    @property
+    def t3(self) -> float | None:
+        """Temperature sensor 3 reading in degrees Celsius."""
+        raw = self.raw_data.get("t3")
+        return raw / 10.0 if raw is not None else None
 
 
 @dataclass

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -32,9 +32,9 @@ and controlling devices, and monitoring real-time changes. For a minimal
         from aiocamedomotic import CameDomoticAPI
         from aiocamedomotic.models import (
             DeviceType, DigitalInputStatus, LightStatus, LightType,
-            OpeningStatus, ScenarioStatus, ThermoZoneMode,
-            ThermoZoneSeason, ThermoZoneStatus, DeviceUpdate,
-            LightUpdate, OpeningUpdate, ThermoZoneUpdate,
+            OpeningStatus, ScenarioStatus, ThermoZoneFanSpeed,
+            ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
+            DeviceUpdate, LightUpdate, OpeningUpdate, ThermoZoneUpdate,
             ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
         )
         from aiocamedomotic.errors import (
@@ -382,11 +382,38 @@ Example output:
     ID: 1, Name: Living Room, Temperature: 20.0°C, Setpoint: 21.5°C, Mode: ThermoZoneMode.AUTO, Season: ThermoZoneSeason.WINTER
     ID: 52, Name: Bedroom, Temperature: 19.5°C, Setpoint: 20.0°C, Mode: ThermoZoneMode.MANUAL, Season: ThermoZoneSeason.WINTER
 
+**Controlling thermoregulation zones:**
+
+.. code-block:: python
+
+    from aiocamedomotic.models import ThermoZoneFanSpeed, ThermoZoneMode, ThermoZoneSeason
+
+    # Set target temperature (keeps current mode)
+    zone = zones[0]
+    await zone.async_set_temperature(22.0)
+
+    # Change operating mode (keeps current temperature)
+    await zone.async_set_mode(ThermoZoneMode.MANUAL)
+
+    # Full configuration with season and fan speed
+    await zone.async_set_config(
+        mode=ThermoZoneMode.AUTO,
+        set_point=21.5,
+        season=ThermoZoneSeason.WINTER,
+        fan_speed=ThermoZoneFanSpeed.MEDIUM,
+    )
+
+    # Set fan speed (keeps current mode and temperature)
+    await zone.async_set_fan_speed(ThermoZoneFanSpeed.SLOW)
+
+    # Change global season for all zones (plant-level command)
+    await api.async_set_thermo_season(ThermoZoneSeason.WINTER)
+
 .. note::
-    Thermoregulation zones are currently **read-only**. The library does not
-    yet support setting temperature, mode, or season. Temperature values are
-    returned as floats in degrees Celsius (the internal integer-times-10
-    representation is converted automatically).
+    Temperature values are returned as floats in degrees Celsius (the internal
+    integer-times-10 representation is converted automatically). The
+    ``season`` and ``fan_speed`` parameters in ``async_set_config`` are
+    optional; when provided, the ``extended_infos`` flag is set automatically.
 
 Analog sensors
 ^^^^^^^^^^^^^^

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -273,6 +273,28 @@ def thermo_zone_data_summer_manual():
 
 
 @pytest.fixture
+def thermo_zone_data_with_fan_dehumidifier():
+    """Mock data for a thermoregulation zone with fan speed and dehumidifier."""
+    return {
+        "act_id": 77,
+        "name": "Office",
+        "floor_ind": 10,
+        "room_ind": 20,
+        "status": 1,
+        "temp": 230,
+        "mode": 1,
+        "set_point": 220,
+        "season": "summer",
+        "leaf": True,
+        "fan_speed": 2,
+        "dehumidifier": {"enabled": 1, "setpoint": 55},
+        "t1": 190,
+        "t2": 200,
+        "t3": 210,
+    }
+
+
+@pytest.fixture
 def analog_sensor_data_temperature():
     """Mock data for an analog temperature sensor."""
     return {

--- a/tests/aiocamedomotic/mocked_requests.py
+++ b/tests/aiocamedomotic/mocked_requests.py
@@ -243,6 +243,27 @@ LOADSCTRL_RELAY_SET_REQ = {
     "sl_cmd": "sl_data_req",
 }
 
+SL_ADD_USER_REQ = {
+    "sl_client_id": "my_session_id",
+    "sl_cmd": "sl_add_user_req",
+    "sl_login": "new_user",
+    "sl_pwd": "new_password",
+    "sl_group": "new_group",
+}
+
+SL_DELETE_USER_REQ = {
+    "sl_client_id": "my_session_id",
+    "sl_cmd": "sl_del_user_req",
+    "sl_login": "user_to_delete",
+}
+
+SL_CHANGE_USER_PASSWORD_REQ = {
+    "sl_cmd": "sl_user_pwd_change_req",
+    "sl_login": "existing_user",
+    "sl_pwd": "current_password",
+    "sl_new_pwd": "new_password",
+}
+
 TERMINALS_GROUPS_LIST_REQ = {
     "sl_appl_msg": {
         "client": "my_session_id",

--- a/tests/aiocamedomotic/mocked_responses.py
+++ b/tests/aiocamedomotic/mocked_responses.py
@@ -464,6 +464,23 @@ TERMINALS_GROUPS_LIST_RESP = {
     "sl_data_ack_reason": 0,
 }
 
+SL_ADD_USER_RESP = {
+    "sl_cmd": "sl_add_user_ack",
+    "sl_data_ack_reason": 0,
+}
+
+SL_DELETE_USER_RESP = {
+    "sl_cmd": "sl_del_user_ack",
+    "sl_data_ack_reason": 0,
+}
+
+SL_CHANGE_USER_PASSWORD_RESP = {
+    "sl_cmd": "sl_user_pwd_change_ack",
+    "sl_user_pwd_change_ack_reason": 0,
+    "sl_ack_reason": 0,
+    "sl_data_ack_reason": 0,
+}
+
 GENERIC_REPLY = {
     "cseq": 4,
     "cmd_name": "generic_reply",

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -1101,6 +1101,40 @@ class TestAuthCredentials:
         ):
             auth_instance.update_auth_credentials("user", "pass")
 
+    async def test_current_username_returns_decrypted_value(self, auth_instance):
+        assert auth_instance.current_username == "username"
+
+    async def test_current_username_returns_none_when_cipher_suite_is_none(
+        self, auth_instance
+    ):
+        auth_instance.cipher_suite = None
+        assert auth_instance.current_username is None
+
+    async def test_update_stored_password_updates_only_password(self, auth_instance):
+        original_session_expiration = auth_instance.session_expiration_timestamp
+        original_client_id = auth_instance.client_id
+        original_username = auth_instance.username
+
+        auth_instance._update_stored_password("new_password")
+
+        assert (
+            auth_instance.cipher_suite.decrypt(auth_instance.password).decode()
+            == "new_password"
+        )
+        assert auth_instance.username == original_username
+        assert auth_instance.session_expiration_timestamp == original_session_expiration
+        assert auth_instance.client_id == original_client_id
+
+    async def test_update_stored_password_raises_when_cipher_suite_none(
+        self, auth_instance
+    ):
+        auth_instance.cipher_suite = None
+
+        with pytest.raises(
+            CameDomoticAuthError, match="credentials are not initialized"
+        ):
+            auth_instance._update_stored_password("new_password")
+
     def test_backup_restore(self):
         """Test Auth backup and restore credentials methods."""
         mock_session = AsyncMock()

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -37,6 +37,7 @@ from aiocamedomotic.models import (
     Scenario,
     ServerInfo,
     ThermoZone,
+    ThermoZoneSeason,
     UpdateList,
     User,
 )
@@ -1254,3 +1255,38 @@ class TestAPIDigitalInputs:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_digital_inputs()
+
+
+class TestAPIThermoSeason:
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_thermo_season_winter(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        await api.async_set_thermo_season(ThermoZoneSeason.WINTER)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["cmd_name"] == "thermo_season_req"
+        assert call_payload["season"] == "winter"
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_thermo_season_summer(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        await api.async_set_thermo_season(ThermoZoneSeason.SUMMER)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["season"] == "summer"
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_thermo_season_plant_off(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        await api.async_set_thermo_season(ThermoZoneSeason.PLANT_OFF)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["season"] == "plant_off"
+
+    async def test_async_set_thermo_season_unknown_raises(self, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        with pytest.raises(ValueError, match="Cannot set season to UNKNOWN"):
+            await api.async_set_thermo_season(ThermoZoneSeason.UNKNOWN)

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -36,6 +36,7 @@ from aiocamedomotic.models import (
     Room,
     Scenario,
     ServerInfo,
+    TerminalGroup,
     ThermoZone,
     ThermoZoneSeason,
     UpdateList,
@@ -201,6 +202,105 @@ class TestAPIUsers:
         users = await api.async_get_users()
         assert len(users) == 0
         assert isinstance(users, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_terminal_groups(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = {
+            "cseq": 1,
+            "cmd_name": "terminals_groups_list_resp",
+            "array": [
+                {"group_name": "ETI/Domo", "group_id": 1},
+                {"group_name": "group2", "group_id": 2},
+            ],
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        groups = await api.async_get_terminal_groups()
+
+        assert len(groups) == 2
+        assert isinstance(groups[0], TerminalGroup)
+        assert groups[0].name == "ETI/Domo"
+        assert groups[0].id == 1
+        assert groups[1].name == "group2"
+        assert groups[1].id == 2
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "terminals_groups_list_req"},
+            response_command="terminals_groups_list_resp",
+        )
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_terminal_groups_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.return_value = {
+            "cseq": 1,
+            "cmd_name": "terminals_groups_list_resp",
+            "array": [],
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        groups = await api.async_get_terminal_groups()
+
+        assert groups == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_terminal_groups_missing_key(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.return_value = {
+            "cseq": 1,
+            "cmd_name": "terminals_groups_list_resp",
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        groups = await api.async_get_terminal_groups()
+
+        assert groups == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_add_user(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = {
+            "sl_cmd": "sl_add_user_ack",
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        user = await api.async_add_user("new_user", "new_password", group="new_group")
+
+        assert isinstance(user, User)
+        assert user.name == "new_user"
+        mock_send_command.assert_called_once_with(
+            {},
+            command_type="sl_add_user_req",
+            additional_payload={
+                "sl_login": "new_user",
+                "sl_pwd": "new_password",
+                "sl_group": "new_group",
+            },
+        )
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_add_user_default_group(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = {
+            "sl_cmd": "sl_add_user_ack",
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_add_user("new_user", "new_password")
+
+        mock_send_command.assert_called_once_with(
+            {},
+            command_type="sl_add_user_req",
+            additional_payload={
+                "sl_login": "new_user",
+                "sl_pwd": "new_password",
+                "sl_group": "*",
+            },
+        )
 
 
 class TestAPIServerInfo:

--- a/tests/aiocamedomotic/test_config.ini.example
+++ b/tests/aiocamedomotic/test_config.ini.example
@@ -12,3 +12,9 @@ dimmable_light_id = 15
 on_off_light_name = Another Lamp Name
 shutter_name = My shutter
 thermo_zone_name = My thermo zone
+
+[test_user]
+# Temporary test user created and deleted during the user management lifecycle test
+username = YOUR_TEST_USERNAME
+password = YOUR_TEST_PASSWORD
+new_password = YOUR_TEST_NEW_PASSWORD

--- a/tests/aiocamedomotic/test_config.ini.example
+++ b/tests/aiocamedomotic/test_config.ini.example
@@ -11,3 +11,4 @@ dimmable_light_name = My dimmable light
 dimmable_light_id = 15
 on_off_light_name = Another Lamp Name
 shutter_name = My shutter
+thermo_zone_name = My thermo zone

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -54,6 +54,7 @@ from aiocamedomotic.models import (
     ScenarioUpdate,
     ServerInfo,
     ThermoZone,
+    ThermoZoneFanSpeed,
     ThermoZoneMode,
     ThermoZoneSeason,
     ThermoZoneStatus,
@@ -493,6 +494,38 @@ class TestDeviceUpdate:
         assert update.device_type == DeviceType.THERMOSTAT
         assert update.device_id == 76
         assert update.update_indicator == UpdateIndicator.THERMOSTAT
+        assert update.t1 == 19.0
+        assert update.t2 == 20.0
+        assert update.t3 == 21.0
+
+    def test_parse_thermo_zone_update_fan_speed(self):
+        raw = {
+            "cmd_name": "thermo_zone_info_ind",
+            "act_id": 10,
+            "name": "Office",
+            "fan_speed": 3,
+            "dehumidifier": {"enabled": 1, "setpoint": 60},
+        }
+        update = parse_update(raw)
+        assert isinstance(update, ThermoZoneUpdate)
+        assert update.fan_speed == ThermoZoneFanSpeed.FAST
+        assert update.dehumidifier_enabled is True
+        assert update.dehumidifier_setpoint == 60.0
+
+    def test_parse_thermo_zone_update_missing_optional_fields(self):
+        raw = {
+            "cmd_name": "thermo_zone_info_ind",
+            "act_id": 10,
+            "name": "Minimal",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, ThermoZoneUpdate)
+        assert update.fan_speed == ThermoZoneFanSpeed.UNKNOWN
+        assert update.dehumidifier_enabled is False
+        assert update.dehumidifier_setpoint is None
+        assert update.t1 is None
+        assert update.t2 is None
+        assert update.t3 is None
 
     def test_parse_scenario_update(self):
         raw = {
@@ -2029,6 +2062,197 @@ class TestThermoZone:
         }
         zone = ThermoZone(zone_data, auth_instance)
         assert zone.season == ThermoZoneSeason.PLANT_OFF
+
+    def test_fan_speed(self, thermo_zone_data_with_fan_dehumidifier, auth_instance):
+        zone = ThermoZone(thermo_zone_data_with_fan_dehumidifier, auth_instance)
+        assert zone.fan_speed == ThermoZoneFanSpeed.MEDIUM
+
+    def test_fan_speed_missing(self, auth_instance):
+        zone_data = {"act_id": 1, "name": "Minimal Zone"}
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.fan_speed == ThermoZoneFanSpeed.UNKNOWN
+
+    def test_fan_speed_unknown_value(self, auth_instance):
+        zone_data = {"act_id": 1, "name": "Test Zone", "fan_speed": 99}
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.fan_speed == ThermoZoneFanSpeed.UNKNOWN
+
+    def test_dehumidifier_enabled(
+        self, thermo_zone_data_with_fan_dehumidifier, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_with_fan_dehumidifier, auth_instance)
+        assert zone.dehumidifier_enabled is True
+
+    def test_dehumidifier_enabled_missing(self, auth_instance):
+        zone_data = {"act_id": 1, "name": "Minimal Zone"}
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.dehumidifier_enabled is False
+
+    def test_dehumidifier_setpoint(
+        self, thermo_zone_data_with_fan_dehumidifier, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_with_fan_dehumidifier, auth_instance)
+        assert zone.dehumidifier_setpoint == 55.0
+
+    def test_dehumidifier_setpoint_missing(self, auth_instance):
+        zone_data = {"act_id": 1, "name": "Minimal Zone"}
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.dehumidifier_setpoint is None
+
+    def test_t1_t2_t3(self, thermo_zone_data_with_fan_dehumidifier, auth_instance):
+        zone = ThermoZone(thermo_zone_data_with_fan_dehumidifier, auth_instance)
+        assert zone.t1 == 19.0
+        assert zone.t2 == 20.0
+        assert zone.t3 == 21.0
+
+    def test_t1_t2_t3_missing(self, auth_instance):
+        zone_data = {"act_id": 1, "name": "Minimal Zone"}
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.t1 is None
+        assert zone.t2 is None
+        assert zone.t3 is None
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_config(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_config(mode=ThermoZoneMode.MANUAL, set_point=22.5)
+        mock_send_command.assert_called_once()
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["cmd_name"] == "thermo_zone_config_req"
+        assert call_payload["act_id"] == 1
+        assert call_payload["mode"] == 1
+        assert call_payload["set_point"] == 225
+        assert call_payload["extended_infos"] == 0
+        assert zone.raw_data["mode"] == 1
+        assert zone.raw_data["set_point"] == 225
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_config_with_season_and_fan_speed(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_config(
+            mode=ThermoZoneMode.AUTO,
+            set_point=21.0,
+            season=ThermoZoneSeason.SUMMER,
+            fan_speed=ThermoZoneFanSpeed.FAST,
+        )
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["extended_infos"] == 1
+        assert call_payload["season"] == "summer"
+        assert call_payload["fan_speed"] == 3
+        assert zone.raw_data["season"] == "summer"
+        assert zone.raw_data["fan_speed"] == 3
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_config_without_extended(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_config(mode=ThermoZoneMode.OFF, set_point=20.0)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["extended_infos"] == 0
+        assert "season" not in call_payload
+        assert "fan_speed" not in call_payload
+
+    async def test_async_set_config_unknown_mode_raises(
+        self,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        with pytest.raises(ValueError, match="Cannot set mode to UNKNOWN"):
+            await zone.async_set_config(mode=ThermoZoneMode.UNKNOWN, set_point=20.0)
+
+    async def test_async_set_config_unknown_season_raises(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        with pytest.raises(ValueError, match="Cannot set season to UNKNOWN"):
+            await zone.async_set_config(
+                mode=ThermoZoneMode.AUTO,
+                set_point=20.0,
+                season=ThermoZoneSeason.UNKNOWN,
+            )
+
+    async def test_async_set_config_unknown_fan_speed_raises(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        with pytest.raises(ValueError, match="Cannot set fan_speed to UNKNOWN"):
+            await zone.async_set_config(
+                mode=ThermoZoneMode.AUTO,
+                set_point=20.0,
+                fan_speed=ThermoZoneFanSpeed.UNKNOWN,
+            )
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_temperature(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_temperature(22.0)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["set_point"] == 220
+        assert call_payload["mode"] == 2  # preserves current AUTO mode
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_mode(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_mode(ThermoZoneMode.MANUAL)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["mode"] == 1
+        assert call_payload["set_point"] == 348  # preserves current setpoint
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_fan_speed_method(
+        self,
+        mock_send_command,
+        thermo_zone_data_winter_auto,
+        auth_instance,
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        await zone.async_set_fan_speed(ThermoZoneFanSpeed.SLOW)
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["fan_speed"] == 1
+        assert call_payload["extended_infos"] == 1
+        assert call_payload["mode"] == 2  # preserves current AUTO mode
+        assert call_payload["set_point"] == 348  # preserves current setpoint
+
+
+class TestThermoZoneFanSpeed:
+    def test_enum_values(self):
+        assert ThermoZoneFanSpeed.OFF.value == 0
+        assert ThermoZoneFanSpeed.SLOW.value == 1
+        assert ThermoZoneFanSpeed.MEDIUM.value == 2
+        assert ThermoZoneFanSpeed.FAST.value == 3
+        assert ThermoZoneFanSpeed.AUTO.value == 4
+        assert ThermoZoneFanSpeed.UNKNOWN.value == -1
 
 
 class TestAnalogSensor:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -30,7 +30,7 @@ from aiocamedomotic.const import (
     UpdateIndicator,
     _ServerFeature,
 )
-from aiocamedomotic.errors import CameDomoticAuthError
+from aiocamedomotic.errors import CameDomoticAuthError, CameDomoticServerError
 from aiocamedomotic.models import (
     AnalogSensor,
     DeviceUpdate,
@@ -53,6 +53,7 @@ from aiocamedomotic.models import (
     ScenarioStatus,
     ScenarioUpdate,
     ServerInfo,
+    TerminalGroup,
     ThermoZone,
     ThermoZoneFanSpeed,
     ThermoZoneMode,
@@ -320,6 +321,128 @@ class TestUser:
         mock_auth.update_auth_credentials.assert_called_once_with(
             "test_user", "test_password"
         )
+
+    @pytest.mark.asyncio
+    async def test_async_delete_sends_correct_command(self):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "other_user"
+        user = User({"name": "user_to_delete"}, mock_auth)
+
+        await user.async_delete()
+
+        mock_auth.async_send_command.assert_called_once_with(
+            {},
+            command_type="sl_del_user_req",
+            additional_payload={"sl_login": "user_to_delete"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_delete_raises_for_current_user(self):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "current_user"
+        user = User({"name": "current_user"}, mock_auth)
+
+        with pytest.raises(ValueError, match="currently authenticated"):
+            await user.async_delete()
+
+        mock_auth.async_send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_change_password_sends_correct_command(self):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "other_user"
+        mock_auth.async_send_command.return_value = {
+            "sl_cmd": "sl_user_pwd_change_ack",
+            "sl_user_pwd_change_ack_reason": 0,
+            "sl_ack_reason": 0,
+            "sl_data_ack_reason": 0,
+        }
+        user = User({"name": "existing_user"}, mock_auth)
+
+        await user.async_change_password("current_password", "new_password")
+
+        mock_auth.async_send_command.assert_called_once_with(
+            {},
+            command_type="sl_user_pwd_change_req",
+            additional_payload={
+                "sl_login": "existing_user",
+                "sl_pwd": "current_password",
+                "sl_new_pwd": "new_password",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_change_password_raises_on_ack_failure(self):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "other_user"
+        mock_auth.async_send_command.return_value = {
+            "sl_cmd": "sl_user_pwd_change_ack",
+            "sl_user_pwd_change_ack_reason": 1,
+            "sl_ack_reason": 0,
+            "sl_data_ack_reason": 0,
+        }
+        user = User({"name": "existing_user"}, mock_auth)
+
+        with pytest.raises(
+            CameDomoticServerError, match="sl_user_pwd_change_ack_reason=1"
+        ):
+            await user.async_change_password("current_password", "new_password")
+
+    @pytest.mark.asyncio
+    async def test_async_change_password_updates_stored_password_for_current_user(self):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "existing_user"
+        mock_auth.async_send_command.return_value = {
+            "sl_cmd": "sl_user_pwd_change_ack",
+            "sl_user_pwd_change_ack_reason": 0,
+            "sl_ack_reason": 0,
+            "sl_data_ack_reason": 0,
+        }
+        user = User({"name": "existing_user"}, mock_auth)
+
+        await user.async_change_password("current_password", "new_password")
+
+        mock_auth._update_stored_password.assert_called_once_with("new_password")
+
+    @pytest.mark.asyncio
+    async def test_async_change_password_does_not_update_stored_password_for_other_user(
+        self,
+    ):
+        mock_auth = AsyncMock(spec=Auth)
+        mock_auth.current_username = "other_user"
+        mock_auth.async_send_command.return_value = {
+            "sl_cmd": "sl_user_pwd_change_ack",
+            "sl_user_pwd_change_ack_reason": 0,
+            "sl_ack_reason": 0,
+            "sl_data_ack_reason": 0,
+        }
+        user = User({"name": "existing_user"}, mock_auth)
+
+        await user.async_change_password("current_password", "new_password")
+
+        mock_auth._update_stored_password.assert_not_called()
+
+
+class TestTerminalGroup:
+    def test_initialization(self):
+        raw_data = {"group_name": "ETI/Domo", "group_id": 1}
+        group = TerminalGroup(raw_data)
+
+        assert group.name == "ETI/Domo"
+        assert group.id == 1
+        assert group.raw_data == raw_data
+
+    def test_invalid_input_missing_group_name(self):
+        with pytest.raises(ValueError):
+            TerminalGroup({"group_id": 1})
+
+    def test_invalid_input_missing_group_id(self):
+        with pytest.raises(ValueError):
+            TerminalGroup({"group_name": "ETI/Domo"})
+
+    def test_invalid_input_none(self):
+        with pytest.raises(ValueError):
+            TerminalGroup(None)
 
 
 class TestUpdateList:

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -40,6 +40,7 @@ from aiocamedomotic.models import (
     ThermoZoneMode,
     ThermoZoneSeason,
     ThermoZoneUpdate,
+    User,
 )
 from aiocamedomotic.models.opening import OpeningStatus
 
@@ -732,6 +733,108 @@ async def test_thermo_zone_updates_after_setpoint_change(
     finally:
         await zone.async_set_temperature(initial_set_point)
         print(f"  Reverted set_point to {initial_set_point}°C")
+
+
+async def test_user_management_lifecycle(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
+    """Full lifecycle: create user, verify, switch session, change password, delete."""
+    admin_username = real_server_config["came_server"]["username"]
+    admin_password = real_server_config["came_server"]["password"]
+
+    test_username = real_server_config["test_user"]["username"]
+    test_password = real_server_config["test_user"]["password"]
+    new_password = real_server_config["test_user"]["new_password"]
+
+    # Step 1: Get users and terminal groups
+    print("\n--- Step 1: Get users and terminal groups ---")
+    users = await api_instance_real.async_get_users()
+    print(f"Users: {[u.name for u in users]}")
+
+    groups = await api_instance_real.async_get_terminal_groups()
+    print(f"Groups: {[g.name for g in groups]}")
+    assert groups, "No terminal groups found — cannot create a user without a group"
+    group_name = groups[0].name
+    print(f"Using group: '{group_name}'")
+
+    # Clean up any leftover test user from a previous failed run
+    leftover = next((u for u in users if u.name == test_username), None)
+    if leftover:
+        print(f"Cleaning up pre-existing '{test_username}' from a previous run")
+        await leftover.async_delete()
+
+    # Step 2: Create the test user
+    print(f"\n--- Step 2: Create user '{test_username}' ---")
+    await api_instance_real.async_add_user(test_username, test_password, group_name)
+    print(f"User '{test_username}' created in group '{group_name}'")
+
+    # Step 3: Verify the new user is in the users list
+    print(f"\n--- Step 3: Verify '{test_username}' appears in users list ---")
+    users_after = await api_instance_real.async_get_users()
+    print(f"Users after creation: {[u.name for u in users_after]}")
+    test_user = next((u for u in users_after if u.name == test_username), None)
+    assert test_user is not None, (
+        f"User '{test_username}' not found in list after creation"
+    )
+    print(f"Confirmed: '{test_username}' is present")
+
+    # Step 4: Switch to test user, get server info, then switch back to admin
+    print(
+        f"\n--- Step 4: Login as '{test_username}', get server info, restore admin ---"
+    )
+    await test_user.async_set_as_current_user(test_password)
+    print(f"Logged in as '{api_instance_real.auth.current_username}'")
+
+    server_info = await api_instance_real.async_get_server_info()
+    print(
+        f"Server info (as '{test_username}'): "
+        f"keycode={server_info.keycode}, swver={server_info.swver}"
+    )
+    assert server_info.keycode, "Server info keycode should not be empty"
+
+    admin_user = User({"name": admin_username}, api_instance_real.auth)
+    await admin_user.async_set_as_current_user(admin_password)
+    print(f"Restored session as '{api_instance_real.auth.current_username}'")
+
+    # Step 5: Change the test user's password
+    print(f"\n--- Step 5: Change password of '{test_username}' ---")
+    users_current = await api_instance_real.async_get_users()
+    test_user = next((u for u in users_current if u.name == test_username), None)
+    assert test_user is not None, (
+        f"User '{test_username}' not found before password change"
+    )
+    await test_user.async_change_password(test_password, new_password)
+    print(f"Password of '{test_username}' changed")
+
+    # Step 6: Login with new password and verify with server info, then restore admin
+    print(f"\n--- Step 6: Login as '{test_username}' with new password ---")
+    await test_user.async_set_as_current_user(new_password)
+    print(f"Logged in as '{api_instance_real.auth.current_username}' with new password")
+
+    server_info = await api_instance_real.async_get_server_info()
+    current = api_instance_real.auth.current_username
+    print(
+        f"Server info (as '{current}' with new password): keycode={server_info.keycode}"
+    )
+    assert server_info.keycode, "Server info keycode should not be empty"
+
+    await admin_user.async_set_as_current_user(admin_password)
+    print(f"Restored session as '{api_instance_real.auth.current_username}'")
+
+    # Step 7: Delete the test user and verify it's gone
+    print(f"\n--- Step 7: Delete '{test_username}' and verify ---")
+    users_before_delete = await api_instance_real.async_get_users()
+    test_user = next((u for u in users_before_delete if u.name == test_username), None)
+    assert test_user is not None, f"User '{test_username}' not found before deletion"
+    await test_user.async_delete()
+    print(f"User '{test_username}' deleted")
+
+    users_after_delete = await api_instance_real.async_get_users()
+    print(f"Users after deletion: {[u.name for u in users_after_delete]}")
+    assert not any(u.name == test_username for u in users_after_delete), (
+        f"User '{test_username}' still present after deletion"
+    )
+    print(f"Confirmed: '{test_username}' is no longer in the users list")
 
 
 async def test_autodiscovery(real_server_config):

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -36,6 +36,9 @@ from aiocamedomotic.models import (
     OpeningUpdate,
     PlantUpdate,
     ScenarioUpdate,
+    ThermoZoneFanSpeed,
+    ThermoZoneMode,
+    ThermoZoneSeason,
     ThermoZoneUpdate,
 )
 from aiocamedomotic.models.opening import OpeningStatus
@@ -429,6 +432,306 @@ async def test_listen_for_updates(api_instance_real: CameDomoticAPI):
         f"\nDone — collected {total_updates} update(s) "
         f"across {max_api_calls} API call(s)."
     )
+
+
+def _get_thermo_zone_name(real_server_config) -> str:
+    """Return the thermo zone name from config or a default."""
+    if (
+        real_server_config
+        and "test_devices" in real_server_config
+        and "thermo_zone_name" in real_server_config["test_devices"]
+    ):
+        return real_server_config["test_devices"]["thermo_zone_name"]
+    return "Zona giorno"
+
+
+async def test_thermo_zone_extended_properties(api_instance_real: CameDomoticAPI):
+    """Reads all thermo zones and prints new extended properties."""
+    print("\nFetching all thermoregulation zones with extended properties...")
+    zones = await api_instance_real.async_get_thermo_zones()
+    if not zones:
+        pytest.skip("No thermoregulation zones found on the server.")
+        return
+
+    print(f"Found {len(zones)} zone(s):\n")
+    for zone in zones:
+        print(
+            f"  Zone '{zone.name}' (ID: {zone.act_id})\n"
+            f"    Temp: {zone.temperature}°C, Setpoint: {zone.set_point}°C\n"
+            f"    Mode: {zone.mode.name}, Season: {zone.season.name}, "
+            f"Status: {zone.status.name}\n"
+            f"    Fan speed: {zone.fan_speed.name}\n"
+            f"    Dehumidifier enabled: {zone.dehumidifier_enabled}, "
+            f"setpoint: {zone.dehumidifier_setpoint}\n"
+            f"    T1: {zone.t1}, T2: {zone.t2}, T3: {zone.t3}"
+        )
+
+        # Verify types are correct
+        assert isinstance(zone.fan_speed, ThermoZoneFanSpeed)
+        assert isinstance(zone.dehumidifier_enabled, bool)
+        assert zone.dehumidifier_setpoint is None or isinstance(
+            zone.dehumidifier_setpoint, float
+        )
+        assert zone.t1 is None or isinstance(zone.t1, float)
+        assert zone.t2 is None or isinstance(zone.t2, float)
+        assert zone.t3 is None or isinstance(zone.t3, float)
+
+
+@pytest.mark.timeout(60)
+async def test_thermo_zone_set_temperature(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
+    """Changes zone setpoint, waits for visual check, then reverts."""
+    zone_name = _get_thermo_zone_name(real_server_config)
+    print(f"\nLooking for zone: '{zone_name}'...")
+
+    zones = await api_instance_real.async_get_thermo_zones()
+    zone = next((z for z in zones if z.name == zone_name), None)
+    if zone is None:
+        pytest.skip(f"Zone '{zone_name}' not found on server")
+        return
+
+    initial_set_point = zone.set_point
+    initial_mode = zone.mode
+    new_set_point = initial_set_point + 1.0
+
+    print(
+        f"Zone '{zone.name}' initial state: "
+        f"mode={initial_mode.name}, set_point={initial_set_point}°C"
+    )
+
+    try:
+        print(f"  Setting temperature to {new_set_point}°C...")
+        await zone.async_set_temperature(new_set_point)
+        assert zone.set_point == new_set_point
+        print(f"  Local state: set_point={zone.set_point}°C — check your app now")
+        await asyncio.sleep(10)
+
+        print(f"  Reverting temperature to {initial_set_point}°C...")
+        await zone.async_set_temperature(initial_set_point)
+        assert zone.set_point == initial_set_point
+        print(f"  Local state: set_point={zone.set_point}°C — check your app now")
+        await asyncio.sleep(5)
+    finally:
+        # Safety net: always try to restore
+        if zone.set_point != initial_set_point:
+            await zone.async_set_temperature(initial_set_point)
+            print(f"  (safety revert to {initial_set_point}°C)")
+
+
+@pytest.mark.timeout(80)
+async def test_thermo_zone_mode_cycle(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
+    """Cycles through MANUAL -> AUTO -> JOLLY -> OFF, then restores."""
+    zone_name = _get_thermo_zone_name(real_server_config)
+    print(f"\nLooking for zone: '{zone_name}'...")
+
+    zones = await api_instance_real.async_get_thermo_zones()
+    zone = next((z for z in zones if z.name == zone_name), None)
+    if zone is None:
+        pytest.skip(f"Zone '{zone_name}' not found on server")
+        return
+
+    initial_mode = zone.mode
+    initial_set_point = zone.set_point
+    print(
+        f"Zone '{zone.name}' initial state: "
+        f"mode={initial_mode.name}, set_point={initial_set_point}°C"
+    )
+
+    modes_to_test = [
+        ThermoZoneMode.MANUAL,
+        ThermoZoneMode.AUTO,
+        ThermoZoneMode.JOLLY,
+        ThermoZoneMode.OFF,
+    ]
+
+    try:
+        for mode in modes_to_test:
+            print(f"  Setting mode to {mode.name}...")
+            await zone.async_set_mode(mode)
+            assert zone.mode == mode
+            print(f"  Local state: mode={zone.mode.name} — check your app now")
+            await asyncio.sleep(8)
+
+        print(f"  Restoring mode to {initial_mode.name}...")
+        await zone.async_set_mode(initial_mode)
+        assert zone.mode == initial_mode
+        print(f"  Local state: mode={zone.mode.name}")
+    finally:
+        if zone.mode != initial_mode:
+            await zone.async_set_config(mode=initial_mode, set_point=initial_set_point)
+            print(f"  (safety revert to mode={initial_mode.name})")
+
+
+@pytest.mark.timeout(60)
+async def test_thermo_zone_set_config_combined(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
+    """Tests async_set_config with mode + set_point + season together."""
+    zone_name = _get_thermo_zone_name(real_server_config)
+    print(f"\nLooking for zone: '{zone_name}'...")
+
+    zones = await api_instance_real.async_get_thermo_zones()
+    zone = next((z for z in zones if z.name == zone_name), None)
+    if zone is None:
+        pytest.skip(f"Zone '{zone_name}' not found on server")
+        return
+
+    initial_mode = zone.mode
+    initial_set_point = zone.set_point
+    initial_season = zone.season
+    print(
+        f"Zone '{zone.name}' initial state: mode={initial_mode.name}, "
+        f"set_point={initial_set_point}°C, season={initial_season.name}"
+    )
+
+    try:
+        print("  Setting: MANUAL, 22.0°C, WINTER...")
+        await zone.async_set_config(
+            mode=ThermoZoneMode.MANUAL,
+            set_point=22.0,
+            season=ThermoZoneSeason.WINTER,
+        )
+        assert zone.mode == ThermoZoneMode.MANUAL
+        assert zone.set_point == 22.0
+        assert zone.season == ThermoZoneSeason.WINTER
+        print(
+            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
+            f"season={zone.season.name} — check your app now"
+        )
+        await asyncio.sleep(10)
+
+        print("  Setting: MANUAL, 18.5°C, SUMMER...")
+        await zone.async_set_config(
+            mode=ThermoZoneMode.MANUAL,
+            set_point=18.5,
+            season=ThermoZoneSeason.SUMMER,
+        )
+        assert zone.mode == ThermoZoneMode.MANUAL
+        assert zone.set_point == 18.5
+        assert zone.season == ThermoZoneSeason.SUMMER
+        print(
+            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
+            f"season={zone.season.name} — check your app now"
+        )
+        await asyncio.sleep(10)
+
+        print(
+            f"  Restoring: {initial_mode.name}, {initial_set_point}°C, "
+            f"{initial_season.name}..."
+        )
+        await zone.async_set_config(
+            mode=initial_mode,
+            set_point=initial_set_point,
+            season=initial_season,
+        )
+        print(
+            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
+            f"season={zone.season.name}"
+        )
+    finally:
+        if (
+            zone.mode != initial_mode
+            or zone.set_point != initial_set_point
+            or zone.season != initial_season
+        ):
+            await zone.async_set_config(
+                mode=initial_mode,
+                set_point=initial_set_point,
+                season=initial_season,
+            )
+            print("  (safety revert applied)")
+
+
+@pytest.mark.timeout(40)
+async def test_async_set_thermo_season_global(
+    api_instance_real: CameDomoticAPI,
+):
+    """Tests global season switch at the plant level."""
+    print("\nFetching zones to determine current season...")
+    zones = await api_instance_real.async_get_thermo_zones()
+    if not zones:
+        pytest.skip("No thermoregulation zones found on the server.")
+        return
+
+    initial_season = zones[0].season
+    print(f"Current season (from first zone): {initial_season.name}")
+
+    try:
+        print("  Setting global season to WINTER...")
+        await api_instance_real.async_set_thermo_season(ThermoZoneSeason.WINTER)
+        print("  Done — check your app now")
+        await asyncio.sleep(8)
+
+        print("  Setting global season to SUMMER...")
+        await api_instance_real.async_set_thermo_season(ThermoZoneSeason.SUMMER)
+        print("  Done — check your app now")
+        await asyncio.sleep(8)
+
+        print(f"  Restoring global season to {initial_season.name}...")
+        await api_instance_real.async_set_thermo_season(initial_season)
+        print("  Done")
+    finally:
+        if initial_season not in (
+            ThermoZoneSeason.UNKNOWN,
+            ThermoZoneSeason.PLANT_OFF,
+        ):
+            await api_instance_real.async_set_thermo_season(initial_season)
+
+
+@pytest.mark.timeout(15)
+async def test_thermo_zone_updates_after_setpoint_change(
+    api_instance_real: CameDomoticAPI, real_server_config
+):
+    """Changes a zone setpoint, then listens for a ThermoZoneUpdate."""
+    zone_name = _get_thermo_zone_name(real_server_config)
+    print(f"\nLooking for zone: '{zone_name}'...")
+
+    zones = await api_instance_real.async_get_thermo_zones()
+    zone = next((z for z in zones if z.name == zone_name), None)
+    if zone is None:
+        pytest.skip(f"Zone '{zone_name}' not found on server")
+        return
+
+    initial_set_point = zone.set_point
+    new_set_point = initial_set_point + 0.5
+    print(
+        f"Zone '{zone.name}' set_point={initial_set_point}°C, "
+        f"changing to {new_set_point}°C to trigger update..."
+    )
+
+    try:
+        await zone.async_set_temperature(new_set_point)
+
+        print("  Listening for ThermoZoneUpdate...")
+        thermo_update_found = False
+        while not thermo_update_found:
+            updates = await api_instance_real.async_get_updates(timeout=10)
+            for update in updates.get_typed_updates():
+                if isinstance(update, ThermoZoneUpdate):
+                    thermo_update_found = True
+                    print(
+                        f"\n  Received ThermoZoneUpdate for '{update.name}' "
+                        f"(act_id={update.act_id}):\n"
+                        f"    Temp: {update.temperature}°C, "
+                        f"Setpoint: {update.set_point}°C\n"
+                        f"    Mode: {update.mode.name}, "
+                        f"Season: {update.season.name}, "
+                        f"Status: {update.status.name}\n"
+                        f"    Fan speed: {update.fan_speed.name}\n"
+                        f"    Dehumidifier enabled: "
+                        f"{update.dehumidifier_enabled}, "
+                        f"setpoint: {update.dehumidifier_setpoint}\n"
+                        f"    T1: {update.t1}, T2: {update.t2}, T3: {update.t3}"
+                    )
+                    break
+
+        assert thermo_update_found, "No ThermoZoneUpdate received"
+    finally:
+        await zone.async_set_temperature(initial_set_point)
+        print(f"  Reverted set_point to {initial_set_point}°C")
 
 
 async def test_autodiscovery(real_server_config):


### PR DESCRIPTION
## Summary

- Add `async_get_users()`, `async_get_terminal_groups()`, and `async_add_user()` to `CameDomoticAPI`
- Add `User.async_delete()`, `User.async_change_password()`, and `User.async_set_as_current_user()` to the `User` model
- Add `TerminalGroup` model with `name` and `id` properties
- Add supporting constants and `Auth` helpers: `backup_auth_credentials`, `restore_auth_credentials`, `update_auth_credentials`, `_update_stored_password`, `current_username`
- Add full unit test coverage for all new API methods and model operations
- Add real-server lifecycle test (`test_user_management_lifecycle`) covering create, session switch, password change, and delete flows

## Test plan

- [x] Unit tests pass: `pytest tests/aiocamedomotic/test_auth.py tests/aiocamedomotic/test_came_domotic_api.py tests/aiocamedomotic/test_models.py`
- [x] Real-server test passes with `RUN_TESTS_ON_REAL_SERVER = True` (tested manually — all 7 steps verified)
- [x] Code quality checks (Black, mypy, pylint, ruff) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thermoregulation: control zones (mode/temperature), fan speed, dehumidifier, and set global season
  * User account management: create users, change passwords, delete users
  * Retrieve terminal groups from the server

* **Documentation**
  * Updated usage examples and roadmap to show thermoregulation controls and version reordering

* **Tests**
  * Added extensive unit and real-server tests covering thermo controls, user lifecycle, and terminal groups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->