### PR TITLE
feat: thermoregulation zone control and extended properties

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,19 +22,25 @@ reflects our commitment to making home automation more accessible and manageable
 This roadmap is subject to change based on community feedback and ongoing development
 insights. We look forward to growing this library together with our users and contributors.
 
-## Current Features (Version 1.5)
+## Current Features (Version 1.6)
 
 - **Session management**: Automated handling of login, logout, and keep-alive processes
   for the API, with automatic session recovery.
 - **Lights management**: List and control lights (on/off, dimmer brightness, RGB color).
 - **Openings management**: List and control shutters/blinds (open, close, stop).
 - **Scenarios management**: List available scenarios and trigger their activation.
-- **Thermoregulation (read-only)**: List thermoregulation zones with their current state,
-  retrieve temperature, setpoint, mode, and season for each zone. Expose top-level analog
-  sensor readings (temperature, humidity, pressure) from the thermo response.
+- **Thermoregulation (full control)**: List thermoregulation zones with their current
+  state; set target temperature, operating mode (OFF, MANUAL, AUTO, JOLLY), and fan speed
+  (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via `thermo_zone_config_req`.
+  Switch between seasons (WINTER, SUMMER, PLANT_OFF) plant-wide via `thermo_season_req`.
+  Expose fan speed, dehumidifier state (enabled/setpoint), and auxiliary temperature
+  sensors (t1, t2, t3) on `ThermoZone` and `ThermoZoneUpdate`. Top-level analog sensor
+  readings (temperature, humidity, pressure) are also exposed.
 - **Digital inputs (read-only)**: List binary sensors (door contacts, motion sensors, etc.)
   via `digitalin_list_req`. Each digital input exposes its current state and attributes.
   Real-time updates are supported via `DigitalInputUpdate`.
+- **User management**: Create and remove users on the CAME server via `user_create_req`
+  and `user_delete_req`; update passwords via `user_passwd_change_req`.
 - **Real-time updates with typed classes**: Long-polling support with typed update objects
   (`LightUpdate`, `OpeningUpdate`, `ThermoZoneUpdate`, `ScenarioUpdate`,
   `DigitalInputUpdate`, `PlantUpdate`). `UpdateList` provides filtering by device type,
@@ -52,21 +58,6 @@ All planned features below are backed by real traffic captures from a domestic C
 Domotic plant and can be tested against a real server. Features that are only known from
 reverse-engineered sources (without real traffic verification) are listed separately
 under [Future considerations](#future-considerations).
-
-### Version 1.6 — User management & Thermoregulation (control)
-
-- **Add/Delete user APIs**: Create and remove users on the CAME server via
-  `user_create_req` and `user_delete_req`.
-- **Change-password support**: Update user passwords via `user_passwd_change_req`.
-- **Real-server lifecycle tests**: End-to-end create → change-password → delete
-  test verified against a real CAME Domotic plant.
-- **Zone configuration**: Set target temperature, operating mode (OFF, MANUAL, AUTO,
-  JOLLY), and fan speed (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via
-  `thermo_zone_config_req`.
-- **Global season**: Switch between heating and cooling seasons (WINTER, SUMMER,
-  PLANT_OFF) for all zones via `thermo_season_req`.
-- **Extended zone properties**: Expose fan speed, dehumidifier state (enabled/setpoint),
-  and auxiliary temperature sensors (t1, t2, t3) on `ThermoZone` and `ThermoZoneUpdate`.
 
 ### Version 1.7 — Energy meters
 

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -356,6 +356,15 @@ class CameDomoticAPI:
         This is a plant-level command that changes the season for the
         entire thermoregulation system.
 
+        .. warning::
+            Setting ``season`` to ``PLANT_OFF`` causes the CAME server to
+            automatically switch **all** thermoregulation zones to
+            ``ThermoZoneMode.OFF``. Reverting the season back to ``WINTER``
+            or ``SUMMER`` does **not** restore the previous zone modes —
+            each zone stays ``OFF`` until its mode is changed explicitly via
+            :meth:`~aiocamedomotic.models.ThermoZone.async_set_mode` or
+            :meth:`~aiocamedomotic.models.ThermoZone.async_set_config`.
+
         Args:
             season: The season to set. Valid values are ``WINTER``,
                 ``SUMMER``, and ``PLANT_OFF``.

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -295,28 +295,28 @@ class ThermoZone(CameEntity):
         mode: ThermoZoneMode,
         set_point: float,
         *,
-        season: ThermoZoneSeason | None = None,
         fan_speed: ThermoZoneFanSpeed | None = None,
     ) -> None:
         """Configure the thermoregulation zone.
 
+        .. note::
+            The season cannot be changed via this method. The CAME server
+            silently ignores any season value sent in a zone config request.
+            Use :meth:`CameDomoticAPI.async_set_thermo_season` to change the
+            season at the plant level.
+
         Args:
             mode: Operating mode to set.
             set_point: Target temperature in degrees Celsius.
-            season: Season setting (optional, requires extended info).
             fan_speed: Fan speed setting (optional, requires extended info).
 
         Raises:
-            ValueError: If ``mode``, ``season``, or ``fan_speed`` is
-                ``UNKNOWN``.
+            ValueError: If ``mode`` or ``fan_speed`` is ``UNKNOWN``.
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
         """
         if mode == ThermoZoneMode.UNKNOWN:
             raise ValueError("Cannot set mode to UNKNOWN")
-
-        if season is not None and season == ThermoZoneSeason.UNKNOWN:
-            raise ValueError("Cannot set season to UNKNOWN")
 
         if fan_speed is not None and fan_speed == ThermoZoneFanSpeed.UNKNOWN:
             raise ValueError("Cannot set fan_speed to UNKNOWN")
@@ -326,26 +326,21 @@ class ThermoZone(CameEntity):
             self.name,
             self.act_id,
         )
-        payload = self._prepare_thermo_config_payload(
-            mode, set_point, season, fan_speed
-        )
+        payload = self._prepare_thermo_config_payload(mode, set_point, fan_speed)
         await self.auth.async_send_command(payload)
 
         # Update the local state if the command succeeded
         self.raw_data["mode"] = mode.value
         self.raw_data["set_point"] = int(round(set_point * 10))
-        if season is not None:
-            self.raw_data["season"] = season.value
         if fan_speed is not None:
             self.raw_data["fan_speed"] = fan_speed.value
 
         LOGGER.info(
-            "Zone '%s' (ID: %s) configured: mode=%s, set_point=%.1f°C%s%s",
+            "Zone '%s' (ID: %s) configured: mode=%s, set_point=%.1f°C%s",
             self.name,
             self.act_id,
             mode.name,
             set_point,
-            f", season={season.name}" if season is not None else "",
             f", fan_speed={fan_speed.name}" if fan_speed is not None else "",
         )
 
@@ -353,7 +348,6 @@ class ThermoZone(CameEntity):
         self,
         mode: ThermoZoneMode,
         set_point: float,
-        season: ThermoZoneSeason | None,
         fan_speed: ThermoZoneFanSpeed | None,
     ) -> dict[str, Any]:
         """Prepare the payload for the zone config API call."""
@@ -362,13 +356,9 @@ class ThermoZone(CameEntity):
             "cmd_name": _CommandName.THERMO_ZONE_CONFIG.value,
             "mode": mode.value,
             "set_point": int(round(set_point * 10)),
+            "extended_infos": 1 if fan_speed is not None else 0,
         }
 
-        needs_extended = season is not None or fan_speed is not None
-        payload["extended_infos"] = 1 if needs_extended else 0
-
-        if season is not None:
-            payload["season"] = season.value
         if fan_speed is not None:
             payload["fan_speed"] = fan_speed.value
 
@@ -376,6 +366,14 @@ class ThermoZone(CameEntity):
 
     async def async_set_temperature(self, temperature: float) -> None:
         """Set the target temperature, keeping the current operating mode.
+
+        .. warning::
+            This method only has an effect when the zone is in
+            ``ThermoZoneMode.MANUAL`` mode. When the zone is in any other mode
+            (e.g. ``AUTO``), the server accepts the request without error but
+            silently discards the new setpoint. Use
+            :meth:`async_set_config` with ``mode=ThermoZoneMode.MANUAL`` to
+            guarantee that the setpoint is applied.
 
         Args:
             temperature: Target temperature in degrees Celsius.

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -388,32 +388,52 @@ Example output:
 
     from aiocamedomotic.models import ThermoZoneFanSpeed, ThermoZoneMode, ThermoZoneSeason
 
-    # Set target temperature (keeps current mode)
+    # Set target temperature (keeps current mode).
+    # Only effective when the zone is in MANUAL mode; in AUTO or other modes
+    # the server silently discards the new setpoint without returning an error.
     zone = zones[0]
     await zone.async_set_temperature(22.0)
+
+    # To guarantee a setpoint change regardless of the current mode, switch to
+    # MANUAL and set the temperature in a single call:
+    await zone.async_set_config(mode=ThermoZoneMode.MANUAL, set_point=22.0)
 
     # Change operating mode (keeps current temperature)
     await zone.async_set_mode(ThermoZoneMode.MANUAL)
 
-    # Full configuration with season and fan speed
+    # Full configuration with fan speed
     await zone.async_set_config(
         mode=ThermoZoneMode.AUTO,
         set_point=21.5,
-        season=ThermoZoneSeason.WINTER,
         fan_speed=ThermoZoneFanSpeed.MEDIUM,
     )
 
     # Set fan speed (keeps current mode and temperature)
     await zone.async_set_fan_speed(ThermoZoneFanSpeed.SLOW)
 
-    # Change global season for all zones (plant-level command)
+    # Change global season for all zones (plant-level command — season cannot
+    # be changed per zone)
     await api.async_set_thermo_season(ThermoZoneSeason.WINTER)
+
+.. warning::
+    **Setting the season to** ``PLANT_OFF`` **forces all zones to** ``OFF``.
+
+    When the season is set to ``PLANT_OFF``, the CAME server automatically
+    switches every thermoregulation zone to ``ThermoZoneMode.OFF``. Reverting
+    the season back to ``WINTER`` or ``SUMMER`` does **not** restore the
+    previous zone modes — each zone stays ``OFF`` until its mode is changed
+    manually (e.g. via ``async_set_mode()`` or ``async_set_config()``).
+
+    If your application needs to restore zone operation after re-enabling a
+    season, you must track each zone's previous mode yourself and re-apply it
+    after changing the season.
 
 .. note::
     Temperature values are returned as floats in degrees Celsius (the internal
     integer-times-10 representation is converted automatically). The
-    ``season`` and ``fan_speed`` parameters in ``async_set_config`` are
-    optional; when provided, the ``extended_infos`` flag is set automatically.
+    ``fan_speed`` parameter in ``async_set_config`` is optional; when
+    provided, the ``extended_infos`` flag is set automatically. Season can
+    only be changed at the plant level via ``async_set_thermo_season()``.
 
 Analog sensors
 ^^^^^^^^^^^^^^

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -914,7 +914,7 @@ Create a CameDomoticAPI object.
   * **password** (*str*) – The password to use for the API.
   * **websession** (*aiohttp.ClientSession* *,* *optional*) – The aiohttp session to use for
     the API. If not provided, a new aiohttp.ClientSession will be created.
-  * **close_websession_on_disposal** (*bool* *,* *default False*) – 
+  * **close_websession_on_disposal** (*bool* *,* *default False*) –
 
     Controls whether the
     aiohttp session is closed when this object is disposed.

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -2257,7 +2257,7 @@ class TestThermoZone:
 
     @pytest.mark.asyncio
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
-    async def test_async_set_config_with_season_and_fan_speed(
+    async def test_async_set_config_with_fan_speed(
         self,
         mock_send_command,
         thermo_zone_data_winter_auto,
@@ -2267,14 +2267,12 @@ class TestThermoZone:
         await zone.async_set_config(
             mode=ThermoZoneMode.AUTO,
             set_point=21.0,
-            season=ThermoZoneSeason.SUMMER,
             fan_speed=ThermoZoneFanSpeed.FAST,
         )
         call_payload = mock_send_command.call_args[0][0]
         assert call_payload["extended_infos"] == 1
-        assert call_payload["season"] == "summer"
+        assert "season" not in call_payload
         assert call_payload["fan_speed"] == 3
-        assert zone.raw_data["season"] == "summer"
         assert zone.raw_data["fan_speed"] == 3
 
     @pytest.mark.asyncio
@@ -2300,17 +2298,6 @@ class TestThermoZone:
         zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
         with pytest.raises(ValueError, match="Cannot set mode to UNKNOWN"):
             await zone.async_set_config(mode=ThermoZoneMode.UNKNOWN, set_point=20.0)
-
-    async def test_async_set_config_unknown_season_raises(
-        self, thermo_zone_data_winter_auto, auth_instance
-    ):
-        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
-        with pytest.raises(ValueError, match="Cannot set season to UNKNOWN"):
-            await zone.async_set_config(
-                mode=ThermoZoneMode.AUTO,
-                set_point=20.0,
-                season=ThermoZoneSeason.UNKNOWN,
-            )
 
     async def test_async_set_config_unknown_fan_speed_raises(
         self, thermo_zone_data_winter_auto, auth_instance

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -506,6 +506,16 @@ async def test_thermo_zone_set_temperature(
         await zone.async_set_temperature(new_set_point)
         assert zone.set_point == new_set_point
         print(f"  Local state: set_point={zone.set_point}°C — check your app now")
+
+        print("  Re-fetching all zones from server to verify server-side value...")
+        zones_after = await api_instance_real.async_get_thermo_zones()
+        zone_after = next((z for z in zones_after if z.name == zone_name), None)
+        if zone_after is not None:
+            print(
+                f"  Server state after change: "
+                f"mode={zone_after.mode.name}, set_point={zone_after.set_point}°C"
+                f" (expected {new_set_point}°C)"
+            )
         await asyncio.sleep(10)
 
         print(f"  Reverting temperature to {initial_set_point}°C...")
@@ -582,97 +592,110 @@ async def test_thermo_zone_set_config_combined(
 
     initial_mode = zone.mode
     initial_set_point = zone.set_point
-    initial_season = zone.season
     print(
         f"Zone '{zone.name}' initial state: mode={initial_mode.name}, "
-        f"set_point={initial_set_point}°C, season={initial_season.name}"
+        f"set_point={initial_set_point}°C, season={zone.season.name}"
     )
 
+    def _print_server_zones(fetched_zones, label):
+        print(f"  Server state ({label}):")
+        for z in fetched_zones:
+            print(
+                f"    '{z.name}': mode={z.mode.name}, "
+                f"set_point={z.set_point}°C, season={z.season.name}"
+            )
+
     try:
-        print("  Setting: MANUAL, 22.0°C, WINTER...")
-        await zone.async_set_config(
-            mode=ThermoZoneMode.MANUAL,
-            set_point=22.0,
-            season=ThermoZoneSeason.WINTER,
-        )
+        print("  Setting: MANUAL, 22.0°C...")
+        await zone.async_set_config(mode=ThermoZoneMode.MANUAL, set_point=22.0)
         assert zone.mode == ThermoZoneMode.MANUAL
         assert zone.set_point == 22.0
-        assert zone.season == ThermoZoneSeason.WINTER
-        print(
-            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
-            f"season={zone.season.name} — check your app now"
-        )
-        await asyncio.sleep(10)
-
-        print("  Setting: MANUAL, 18.5°C, SUMMER...")
-        await zone.async_set_config(
-            mode=ThermoZoneMode.MANUAL,
-            set_point=18.5,
-            season=ThermoZoneSeason.SUMMER,
-        )
-        assert zone.mode == ThermoZoneMode.MANUAL
-        assert zone.set_point == 18.5
-        assert zone.season == ThermoZoneSeason.SUMMER
-        print(
-            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
-            f"season={zone.season.name} — check your app now"
-        )
-        await asyncio.sleep(10)
-
-        print(
-            f"  Restoring: {initial_mode.name}, {initial_set_point}°C, "
-            f"{initial_season.name}..."
-        )
-        await zone.async_set_config(
-            mode=initial_mode,
-            set_point=initial_set_point,
-            season=initial_season,
-        )
         print(
             f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
             f"season={zone.season.name}"
         )
+        _print_server_zones(
+            await api_instance_real.async_get_thermo_zones(), "after MANUAL/22.0"
+        )
+        await asyncio.sleep(10)
+
+        print("  Setting: MANUAL, 18.5°C...")
+        await zone.async_set_config(mode=ThermoZoneMode.MANUAL, set_point=18.5)
+        assert zone.mode == ThermoZoneMode.MANUAL
+        assert zone.set_point == 18.5
+        print(
+            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
+            f"season={zone.season.name}"
+        )
+        _print_server_zones(
+            await api_instance_real.async_get_thermo_zones(), "after MANUAL/18.5"
+        )
+        await asyncio.sleep(10)
+
+        print(f"  Restoring: {initial_mode.name}, {initial_set_point}°C...")
+        await zone.async_set_config(mode=initial_mode, set_point=initial_set_point)
+        print(
+            f"  Local state: mode={zone.mode.name}, set_point={zone.set_point}°C, "
+            f"season={zone.season.name}"
+        )
+        _print_server_zones(
+            await api_instance_real.async_get_thermo_zones(), "after restore"
+        )
     finally:
-        if (
-            zone.mode != initial_mode
-            or zone.set_point != initial_set_point
-            or zone.season != initial_season
-        ):
-            await zone.async_set_config(
-                mode=initial_mode,
-                set_point=initial_set_point,
-                season=initial_season,
-            )
+        if zone.mode != initial_mode or zone.set_point != initial_set_point:
+            await zone.async_set_config(mode=initial_mode, set_point=initial_set_point)
             print("  (safety revert applied)")
 
 
-@pytest.mark.timeout(40)
+@pytest.mark.timeout(60)
 async def test_async_set_thermo_season_global(
     api_instance_real: CameDomoticAPI,
 ):
-    """Tests global season switch at the plant level."""
+    """Tests global season switch at the plant level.
+
+    Sequence: PLANT_OFF -> WINTER -> SUMMER -> restore.
+    """
     print("\nFetching zones to determine current season...")
     zones = await api_instance_real.async_get_thermo_zones()
     if not zones:
         pytest.skip("No thermoregulation zones found on the server.")
         return
 
+    def _print_all_seasons(fetched_zones, label):
+        print(f"  Server state ({label}):")
+        for z in fetched_zones:
+            print(f"    '{z.name}': season={z.season.name}")
+
     initial_season = zones[0].season
     print(f"Current season (from first zone): {initial_season.name}")
 
     try:
+        print("  Setting global season to PLANT_OFF...")
+        await api_instance_real.async_set_thermo_season(ThermoZoneSeason.PLANT_OFF)
+        _print_all_seasons(
+            await api_instance_real.async_get_thermo_zones(), "after PLANT_OFF"
+        )
+        await asyncio.sleep(8)
+
         print("  Setting global season to WINTER...")
         await api_instance_real.async_set_thermo_season(ThermoZoneSeason.WINTER)
-        print("  Done — check your app now")
+        _print_all_seasons(
+            await api_instance_real.async_get_thermo_zones(), "after WINTER"
+        )
         await asyncio.sleep(8)
 
         print("  Setting global season to SUMMER...")
         await api_instance_real.async_set_thermo_season(ThermoZoneSeason.SUMMER)
-        print("  Done — check your app now")
+        _print_all_seasons(
+            await api_instance_real.async_get_thermo_zones(), "after SUMMER"
+        )
         await asyncio.sleep(8)
 
         print(f"  Restoring global season to {initial_season.name}...")
         await api_instance_real.async_set_thermo_season(initial_season)
+        _print_all_seasons(
+            await api_instance_real.async_get_thermo_zones(), "after restore"
+        )
         print("  Done")
     finally:
         if initial_season not in (
@@ -682,11 +705,14 @@ async def test_async_set_thermo_season_global(
             await api_instance_real.async_set_thermo_season(initial_season)
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 async def test_thermo_zone_updates_after_setpoint_change(
     api_instance_real: CameDomoticAPI, real_server_config
 ):
-    """Changes a zone setpoint, then listens for a ThermoZoneUpdate."""
+    """Switches zone to MANUAL, changes setpoint, listens for a ThermoZoneUpdate.
+
+    Restores zone state after the test.
+    """
     zone_name = _get_thermo_zone_name(real_server_config)
     print(f"\nLooking for zone: '{zone_name}'...")
 
@@ -696,15 +722,17 @@ async def test_thermo_zone_updates_after_setpoint_change(
         pytest.skip(f"Zone '{zone_name}' not found on server")
         return
 
+    initial_mode = zone.mode
     initial_set_point = zone.set_point
     new_set_point = initial_set_point + 0.5
     print(
-        f"Zone '{zone.name}' set_point={initial_set_point}°C, "
-        f"changing to {new_set_point}°C to trigger update..."
+        f"Zone '{zone.name}' initial state: mode={initial_mode.name}, "
+        f"set_point={initial_set_point}°C"
     )
 
     try:
-        await zone.async_set_temperature(new_set_point)
+        print(f"  Switching to MANUAL and setting set_point to {new_set_point}°C...")
+        await zone.async_set_config(mode=ThermoZoneMode.MANUAL, set_point=new_set_point)
 
         print("  Listening for ThermoZoneUpdate...")
         thermo_update_found = False
@@ -731,8 +759,10 @@ async def test_thermo_zone_updates_after_setpoint_change(
 
         assert thermo_update_found, "No ThermoZoneUpdate received"
     finally:
-        await zone.async_set_temperature(initial_set_point)
-        print(f"  Reverted set_point to {initial_set_point}°C")
+        await zone.async_set_config(mode=initial_mode, set_point=initial_set_point)
+        print(
+            f"  Reverted to mode={initial_mode.name}, set_point={initial_set_point}°C"
+        )
 
 
 async def test_user_management_lifecycle(


### PR DESCRIPTION
## Summary

- Removes the `season` parameter from `ThermoZone.async_set_config` — the CAME server silently ignores it; season changes must go through the plant-level `CameDomoticAPI.async_set_thermo_season`
- Documents that `async_set_temperature` only takes effect when the zone is in `MANUAL` mode; in other modes the server discards the new setpoint silently
- Adds a warning that setting the season to `PLANT_OFF` forces **all** zones to `OFF` and the previous modes are not restored when re-enabling a season
- Updates unit tests and real-server integration tests to reflect the removed `season` parameter

## Test plan

- [x] Run unit tests: `pytest tests/aiocamedomotic/test_models.py`
- [x] Verify `async_set_config` no longer accepts `season`
- [x] Verify `async_set_thermo_season(PLANT_OFF)` warning is visible in docs
- [x] (Optional) Run real-server tests against a CAME Domotic server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Season parameter removed from per-zone configuration API; season changes now available only through plant-level API calls

* **Documentation**
  * Added warnings describing PLANT_OFF season behavior and required manual zone reconfiguration
  * Clarified that temperature setpoint changes only apply when zone is in MANUAL mode
  * Updated configuration examples to reflect API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->