### PR TITLE
Revert version bump to v1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "aiocamedomotic"
-version = "1.7.0"
+version = "1.6.4"
 description = "Async Python library for interacting with CAME Domotic home automation systems. Provides automatic session management and device control."
 license = "Apache-2.0"
 authors = ["camedomotic-unofficial <camedomotic-unofficial@gmail.com>"]


### PR DESCRIPTION
## Summary
- Reverts the version bump commit from the build-and-publish workflow run that was triggered without the 'publish to production' flag
- The v1.7.0 tag has already been deleted from remote

## Test plan
- [x] Pre-commit hooks pass
- [x] Verify pyproject.toml version is back to v1.6.4 after merge