### PR TITLE
chore: rebrand library name and update copyright year

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AIOCameDomotic is an unofficial Python library that provides an asynchronous API for interacting with CAME Domotic home automation systems. The library abstracts away the complexity of the CAME API, offers automatic session management, and is primarily developed for integration with Home Assistant but usable independently.
+AIOCameDomotic is a Python library that provides an asynchronous API for interacting with CAME Domotic home automation systems. The library abstracts away the complexity of the CAME API, offers automatic session management, and is primarily developed for integration with Home Assistant but usable independently.
 
 ## Build & Development Commands
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Welcome!
    :alt: Documentation status
 
 
-The **CAME Domotic Unofficial Library** (`aiocamedomotic <https://github.com/camedomotic-unofficial/aiocamedomotic>`_)
+The **CAME Domotic Library** (`aiocamedomotic <https://github.com/camedomotic-unofficial/aiocamedomotic>`_)
 provides a streamlined Python interface for interacting with CAME Domotic plants, much
 like the official
 `CAME Domotic app <https://www.came.com/global/itex/installers/solutions/domotica-e-termoregolazione/prodotti-compatibili-domotica/app-domotic-30>`_.

--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -12,11 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The **CAME Domotic Unofficial Library** provides a streamlined Python interface for
+The **CAME Domotic Library** provides a streamlined Python interface for
 interacting with CAME Domotic plants, much like the official *CAME Domotic app*.
 
 This library is designed to simplify the management of domotic devices by abstracting
 the complexities of the CAME Domotic API.
+
+Note:
+    This library is independently developed and is not affiliated with, endorsed by,
+    or supported by CAME. It may not be compatible with all CAME Domotic systems.
+    While this library is stable and publicly released, it comes with no guarantees.
+    Use at your own risk. This library is not intended for use in critical systems,
+    such as security or life-support systems.
 """
 
 from __future__ import annotations

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -16,12 +16,12 @@
 This module manages the HTTP interaction with the CAME Domotic API.
 
 Note:
-   As a consumer of the CAME Domotic Unofficial library, **it's quite unlikely that you
+   As a consumer of the CAME Domotic library, **it's quite unlikely that you
    will need to use this class directly**: you should use the ``CameDomoticAPI`` and the
    CameEntity classes instead.
 
    In case of special needs, consider requesting the implementation of the desired
-   feature in the CAME Domotic Unofficial library, or forking the library and implement
+   feature in the CAME Domotic library, or forking the library and implement
    the feature yourself.
 """
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ with open(_pyproject_path, "rb") as f:
 release = _pyproject["tool"]["poetry"]["version"]
 
 project = "aiocamedomotic"
-copyright = "2024, CAME Domotic Unofficial team"
+copyright = "2026, CAME Domotic Unofficial team"
 author = "fredericks1982"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 This guide will walk you through the steps to quickly start using the CAME Domotic
-Unofficial library in your projects. Before you begin, ensure you have:
+library in your projects. Before you begin, ensure you have:
 
 - Python 3.12, 3.13 or 3.14 installed on your system.
 - Access to a CAME Domotic server.
@@ -11,7 +11,7 @@ Installation
 ------------
 
 Use `pip <https://pip.pypa.io/en/stable/>`_ to install the latest version of the CAME
-Domotic Unofficial library and its dependencies:
+Domotic library and its dependencies:
 
 .. code-block:: bash
 
@@ -170,7 +170,7 @@ Let's go step by step:
             # Turn the light off
             await kitchen_lamp.async_set_status(LightStatus.OFF)
 
-Congratulations! You've successfully used the CAME Domotic Unofficial library to
+Congratulations! You've successfully used the CAME Domotic library to
 interact with your CAME Domotic server.
 
 Exploring further
@@ -179,4 +179,4 @@ Exploring further
 - For more detailed examples see :doc:`usage_examples`.
 - To check the technical specifications see the :doc:`api_reference`.
 
-Thank you for choosing the CAME Domotic Unofficial library. Happy automating!
+Thank you for choosing the CAME Domotic library. Happy automating!

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,7 +6,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-D22128.svg)](https://opensource.org/licenses/Apache-2.0)[![Python 3.12 | 3.13 | 3.14](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-417fb0.svg)](https://www.python.org)[![SonarCloud - Security Rating](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=security_rating)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=vulnerabilities)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Bugs](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=bugs)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![Documentation status](https://readthedocs.org/projects/aiocamedomotic/badge/?version=latest)](https://aiocamedomotic.readthedocs.io/en/latest/?badge=latest)
 
-The **CAME Domotic Unofficial Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
+The **CAME Domotic Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
 provides a streamlined Python interface for interacting with CAME Domotic plants, much
 like the official
 [CAME Domotic app](https://www.came.com/global/itex/installers/solutions/domotica-e-termoregolazione/prodotti-compatibili-domotica/app-domotic-30).
@@ -69,7 +69,7 @@ on GitHub.
 ## Getting started
 
 This guide will walk you through the steps to quickly start using the CAME Domotic
-Unofficial library in your projects. Before you begin, ensure you have:
+library in your projects. Before you begin, ensure you have:
 
 - Python 3.12, 3.13 or 3.14 installed on your system.
 - Access to a CAME Domotic server.
@@ -77,7 +77,7 @@ Unofficial library in your projects. Before you begin, ensure you have:
 ### Installation
 
 Use [pip](https://pip.pypa.io/en/stable/) to install the latest version of the CAME
-Domotic Unofficial library and its dependencies:
+Domotic library and its dependencies:
 
 ```bash
 pip install aiocamedomotic
@@ -226,7 +226,7 @@ Let’s go step by step:
        await kitchen_lamp.async_set_status(LightStatus.OFF)
    ```
 
-Congratulations! You’ve successfully used the CAME Domotic Unofficial library to
+Congratulations! You’ve successfully used the CAME Domotic library to
 interact with your CAME Domotic server.
 
 ### Exploring further
@@ -234,7 +234,7 @@ interact with your CAME Domotic server.
 - For more detailed examples see [Usage examples](#usage-examples).
 - To check the technical specifications see the [API Reference](#api-reference).
 
-Thank you for choosing the CAME Domotic Unofficial library. Happy automating!
+Thank you for choosing the CAME Domotic library. Happy automating!
 
 ## Usage examples
 
@@ -936,7 +936,7 @@ Create a CameDomoticAPI object.
   * **password** (*str*) – The password to use for the API.
   * **websession** (*aiohttp.ClientSession* *,* *optional*) – The aiohttp session to use for
     the API. If not provided, a new aiohttp.ClientSession will be created.
-  * **close_websession_on_disposal** (*bool* *,* *default False*) – 
+  * **close_websession_on_disposal** (*bool* *,* *default False*) –
 
     Controls whether the
     aiohttp session is closed when this object is disposed.
@@ -3302,12 +3302,12 @@ See also the exception hierarchy mapping for Home Assistant integrations:
 This module manages the HTTP interaction with the CAME Domotic API.
 
 ##### NOTE
-As a consumer of the CAME Domotic Unofficial library, **it’s quite unlikely that you
+As a consumer of the CAME Domotic library, **it’s quite unlikely that you
 will need to use this class directly**: you should use the `CameDomoticAPI` and the
 CameEntity classes instead.
 
 In case of special needs, consider requesting the implementation of the desired
-feature in the CAME Domotic Unofficial library, or forking the library and implement
+feature in the CAME Domotic library, or forking the library and implement
 the feature yourself.
 
 #### *class* aiocamedomotic.auth.Auth(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = False)

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-D22128.svg)](https://opensource.org/licenses/Apache-2.0)[![Python 3.12 | 3.13 | 3.14](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-417fb0.svg)](https://www.python.org)[![SonarCloud - Security Rating](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=security_rating)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=vulnerabilities)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Bugs](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=bugs)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![Documentation status](https://readthedocs.org/projects/aiocamedomotic/badge/?version=latest)](https://aiocamedomotic.readthedocs.io/en/latest/?badge=latest)
 
-The **CAME Domotic Unofficial Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
+The **CAME Domotic Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
 provides a streamlined Python interface for interacting with CAME Domotic plants, much
 like the official
 [CAME Domotic app](https://www.came.com/global/itex/installers/solutions/domotica-e-termoregolazione/prodotti-compatibili-domotica/app-domotic-30).
@@ -69,7 +69,7 @@ on GitHub.
 ## Getting started
 
 This guide will walk you through the steps to quickly start using the CAME Domotic
-Unofficial library in your projects. Before you begin, ensure you have:
+library in your projects. Before you begin, ensure you have:
 
 - Python 3.12, 3.13 or 3.14 installed on your system.
 - Access to a CAME Domotic server.
@@ -77,7 +77,7 @@ Unofficial library in your projects. Before you begin, ensure you have:
 ### Installation
 
 Use [pip](https://pip.pypa.io/en/stable/) to install the latest version of the CAME
-Domotic Unofficial library and its dependencies:
+Domotic library and its dependencies:
 
 ```bash
 pip install aiocamedomotic
@@ -226,7 +226,7 @@ Let’s go step by step:
        await kitchen_lamp.async_set_status(LightStatus.OFF)
    ```
 
-Congratulations! You’ve successfully used the CAME Domotic Unofficial library to
+Congratulations! You’ve successfully used the CAME Domotic library to
 interact with your CAME Domotic server.
 
 ### Exploring further
@@ -234,7 +234,7 @@ interact with your CAME Domotic server.
 - For more detailed examples see [Usage examples](#usage-examples).
 - To check the technical specifications see the [API Reference](#api-reference).
 
-Thank you for choosing the CAME Domotic Unofficial library. Happy automating!
+Thank you for choosing the CAME Domotic library. Happy automating!
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove "Unofficial" from the library name across documentation, code, and LLM reference files
- Add a disclaimer note in `__init__.py` clarifying independent development status
- Update copyright year to 2026

## Test plan
- [x] All existing tests pass (379 passed, 21 skipped)
- [x] Pre-commit hooks pass