### PR TITLE
Fix relay model optional property safety and docs cleanup

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -45,6 +45,7 @@ from .models import (
     Light,
     Opening,
     PlantTopology,
+    Relay,
     Room,
     Scenario,
     ServerInfo,
@@ -520,6 +521,38 @@ class CameDomoticAPI:
         openings_data = json_response.get("array", []) or []
         LOGGER.info("Retrieved %d opening(s)", len(openings_data))
         return [Opening(opening_data, self.auth) for opening_data in openings_data]
+
+    async def async_get_relays(self) -> list[Relay]:
+        """Get the list of all relay devices defined on the server.
+
+        Relays are simple on/off switches that can be controlled remotely.
+
+        .. note::
+            This method uses API commands documented in the CAME API
+            specification but not yet verified against a real server.
+            Behaviour may differ across firmware versions.
+
+        Returns:
+            list[Relay]: List of relays.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching relays list")
+        payload = {
+            "cmd_name": _CommandName.RELAYS_LIST.value,
+            "topologic_scope": _TopologicScope.PLANT.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.RELAYS_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        relays_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d relay(s)", len(relays_list))
+        return [Relay(relay_data, self.auth) for relay_data in relays_list]
 
     async def async_get_scenarios(self) -> list[Scenario]:
         """Get the list of all scenarios defined on the server.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -159,6 +159,7 @@ class _CommandName(Enum):
     LIGHT_SWITCH = "light_switch_req"
     OPENING_MOVE = "opening_move_req"
     SCENARIO_ACTIVATION = "scenario_activation_req"
+    RELAY_ACTIVATION = "relay_activation_req"
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
     THERMO_SEASON = "thermo_season_req"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_req"
@@ -239,6 +240,7 @@ class UpdateIndicator(Enum):
     Values:
         - LIGHT ("light_switch_ind")
         - OPENING ("opening_move_ind")
+        - RELAY ("relay_status_ind")
         - THERMOSTAT ("thermo_zone_info_ind")
         - DIGITAL_INPUT ("digitalin_status_ind")
         - SCENARIO_STATUS ("scenario_status_ind")
@@ -258,6 +260,7 @@ class UpdateIndicator(Enum):
     # Traffic-observed names
     LIGHT = "light_switch_ind"
     OPENING = "opening_move_ind"
+    RELAY = "relay_status_ind"
     THERMOSTAT = "thermo_zone_info_ind"
     DIGITAL_INPUT = "digitalin_status_ind"
     SCENARIO_STATUS = "scenario_status_ind"
@@ -285,6 +288,7 @@ _UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
     "scenario_status_ind": DeviceType.SCENARIO,
     "scenario_activation_ind": DeviceType.SCENARIO,
     "meter_instant_power_ind": DeviceType.ENERGY_SENSOR,
+    "relay_status_ind": DeviceType.GENERIC_RELAY,
     # API_reference.md variant names (firmware compatibility)
     "light_update_ind": DeviceType.LIGHT,
     "opening_update_ind": DeviceType.OPENING,

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -38,6 +38,7 @@ from .digital_input import (  # noqa: F401
 )
 from .light import Light, LightStatus, LightType  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
+from .relay import Relay, RelayStatus  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
 from .thermo_zone import (  # noqa: F401
     AnalogSensor,
@@ -54,6 +55,7 @@ from .update import (  # noqa: F401
     LightUpdate,
     OpeningUpdate,
     PlantUpdate,
+    RelayUpdate,
     ScenarioUpdate,
     ThermoZoneUpdate,
     UpdateList,
@@ -82,6 +84,9 @@ __all__ = [
     "OpeningUpdate",
     "PlantTopology",
     "PlantUpdate",
+    "Relay",
+    "RelayStatus",
+    "RelayUpdate",
     "Room",
     "Scenario",
     "ScenarioStatus",

--- a/aiocamedomotic/models/relay.py
+++ b/aiocamedomotic/models/relay.py
@@ -47,6 +47,8 @@ class RelayStatus(Enum):
     Allowed values are:
         - OFF (0)
         - ON (1)
+        - UNKNOWN (-1): Returned when the server reports an unrecognised
+          status value. Not a valid target for ``async_set_status``.
     """
 
     OFF = 0
@@ -92,7 +94,7 @@ class Relay(CameEntity):
     @property
     def floor_ind(self) -> int:
         """Floor index of the relay."""
-        return self.raw_data["floor_ind"]
+        return self.raw_data.get("floor_ind", 0)
 
     @property
     def name(self) -> str:
@@ -102,7 +104,7 @@ class Relay(CameEntity):
     @property
     def room_ind(self) -> int:
         """Room index of the relay."""
-        return self.raw_data["room_ind"]
+        return self.raw_data.get("room_ind", 0)
 
     @property
     def status(self) -> RelayStatus:

--- a/aiocamedomotic/models/relay.py
+++ b/aiocamedomotic/models/relay.py
@@ -1,0 +1,157 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic relay entity models and control functionality.
+
+This module implements the classes for working with generic relays in a CAME
+Domotic system. Generic relays are simple on/off switches that can be
+controlled remotely. They provide binary state control without brightness,
+color, or position capabilities.
+
+.. note::
+    The relay API commands (``relays_list_req``, ``relay_activation_req``)
+    are documented in the CAME API specification but have not been verified
+    against a real server. Behaviour may differ across firmware versions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ..auth import Auth
+from ..const import _CommandName
+from ..utils import (
+    LOGGER,
+    EntityValidator,
+)
+from .base import CameEntity
+
+
+class RelayStatus(Enum):
+    """Status of a relay.
+
+    Allowed values are:
+        - OFF (0)
+        - ON (1)
+    """
+
+    OFF = 0
+    ON = 1
+    UNKNOWN = -1
+
+
+@dataclass
+class Relay(CameEntity):
+    """
+    Relay entity in the CameDomotic API.
+
+    Represents a generic relay (simple on/off switch) in the CAME Domotic
+    system. Provides properties to read relay attributes and a method to
+    control relay state.
+
+    Raises:
+        ValueError: If ``name`` or ``act_id`` keys are missing from the
+            input data or the auth argument is not an instance of the
+            expected ``Auth`` class.
+    """
+
+    raw_data: dict[str, Any]
+    auth: Auth
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def act_id(self) -> int:
+        """ID of the relay."""
+        return self.raw_data["act_id"]
+
+    @property
+    def floor_ind(self) -> int:
+        """Floor index of the relay."""
+        return self.raw_data["floor_ind"]
+
+    @property
+    def name(self) -> str:
+        """Name of the relay."""
+        return self.raw_data["name"]
+
+    @property
+    def room_ind(self) -> int:
+        """Room index of the relay."""
+        return self.raw_data["room_ind"]
+
+    @property
+    def status(self) -> RelayStatus:
+        """Status of the relay. Allowed values are OFF (0) and ON (1)."""
+        try:
+            return RelayStatus(self.raw_data["status"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown relay status '%s' encountered for relay '%s' (ID: %s). "
+                "Returning RelayStatus.UNKNOWN. Please report this "
+                "to the library developers.",
+                self.raw_data.get("status"),
+                self.name,
+                self.act_id,
+            )
+            return RelayStatus.UNKNOWN
+
+    async def async_set_status(self, status: RelayStatus) -> None:
+        """Control the relay.
+
+        Args:
+            status (RelayStatus): Desired relay status (ON or OFF).
+
+        Raises:
+            ValueError: If ``status`` is ``RelayStatus.UNKNOWN``.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if status == RelayStatus.UNKNOWN:
+            raise ValueError("Cannot set relay status to UNKNOWN")
+
+        await self.auth.async_get_valid_client_id()
+        LOGGER.debug(
+            "User authenticated, sending 'relay_activation_req' command to the API."
+        )
+
+        payload = {
+            "act_id": self.act_id,
+            "cmd_name": _CommandName.RELAY_ACTIVATION.value,
+            "wanted_status": status.value,
+        }
+        await self.auth.async_send_command(payload)
+
+        # Update the status of the relay if everything went as expected
+        self.raw_data["status"] = status.value
+
+        LOGGER.info(
+            "Relay '%s' (ID: %s) set to %s",
+            self.name,
+            self.act_id,
+            status.name,
+        )

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -33,6 +33,7 @@ from ..utils import LOGGER
 from .base import CameEntity
 from .light import LightStatus, LightType
 from .opening import OpeningStatus
+from .relay import RelayStatus
 from .scenario import ScenarioStatus
 from .thermo_zone import (
     ThermoZoneFanSpeed,
@@ -199,6 +200,36 @@ class OpeningUpdate(DeviceUpdate):
     def device_id(self) -> int | None:
         """For openings the primary ID is ``open_act_id``."""
         return self.raw_data.get("open_act_id")
+
+
+@dataclass
+class RelayUpdate(DeviceUpdate):
+    """Typed update for a relay device (``relay_status_ind`` /
+    ``relay_update_ind``).
+    """
+
+    @property
+    def act_id(self) -> int:
+        """Relay actuator ID."""
+        return self.raw_data["act_id"]
+
+    @property
+    def floor_ind(self) -> int:
+        """Floor index."""
+        return self.raw_data.get("floor_ind", 0)
+
+    @property
+    def room_ind(self) -> int:
+        """Room index."""
+        return self.raw_data.get("room_ind", 0)
+
+    @property
+    def status(self) -> RelayStatus:
+        """Relay status (OFF, ON)."""
+        try:
+            return RelayStatus(self.raw_data["status"])
+        except (ValueError, KeyError):
+            return RelayStatus.UNKNOWN
 
 
 @dataclass
@@ -380,6 +411,8 @@ _INDICATOR_TO_UPDATE_CLASS: dict[str, type[DeviceUpdate]] = {
     "scenario_status_ind": ScenarioUpdate,
     "scenario_activation_ind": ScenarioUpdate,
     "scenario_user_ind": ScenarioUpdate,
+    "relay_status_ind": RelayUpdate,
+    "relay_update_ind": RelayUpdate,
     "digitalin_status_ind": DigitalInputUpdate,
     "digitalin_update_ind": DigitalInputUpdate,
     "plant_update_ind": PlantUpdate,

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -38,6 +38,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.base
    :members:
 
+.. automodule:: aiocamedomotic.models.digital_input
+   :members:
+
 .. automodule:: aiocamedomotic.models.light
    :members:
 
@@ -51,9 +54,6 @@ Entity models
    :members:
 
 .. automodule:: aiocamedomotic.models.thermo_zone
-   :members:
-
-.. automodule:: aiocamedomotic.models.digital_input
    :members:
 
 .. automodule:: aiocamedomotic.models.update

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -44,6 +44,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.opening
    :members:
 
+.. automodule:: aiocamedomotic.models.relay
+   :members:
+
 .. automodule:: aiocamedomotic.models.scenario
    :members:
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -32,10 +32,11 @@ and controlling devices, and monitoring real-time changes. For a minimal
         from aiocamedomotic import CameDomoticAPI
         from aiocamedomotic.models import (
             AnalogSensorType, DeviceType, DigitalInputStatus, LightStatus,
-            LightType, OpeningStatus, ScenarioStatus, ThermoZoneFanSpeed,
+            LightType, OpeningStatus, RelayStatus, ScenarioStatus,
+            ThermoZoneFanSpeed,
             ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
-            DeviceUpdate, LightUpdate, OpeningUpdate, ThermoZoneUpdate,
-            ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
+            DeviceUpdate, LightUpdate, OpeningUpdate, RelayUpdate,
+            ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
         )
         from aiocamedomotic.errors import (
             CameDomoticError,
@@ -231,6 +232,9 @@ You can use the features list to decide which device APIs to call:
 
     if "openings" in server_info.features:
         openings = await api.async_get_openings()
+
+    if "relays" in server_info.features:
+        relays = await api.async_get_relays()
 
     if "thermoregulation" in server_info.features:
         zones = await api.async_get_thermo_zones()
@@ -548,6 +552,53 @@ Example output:
     Some digital inputs do not report a ``status`` until their first state
     change. In that case, ``status`` returns ``DigitalInputStatus.UNKNOWN``.
 
+Relays
+^^^^^^
+
+Relays are simple on/off switches that can be controlled remotely. Unlike
+lights, they have no brightness or color capabilities.
+
+**Fetching and inspecting relays:**
+
+.. code-block:: python
+
+    from aiocamedomotic.models import RelayStatus
+
+    relays = await api.async_get_relays()
+
+    for relay in relays:
+        print(f"ID: {relay.act_id}, Name: {relay.name}, Status: {relay.status}")
+
+Example output:
+
+.. code-block:: text
+
+    ID: 31, Name: Garden Pump, Status: RelayStatus.ON
+    ID: 32, Name: Gate Motor, Status: RelayStatus.OFF
+
+**Finding a specific relay:**
+
+.. code-block:: python
+
+    # By ID
+    pump = next((r for r in relays if r.act_id == 31), None)
+
+    # By name
+    gate = next((r for r in relays if r.name == "Gate Motor"), None)
+
+**Controlling relays:**
+
+.. code-block:: python
+
+    if pump:
+        await pump.async_set_status(RelayStatus.ON)
+        await pump.async_set_status(RelayStatus.OFF)
+
+.. note::
+    The relay API commands are documented in the CAME API specification but
+    have not been verified against a real server. If you encounter unexpected
+    behaviour, please report it to the library developers.
+
 
 Monitoring real-time updates
 ----------------------------
@@ -657,6 +708,9 @@ compatibility. For **typed** update objects with convenient properties, use
         elif isinstance(update, DigitalInputUpdate):
             print(f"Input '{update.name}': status={update.status}, addr={update.addr}")
 
+        elif isinstance(update, RelayUpdate):
+            print(f"Relay '{update.name}': {update.status.name}")
+
         elif isinstance(update, PlantUpdate):
             print("Plant configuration changed, re-fetching devices...")
 
@@ -674,6 +728,7 @@ happens, all locally cached device lists must be discarded and re-fetched:
     if updates.has_plant_update:
         lights = await api.async_get_lights()
         openings = await api.async_get_openings()
+        relays = await api.async_get_relays()
         scenarios = await api.async_get_scenarios()
         thermo_zones = await api.async_get_thermo_zones()
         sensors = await api.async_get_analog_sensors()

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -181,6 +181,30 @@ def light_data_rgb():
 
 
 @pytest.fixture
+def relay_data_on():
+    """Mock data for a relay that is ON."""
+    return {
+        "act_id": 31,
+        "name": "Test Relay",
+        "status": 1,
+        "floor_ind": 2,
+        "room_ind": 3,
+    }
+
+
+@pytest.fixture
+def relay_data_off():
+    """Mock data for a relay that is OFF."""
+    return {
+        "act_id": 32,
+        "name": "Test Relay Off",
+        "status": 0,
+        "floor_ind": 1,
+        "room_ind": 4,
+    }
+
+
+@pytest.fixture
 def opening_data_shutter_stopped():
     """Mock data for a stopped shutter opening."""
     return {

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -36,6 +36,7 @@ from aiocamedomotic.models import (
     Light,
     Opening,
     PlantTopology,
+    Relay,
     Room,
     Scenario,
     ServerInfo,
@@ -845,6 +846,124 @@ class TestAPIOpenings:
         assert len(openings) == 1
         assert openings[0].status.value == -1  # OpeningStatus.UNKNOWN
         assert openings[0].type.value == -1  # OpeningType.UNKNOWN
+
+
+class TestAPIRelays:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "act_id": 31,
+                    "floor_ind": 2,
+                    "name": "relay_Garden",
+                    "room_ind": 3,
+                    "status": 1,
+                },
+                {
+                    "act_id": 32,
+                    "floor_ind": 1,
+                    "name": "relay_Gate",
+                    "room_ind": 4,
+                    "status": 0,
+                },
+            ],
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        relays = await api.async_get_relays()
+        assert len(relays) == 2
+        assert isinstance(relays[0], Relay)
+        assert isinstance(relays[1], Relay)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays_empty_array(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        relays = await api.async_get_relays()
+        assert len(relays) == 0
+        assert isinstance(relays, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        relays = await api.async_get_relays()
+        assert len(relays) == 0
+        assert isinstance(relays, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays_null_array(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        relays = await api.async_get_relays()
+        assert relays == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays_missing_act_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "floor_ind": 2,
+                    "name": "relay_Garden",
+                    "room_ind": 3,
+                    "status": 1,
+                }
+            ],
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            await api.async_get_relays()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_relays_missing_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [
+                {
+                    "act_id": 31,
+                    "floor_ind": 2,
+                    "room_ind": 3,
+                    "status": 1,
+                }
+            ],
+            "cmd_name": "relays_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            await api.async_get_relays()
 
 
 class TestAPIScenarios:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -49,6 +49,9 @@ from aiocamedomotic.models import (
     OpeningType,
     OpeningUpdate,
     PlantUpdate,
+    Relay,
+    RelayStatus,
+    RelayUpdate,
     Room,
     Scenario,
     ScenarioStatus,
@@ -112,6 +115,9 @@ class TestDeviceType:
         assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_status_ind"] == DeviceType.SCENARIO
         assert (
             _UPDATE_CMD_TO_DEVICE_TYPE["scenario_activation_ind"] == DeviceType.SCENARIO
+        )
+        assert (
+            _UPDATE_CMD_TO_DEVICE_TYPE["relay_status_ind"] == DeviceType.GENERIC_RELAY
         )
         assert (
             _UPDATE_CMD_TO_DEVICE_TYPE["meter_instant_power_ind"]
@@ -587,6 +593,50 @@ class TestDeviceUpdate:
         assert isinstance(update, OpeningUpdate)
         assert update.status == OpeningStatus.UNKNOWN
 
+    def test_parse_relay_update(self):
+        raw = {
+            "cmd_name": "relay_status_ind",
+            "act_id": 31,
+            "name": "Garden Pump",
+            "floor_ind": 2,
+            "room_ind": 3,
+            "status": 1,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, RelayUpdate)
+        assert update.act_id == 31
+        assert update.name == "Garden Pump"
+        assert update.floor_ind == 2
+        assert update.room_ind == 3
+        assert update.status == RelayStatus.ON
+        assert update.device_type == DeviceType.GENERIC_RELAY
+        assert update.device_id == 31
+        assert update.update_indicator == UpdateIndicator.RELAY
+
+    def test_parse_relay_update_legacy(self):
+        raw = {
+            "cmd_name": "relay_update_ind",
+            "act_id": 32,
+            "name": "Gate Motor",
+            "status": 0,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, RelayUpdate)
+        assert update.act_id == 32
+        assert update.status == RelayStatus.OFF
+        assert update.update_indicator == UpdateIndicator.RELAY_LEGACY
+
+    def test_parse_relay_update_unknown_status(self):
+        raw = {
+            "cmd_name": "relay_status_ind",
+            "act_id": 1,
+            "name": "Test",
+            "status": 99,
+        }
+        update = parse_update(raw)
+        assert isinstance(update, RelayUpdate)
+        assert update.status == RelayStatus.UNKNOWN
+
     def test_parse_thermo_zone_update(self):
         raw = {
             "cmd_name": "thermo_zone_info_ind",
@@ -756,6 +806,10 @@ class TestDeviceUpdate:
                 {"cmd_name": "thermo_update_ind", "act_id": 1, "temp_dec": 200}
             ),
             ThermoZoneUpdate,
+        )
+        assert isinstance(
+            parse_update({"cmd_name": "relay_update_ind", "act_id": 1, "status": 0}),
+            RelayUpdate,
         )
         assert isinstance(
             parse_update(
@@ -1843,6 +1897,123 @@ class TestOpening:
             ValueError, match="'auth' must be an instance of Auth, got dict"
         ):
             Opening(opening_data, {"fake": "auth"})
+
+
+class TestRelay:
+    def test_initialization(self, relay_data_on, auth_instance):
+        relay = Relay(relay_data_on, auth_instance)
+        assert relay.raw_data == relay_data_on
+        assert relay.auth == auth_instance
+
+        # Test post_init validation - missing act_id
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            Relay({"name": "Test"}, auth_instance)
+
+        # Test post_init validation - missing name
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            Relay({"act_id": 1}, auth_instance)
+
+    def test_properties(self, relay_data_on, auth_instance):
+        relay = Relay(relay_data_on, auth_instance)
+        assert relay.act_id == relay_data_on["act_id"]
+        assert relay.floor_ind == relay_data_on["floor_ind"]
+        assert relay.name == relay_data_on["name"]
+        assert relay.room_ind == relay_data_on["room_ind"]
+        assert relay.status == RelayStatus(relay_data_on["status"])
+
+    def test_properties_off(self, relay_data_off, auth_instance):
+        relay = Relay(relay_data_off, auth_instance)
+        assert relay.act_id == 32
+        assert relay.status == RelayStatus.OFF
+
+    def test_unknown_status(self, auth_instance):
+        unknown_relay_data = {
+            "act_id": 1,
+            "name": "Unknown Relay",
+            "status": 99,
+            "floor_ind": 2,
+            "room_ind": 3,
+        }
+
+        relay = Relay(unknown_relay_data, auth_instance)
+
+        assert relay.raw_data == unknown_relay_data
+        assert relay.name == "Unknown Relay"
+        assert relay.status == RelayStatus.UNKNOWN
+        assert relay.act_id == 1
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        relay_data_off,
+        auth_instance,
+    ):
+        relay = Relay(relay_data_off, auth_instance)
+
+        # Turn ON
+        await relay.async_set_status(RelayStatus.ON)
+        mock_send_command.assert_called_once()
+        payload = mock_send_command.call_args[0][0]
+        assert payload["act_id"] == relay_data_off["act_id"]
+        assert payload["cmd_name"] == "relay_activation_req"
+        assert payload["wanted_status"] == RelayStatus.ON.value
+        assert relay.status == RelayStatus.ON
+
+        # Turn OFF
+        await relay.async_set_status(RelayStatus.OFF)
+        assert mock_send_command.call_count == 2
+        payload = mock_send_command.call_args[0][0]
+        assert payload["wanted_status"] == RelayStatus.OFF.value
+        assert relay.status == RelayStatus.OFF
+
+    @pytest.mark.asyncio
+    async def test_async_set_status_unknown_raises(self, relay_data_on, auth_instance):
+        relay = Relay(relay_data_on, auth_instance)
+
+        with pytest.raises(ValueError, match="Cannot set relay status to UNKNOWN"):
+            await relay.async_set_status(RelayStatus.UNKNOWN)
+
+    def test_edge_case_missing_optional_field(self, auth_instance):
+        relay_data = {
+            "act_id": 1,
+            "name": "Test Relay",
+            "status": 1,
+            # Missing optional fields like floor_ind, room_ind
+        }
+
+        relay = Relay(relay_data, auth_instance)
+
+        assert relay.name == "Test Relay"
+        assert relay.act_id == 1
+        assert relay.status == RelayStatus.ON
+
+    def test_auth_type_validation(self):
+        relay_data = {
+            "act_id": 1,
+            "name": "Test Relay",
+            "status": 0,
+        }
+
+        # Test with non-Auth object (string)
+        with pytest.raises(
+            ValueError, match="'auth' must be an instance of Auth, got str"
+        ):
+            Relay(relay_data, "not_an_auth_instance")
+
+        # Test with non-Auth object (dict)
+        with pytest.raises(
+            ValueError, match="'auth' must be an instance of Auth, got dict"
+        ):
+            Relay(relay_data, {"fake": "auth"})
 
 
 class TestFloor:


### PR DESCRIPTION
## Summary
- Use `.get()` with defaults for optional `floor_ind`/`room_ind` relay properties to prevent `KeyError` when fields are absent
- Document `UNKNOWN` member in `RelayStatus` enum docstring
- Alphabetize `automodule` entries in `api_reference.rst`

## Test plan
- [x] Existing relay model tests pass (`TestRelay`: 8 passed)
- [x] Existing relay API tests pass (`TestAPIRelays`: 6 passed)
- [x] Pre-commit hooks pass (ruff, mypy, bandit, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay device support—fetch and monitor all relays in your CAME Domotic system
  * Control relay state asynchronously with on/off commands
  * Relay status updates now integrated into device monitoring and update notifications
  * Expanded documentation with relay operation examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->