### PR TITLE
docs: document llms.txt and llms-full.txt availability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,14 @@ We use 4 spaces for indentation. Our code is formatted with [Black](https://blac
 Before submitting a pull request, please make sure your code is formatted, linted,
 type-checked, and all tests pass.
 
+### AI-assisted development
+
+This project exposes [`llms.txt`](llms.txt) and [`llms-full.txt`](llms-full.txt) files
+at the repository root, following the [llms.txt standard](https://llmstxt.org/). These
+files contain the full project documentation in a format optimized for use with AI coding
+assistants. Point your AI tool at these files to give it full context about the library's
+API and usage patterns.
+
 ### Testing with real CAME servers
 
 The project includes tests that can be run against a real CAME Domotic server. These tests are skipped by default unless configured.

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ Once you are a bit more familiar with the library, you may want to explore the f
 resources too:
 
 - `API reference <https://aiocamedomotic.readthedocs.io/latest/api_reference.html>`_
+- `LLM-friendly docs <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms.txt>`_
+  (also available: `full version <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms-full.txt>`_)
 - `What's new (releases) <https://github.com/camedomotic-unofficial/aiocamedomotic/releases>`_
 - `Development roadmap <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap>`_
 - `Security Policy <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy>`_


### PR DESCRIPTION
## Summary
- Add a link to `llms.txt` and `llms-full.txt` in the README resource list
- Add an "AI-assisted development" subsection in CONTRIBUTING.md pointing to these files

## Test plan
- [ ] Verify Sphinx docs build without errors
- [ ] Confirm README renders correctly on GitHub with the new bullet point
- [ ] Confirm CONTRIBUTING.md renders correctly with the new section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new AI-friendly documentation resources to the guides section.
  * Expanded contributing guidelines with information about AI-assisted development resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->