### PR TITLE
Add AnalogSensorType usage examples and expand enum tests

### DIFF
--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -31,8 +31,8 @@ and controlling devices, and monitoring real-time changes. For a minimal
 
         from aiocamedomotic import CameDomoticAPI
         from aiocamedomotic.models import (
-            DeviceType, DigitalInputStatus, LightStatus, LightType,
-            OpeningStatus, ScenarioStatus, ThermoZoneFanSpeed,
+            AnalogSensorType, DeviceType, DigitalInputStatus, LightStatus,
+            LightType, OpeningStatus, ScenarioStatus, ThermoZoneFanSpeed,
             ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
             DeviceUpdate, LightUpdate, OpeningUpdate, ThermoZoneUpdate,
             ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
@@ -462,22 +462,50 @@ Analog sensors
 ^^^^^^^^^^^^^^
 
 Analog sensors provide top-level readings (temperature, humidity, pressure)
-from the thermoregulation system:
+from the thermoregulation system. Each sensor carries an ``AnalogSensorType``
+that identifies the kind of measurement it represents.
+
+**Fetching and inspecting sensors:**
 
 .. code-block:: python
+
+    from aiocamedomotic.models import AnalogSensorType
 
     sensors = await api.async_get_analog_sensors()
 
     for sensor in sensors:
-        print(f"Name: {sensor.name}, Value: {sensor.value}, Unit: {sensor.unit}")
+        print(
+            f"Name: {sensor.name}, Type: {sensor.sensor_type}, "
+            f"Value: {sensor.value}, Unit: {sensor.unit}"
+        )
 
 Example output:
 
 .. code-block:: text
 
-    Name: Outdoor Temperature, Value: 21.5, Unit: °C
-    Name: Indoor Humidity, Value: 55, Unit: %
-    Name: Barometric Pressure, Value: 1013, Unit: hPa
+    Name: Outdoor Temperature, Type: AnalogSensorType.TEMPERATURE, Value: 21.5, Unit: C
+    Name: Indoor Humidity, Type: AnalogSensorType.HUMIDITY, Value: 55, Unit: %
+    Name: Barometric Pressure, Type: AnalogSensorType.PRESSURE, Value: 1013, Unit: hPa
+
+**Filtering by sensor type:**
+
+.. code-block:: python
+
+    # Get only temperature sensors
+    temp_sensors = [
+        s for s in sensors if s.sensor_type == AnalogSensorType.TEMPERATURE
+    ]
+    for s in temp_sensors:
+        print(f"{s.name}: {s.value}°{s.unit}")
+
+    # Find a specific sensor by ID
+    outdoor = next((s for s in sensors if s.act_id == 100), None)
+
+.. note::
+    Temperature sensor values are automatically scaled from the raw
+    integer-times-10 representation (e.g. ``215`` becomes ``21.5``).
+    Humidity and pressure values are returned as-is. The ``sensor_type``
+    property (an ``AnalogSensorType`` enum) determines the scaling behavior.
 
 Digital inputs (binary sensors)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -958,7 +958,7 @@ Create a CameDomoticAPI object.
   * **password** (*str*) – The password to use for the API.
   * **websession** (*aiohttp.ClientSession* *,* *optional*) – The aiohttp session to use for
     the API. If not provided, a new aiohttp.ClientSession will be created.
-  * **close_websession_on_disposal** (*bool* *,* *default False*) – 
+  * **close_websession_on_disposal** (*bool* *,* *default False*) –
 
     Controls whether the
     aiohttp session is closed when this object is disposed.

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -2377,6 +2377,16 @@ class TestAnalogSensorType:
         assert AnalogSensorType("temperature") == AnalogSensorType.TEMPERATURE
         assert AnalogSensorType("humidity") == AnalogSensorType.HUMIDITY
         assert AnalogSensorType("pressure") == AnalogSensorType.PRESSURE
+        assert AnalogSensorType("unknown") == AnalogSensorType.UNKNOWN
+
+    def test_members(self):
+        members = set(AnalogSensorType)
+        assert members == {
+            AnalogSensorType.TEMPERATURE,
+            AnalogSensorType.HUMIDITY,
+            AnalogSensorType.PRESSURE,
+            AnalogSensorType.UNKNOWN,
+        }
 
     def test_invalid_value(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Enhanced the analog sensors section in `usage_examples.rst` to document the `AnalogSensorType` enum: added `AnalogSensorType` to the import block, showcased the `sensor_type` property, demonstrated filtering sensors by type, and added a note explaining temperature value scaling behavior
- Added missing `AnalogSensorType` enum tests: `test_from_value` now covers the `UNKNOWN` member, and a new `test_members` test verifies enum membership/iteration

## Test plan
- [x] All existing tests pass (`pytest`)
- [x] New `TestAnalogSensorType::test_members` and updated `test_from_value` pass
- [x] Sphinx docs build without errors
- [x] All pre-commit hooks pass (ruff, mypy, bandit, codespell, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded usage examples to demonstrate AnalogSensorType and sensor_type functionality
  * Added documentation for sensor scaling behavior (temperature scaled 10x; humidity and pressure returned as-is)
  * Included new code examples for filtering and selecting sensors by ID

* **New Features**
  * AnalogSensorType enum now includes UNKNOWN member to handle unsupported sensor types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->