### PR TITLE
fix: resolve asyncio.Lock deadlock in async_keep_alive

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -356,6 +356,7 @@ class Auth:
         skip_ack_check: bool = False,
         command_type: str = _CommandType.DATA_REQUEST.value,
         additional_payload: dict[str, Any] | None = None,
+        _caller_holds_lock: bool = False,
     ) -> dict[str, Any]:
         """Send a command to the CAME Domotic server.
 
@@ -371,6 +372,11 @@ class Auth:
                 (default: "sl_data_req").
             additional_payload (dict, optional): additional key-value pairs to include
                 in the request payload (default: None).
+            _caller_holds_lock (bool, optional): when True, the caller already
+                holds ``self._lock`` and has validated the session, so this
+                method uses ``self.client_id`` directly instead of calling
+                ``async_get_valid_client_id()`` (which would deadlock).
+                For internal use only (default: False).
 
         Returns:
             dict: the JSON response from the server.
@@ -390,6 +396,8 @@ class Auth:
             _CommandType.CHANGE_USER_PASSWORD_REQUEST.value,
         ):
             client_id = ""
+        elif _caller_holds_lock:
+            client_id = self.client_id
         else:
             client_id = await self.async_get_valid_client_id()
 
@@ -670,7 +678,9 @@ class Auth:
         """
         LOGGER.debug("Sending keep-alive to '%s'", self.host)
         await self.async_send_command(
-            {}, command_type=_CommandType.KEEP_ALIVE_REQUEST.value
+            {},
+            command_type=_CommandType.KEEP_ALIVE_REQUEST.value,
+            _caller_holds_lock=True,
         )
 
     @handle_came_domotic_errors

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -943,7 +943,9 @@ class TestAuthKeepAlive:
     ):
         await auth_instance.async_keep_alive()
         mock_is_session_valid.assert_called_once()
-        mock_send_command.assert_called_once_with({}, command_type="sl_keep_alive_req")
+        mock_send_command.assert_called_once_with(
+            {}, command_type="sl_keep_alive_req", _caller_holds_lock=True
+        )
 
     @patch.object(Auth, "is_session_valid", return_value=True)
     @patch.object(
@@ -958,7 +960,9 @@ class TestAuthKeepAlive:
         with pytest.raises(CameDomoticServerError):
             await auth_instance.async_keep_alive()
         mock_is_session_valid.assert_called_once()
-        mock_send_command.assert_called_once_with({}, command_type="sl_keep_alive_req")
+        mock_send_command.assert_called_once_with(
+            {}, command_type="sl_keep_alive_req", _caller_holds_lock=True
+        )
 
     @patch.object(Auth, "is_session_valid", return_value=False)
     @patch.object(Auth, "_async_perform_login", new_callable=AsyncMock)

--- a/tests/aiocamedomotic/test_real.py
+++ b/tests/aiocamedomotic/test_real.py
@@ -867,6 +867,57 @@ async def test_user_management_lifecycle(
     print(f"Confirmed: '{test_username}' is no longer in the users list")
 
 
+@pytest.mark.timeout(5)
+async def test_consecutive_scenario_then_light_list(
+    api_instance_real: CameDomoticAPI,
+):
+    """Tests two consecutive API calls: scenario list followed by light list."""
+    print("\nFetching scenarios...")
+    scenarios = await api_instance_real.async_get_scenarios()
+    print(f"Got {len(scenarios)} scenario(s)")
+    for s in scenarios:
+        print(f"  Scenario ID={s.id}, Name='{s.name}'")
+
+    print("\nSending keep-alive...")
+    await api_instance_real.auth.async_keep_alive()
+    print("Keep-alive succeeded.")
+
+    print("\nFetching lights (immediately after scenarios)...")
+    lights = await api_instance_real.async_get_lights()
+    print(f"Got {len(lights)} light(s)")
+    for light in lights:
+        print(f"  Light act_id={light.act_id}, Name='{light.name}'")
+
+    assert scenarios is not None
+    assert lights is not None
+    print("\nBoth consecutive calls completed successfully.")
+
+
+async def test_async_ping(api_instance_real: CameDomoticAPI):
+    """Tests server info retrieval followed by a ping with latency measurement."""
+    print("\nFetching server info...")
+    server_info = await api_instance_real.async_get_server_info()
+    print(
+        f"Server Info - Keycode: {server_info.keycode}, "
+        f"Swver: {server_info.swver}, Board: {server_info.board}"
+    )
+
+    print("Pinging server...")
+    latency_ms = await api_instance_real.async_ping()
+    print(f"Ping successful — round-trip latency: {latency_ms:.1f} ms")
+
+    assert isinstance(latency_ms, float)
+    assert latency_ms >= 0
+
+
+async def test_async_keep_alive(api_instance_real: CameDomoticAPI):
+    """Tests that async_keep_alive succeeds on a live session."""
+    print("\nCalling async_keep_alive...")
+    await api_instance_real.auth.async_keep_alive()
+    print("Keep-alive succeeded — session is still valid")
+    assert api_instance_real.auth.is_session_valid()
+
+
 async def test_autodiscovery(real_server_config):
     """Tests the two-step autodiscovery: MAC prefix check + API verification."""
     mac_address = real_server_config["came_server"].get("mac_address", "")


### PR DESCRIPTION
## Summary
- `async_keep_alive()` acquired `self._lock` then called `async_send_command()` → `async_get_valid_client_id()`, which attempted to re-acquire the same non-reentrant `asyncio.Lock`, causing a deadlock
- This affected `async_keep_alive()`, `async_ping()`, and `async_login()` (when session was still valid) — any call after a prior API command would hang indefinitely
- Added `_caller_holds_lock` parameter to `async_send_command()` so `_async_perform_keep_alive()` bypasses the redundant lock acquisition

## Test plan
- [x] Unit tests updated and passing (383 passed)
- [x] Verified fix on real server: `async_keep_alive()` after `async_get_scenarios()` succeeds
- [x] Verified fix on real server: `async_ping()` after `async_get_server_info()` succeeds
- [x] Added `test_consecutive_scenario_then_light_list` real-server test covering the scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keep-alive mechanism to prevent potential deadlocks during concurrent operations.

* **Tests**
  * Added tests for keep-alive functionality, server ping latency, and sequential API operations to enhance reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->