### PR TITLE
docs: remove status updates management from roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,10 +92,6 @@ considered for future development once real-world testing is possible:
 - **Cameras (TVCC)**: Camera listing (entirely unverified).
 - **Security system**: Area/scenario management and alarm control (entirely unverified).
 - **Maps**: Floor plan/map retrieval (entirely unverified).
-- **Status updates management**: Automatic long-polling loop with event callbacks,
-  push-based state synchronization, and automatic `plant_update_ind` handling for full
-  cache invalidation. Typed update classes and filtering are already available (v1.5);
-  this item covers the higher-level automation layer on top.
 - **Infrastructure improvements**: Automated keep-alive scheduling, per-actuator scope
   queries, and connection resilience improvements.
 


### PR DESCRIPTION
## Summary
- Remove "Status updates management" from the roadmap's future considerations
- The API primitives (typed update classes, `UpdateList` filtering, long-polling support) are already shipped
- The higher-level automation layer (automatic long-polling loop, event callbacks, cache invalidation) belongs in the integration consumer, not in this API wrapper library

## Test plan
- [ ] Verify ROADMAP.md renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a previously planned feature consideration from the public roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->