### PR TITLE
Add TVCC camera model and API method

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -40,6 +40,7 @@ from .errors import CameDomoticAuthError
 from .models import (
     AnalogSensor,
     AnalogSensorType,
+    Camera,
     DigitalInput,
     Floor,
     Light,
@@ -497,6 +498,39 @@ class CameDomoticAPI:
         return [
             DigitalInput(digitalin_data, self.auth) for digitalin_data in digitalin_list
         ]
+
+    async def async_get_cameras(self) -> list[Camera]:
+        """Get the list of all TVCC cameras defined on the server.
+
+        Cameras are read-only entities providing access to IP camera
+        stream URIs. They do not support control commands.
+
+        .. note::
+            This method uses API commands documented in the CAME JS client
+            but not yet verified against a real server. Behaviour may differ
+            across firmware versions.
+
+        Returns:
+            list[Camera]: List of cameras.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching cameras list")
+        payload = {
+            "cmd_name": _CommandName.TVCC_CAMERAS_LIST.value,
+            "username": self.auth.current_username,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.TVCC_CAMERAS_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        cameras_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d camera(s)", len(cameras_list))
+        return [Camera(camera_data, self.auth) for camera_data in cameras_list]
 
     async def async_get_openings(self) -> list[Opening]:
         """Get the list of all opening devices defined on the server.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -149,6 +149,7 @@ class _CommandName(Enum):
     THERMO_LIST = "thermo_list_req"
     METERS_LIST = "meters_list_req"
     DIGITALIN_LIST = "digitalin_list_req"
+    TVCC_CAMERAS_LIST = "tvcc_cameras_list_req"
     # Nested lists (topology-aware)
     NESTED_LIGHT_LIST = "nested_light_list_req"
     NESTED_OPENINGS_LIST = "nested_openings_list_req"
@@ -179,6 +180,7 @@ class _CommandNameResponse(Enum):
     THERMO_LIST = "thermo_list_resp"
     METERS_LIST = "meters_list_resp"
     DIGITALIN_LIST = "digitalin_list_resp"
+    TVCC_CAMERAS_LIST = "tvcc_cameras_list_resp"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
     # Status
     STATUS_UPDATE = "status_update_resp"

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -31,6 +31,7 @@ from .base import (  # noqa: F401
     TopologyRoom,
     User,
 )
+from .camera import Camera  # noqa: F401
 from .digital_input import (  # noqa: F401
     DigitalInput,
     DigitalInputStatus,
@@ -66,6 +67,7 @@ from .update import (  # noqa: F401
 __all__ = [
     "AnalogSensor",
     "AnalogSensorType",
+    "Camera",
     "CameEntity",
     "DeviceType",
     "DeviceUpdate",

--- a/aiocamedomotic/models/camera.py
+++ b/aiocamedomotic/models/camera.py
@@ -1,0 +1,130 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic TVCC camera entity models.
+
+This module implements the classes for working with TVCC (closed-circuit
+television) cameras in a CAME Domotic system. Cameras are read-only entities
+that provide access to IP camera stream URIs but do not support control
+commands.
+
+.. note::
+    This module is based on reverse-engineered API documentation from the
+    CAME JS client and has not been verified against a real CAME Domotic
+    server. Behaviour may differ across firmware versions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..auth import Auth
+from ..utils import EntityValidator
+from .base import CameEntity
+
+
+@dataclass
+class Camera(CameEntity):
+    """
+    TVCC camera entity in the CameDomotic API.
+
+    Cameras are read-only devices that provide streaming video and still-image
+    URIs for IP cameras connected to the CAME Domotic system. They cannot be
+    controlled remotely — this is purely a viewing/monitoring feature.
+
+    .. warning::
+        The ``uri`` and ``uri_still`` fields point directly to camera HTTP
+        endpoints on the local network. These URIs may contain embedded
+        authentication credentials (e.g. ``http://user:pass@camera/stream``).
+        Avoid logging or displaying these values without sanitisation.
+
+    Raises:
+        ValueError: If ``name`` or ``id`` keys are missing from the input
+            data or the auth argument is not an instance of the expected
+            ``Auth`` class.
+    """
+
+    raw_data: dict[str, Any]
+    auth: Auth
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "id"],
+            typed_keys={"id": int},
+        )
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def id(self) -> int:
+        """Unique camera identifier.
+
+        Unlike other device models which use ``act_id``, cameras use a plain
+        ``id`` field as their primary key (JS field: ``id``, ``idProperty``).
+        """
+        return self.raw_data["id"]
+
+    @property
+    def name(self) -> str:
+        """Camera display name (JS field: ``name``)."""
+        return self.raw_data["name"]
+
+    @property
+    def uri(self) -> str:
+        """Primary streaming video URI.
+
+        Points directly to the camera's stream endpoint on the LAN.
+        The actual protocol/format is opaque — the JS client loads it
+        in an iframe (JS field: ``uri``).
+        """
+        return self.raw_data.get("uri", "")
+
+    @property
+    def uri_still(self) -> str:
+        """Snapshot/still-image URI.
+
+        Returns a single JPEG frame from the camera. Useful for thumbnails
+        or as a fallback when the primary stream format is not supported.
+        Append ``?t=<timestamp>`` for cache busting on repeated fetches
+        (JS field: ``uri_still``).
+        """
+        return self.raw_data.get("uri_still", "")
+
+    @property
+    def stream_type(self) -> str:
+        """Raw stream format string as returned by the server.
+
+        The only known value with special semantics is ``"swf"`` (Flash).
+        All other values are treated identically by the JS client
+        (JS field: ``stream_type``).
+        """
+        return self.raw_data.get("stream_type", "")
+
+    @property
+    def is_flash(self) -> bool:
+        """Whether this camera uses a Flash (SWF) stream.
+
+        Flash streams are obsolete — consumers should fall back to
+        :attr:`uri_still` for cameras where this is ``True``.
+
+        Derived from: ``stream_type == "swf"`` (same check as JS client,
+        line 5493).
+        """
+        return self.stream_type == "swf"

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -419,6 +419,7 @@ class AnalogSensorType(Enum):
     - TEMPERATURE ("temperature")
     - HUMIDITY ("humidity")
     - PRESSURE ("pressure")
+    - UNKNOWN ("unknown")
     """
 
     TEMPERATURE = "temperature"
@@ -452,6 +453,7 @@ class AnalogSensor(CameEntity):
 
     raw_data: dict[str, Any]
     sensor_type: AnalogSensorType = AnalogSensorType.UNKNOWN
+    """The type of sensor (temperature, humidity, or pressure)."""
 
     def __post_init__(self) -> None:
         EntityValidator.validate_data(

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -38,6 +38,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.base
    :members:
 
+.. automodule:: aiocamedomotic.models.camera
+   :members:
+
 .. automodule:: aiocamedomotic.models.digital_input
    :members:
 

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -371,4 +371,28 @@ def digital_input_data_without_status():
     }
 
 
+@pytest.fixture
+def camera_data_flash():
+    """Mock data for a camera with Flash (SWF) stream."""
+    return {
+        "id": 1,
+        "name": "Front Door Camera",
+        "uri": "http://192.168.1.100:8080/stream.swf",
+        "uri_still": "http://192.168.1.100:8080/snapshot.jpg",
+        "stream_type": "swf",
+    }
+
+
+@pytest.fixture
+def camera_data_standard():
+    """Mock data for a camera with standard (non-Flash) stream."""
+    return {
+        "id": 2,
+        "name": "Garden Camera",
+        "uri": "http://192.168.1.101:8080/video",
+        "uri_still": "http://192.168.1.101:8080/snapshot.jpg",
+        "stream_type": "mjpeg",
+    }
+
+
 # endregion

--- a/tests/aiocamedomotic/mocked_requests.py
+++ b/tests/aiocamedomotic/mocked_requests.py
@@ -274,3 +274,15 @@ TERMINALS_GROUPS_LIST_REQ = {
     "sl_client_id": "my_session_id",
     "sl_cmd": "sl_data_req",
 }
+
+TVCC_CAMERAS_LIST_REQ = {
+    "sl_appl_msg": {
+        "client": "my_session_id",
+        "cmd_name": "tvcc_cameras_list_req",
+        "cseq": 1,
+        "username": "username",
+    },
+    "sl_appl_msg_type": "domo",
+    "sl_client_id": "my_session_id",
+    "sl_cmd": "sl_data_req",
+}

--- a/tests/aiocamedomotic/mocked_responses.py
+++ b/tests/aiocamedomotic/mocked_responses.py
@@ -481,6 +481,28 @@ SL_CHANGE_USER_PASSWORD_RESP = {
     "sl_data_ack_reason": 0,
 }
 
+TVCC_CAMERAS_LIST_RESP = {
+    "cmd_name": "tvcc_cameras_list_resp",
+    "cseq": 7,
+    "sl_data_ack_reason": 0,
+    "array": [
+        {
+            "id": 1,
+            "name": "Front Door Camera",
+            "uri": "http://192.168.1.100:8080/stream.swf",
+            "uri_still": "http://192.168.1.100:8080/snapshot.jpg",
+            "stream_type": "swf",
+        },
+        {
+            "id": 2,
+            "name": "Garden Camera",
+            "uri": "http://192.168.1.101:8080/video",
+            "uri_still": "http://192.168.1.101:8080/snapshot.jpg",
+            "stream_type": "other_format",
+        },
+    ],
+}
+
 GENERIC_REPLY = {
     "cseq": 4,
     "cmd_name": "generic_reply",

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -31,6 +31,7 @@ from aiocamedomotic.errors import (
 from aiocamedomotic.models import (
     AnalogSensor,
     AnalogSensorType,
+    Camera,
     DigitalInput,
     Floor,
     Light,
@@ -52,6 +53,7 @@ from tests.aiocamedomotic.mocked_responses import (
     LIGHT_LIST_RESP,
     SCENARIOS_LIST_RESP,
     THERMO_LIST_RESP,
+    TVCC_CAMERAS_LIST_RESP,
 )
 
 
@@ -1481,6 +1483,67 @@ class TestAPIDigitalInputs:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_digital_inputs()
+
+
+class TestAPICameras:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_cameras(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = TVCC_CAMERAS_LIST_RESP
+
+        cameras = await api.async_get_cameras()
+        assert len(cameras) == len(TVCC_CAMERAS_LIST_RESP["array"])
+        assert isinstance(cameras[0], Camera)
+        assert isinstance(cameras[1], Camera)
+
+        # Verify the payload includes username
+        call_args = mock_send_command.call_args
+        payload = call_args[0][0]
+        assert "username" in payload
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_cameras_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "tvcc_cameras_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        cameras = await api.async_get_cameras()
+        assert len(cameras) == 0
+        assert isinstance(cameras, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_cameras_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "tvcc_cameras_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        cameras = await api.async_get_cameras()
+        assert len(cameras) == 0
+        assert isinstance(cameras, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_cameras_null_array(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "tvcc_cameras_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        cameras = await api.async_get_cameras()
+        assert cameras == []
 
 
 class TestAPIThermoSeason:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -34,6 +34,7 @@ from aiocamedomotic.errors import CameDomoticAuthError, CameDomoticServerError
 from aiocamedomotic.models import (
     AnalogSensor,
     AnalogSensorType,
+    Camera,
     DeviceUpdate,
     DigitalInput,
     DigitalInputStatus,
@@ -2683,3 +2684,60 @@ class TestDigitalInput:
         assert di.utc_time == 0
         assert di.status == DigitalInputStatus.UNKNOWN
         assert di.type == DigitalInputType.UNKNOWN
+
+
+class TestCamera:
+    def test_init_valid_data(self, auth_instance, camera_data_flash):
+        camera = Camera(camera_data_flash, auth_instance)
+        assert camera.id == 1
+        assert camera.name == "Front Door Camera"
+        assert camera.uri == "http://192.168.1.100:8080/stream.swf"
+        assert camera.uri_still == "http://192.168.1.100:8080/snapshot.jpg"
+        assert camera.stream_type == "swf"
+
+    def test_init_standard_stream(self, auth_instance, camera_data_standard):
+        camera = Camera(camera_data_standard, auth_instance)
+        assert camera.id == 2
+        assert camera.name == "Garden Camera"
+        assert camera.uri == "http://192.168.1.101:8080/video"
+        assert camera.uri_still == "http://192.168.1.101:8080/snapshot.jpg"
+        assert camera.stream_type == "mjpeg"
+
+    def test_missing_name_raises(self, auth_instance):
+        data = {"id": 1}
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            Camera(data, auth_instance)
+
+    def test_missing_id_raises(self, auth_instance):
+        data = {"name": "Test Camera"}
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            Camera(data, auth_instance)
+
+    def test_invalid_id_type_raises(self, auth_instance):
+        data = {"id": "not_an_int", "name": "Test Camera"}
+        with pytest.raises(ValueError, match="id"):
+            Camera(data, auth_instance)
+
+    def test_invalid_auth_raises(self, camera_data_flash):
+        with pytest.raises(ValueError, match="'auth' must be an instance of Auth"):
+            Camera(camera_data_flash, "not_an_auth")
+
+    def test_optional_fields_defaults(self, auth_instance):
+        data = {"id": 5, "name": "Minimal Camera"}
+        camera = Camera(data, auth_instance)
+        assert camera.uri == ""
+        assert camera.uri_still == ""
+        assert camera.stream_type == ""
+
+    def test_is_flash_true(self, auth_instance, camera_data_flash):
+        camera = Camera(camera_data_flash, auth_instance)
+        assert camera.is_flash is True
+
+    def test_is_flash_false(self, auth_instance, camera_data_standard):
+        camera = Camera(camera_data_standard, auth_instance)
+        assert camera.is_flash is False
+
+    def test_is_flash_empty_string(self, auth_instance):
+        data = {"id": 3, "name": "No Stream Type Camera"}
+        camera = Camera(data, auth_instance)
+        assert camera.is_flash is False


### PR DESCRIPTION
## Summary
- Add read-only `Camera` entity for CAME Domotic TVCC (video surveillance) with `id`, `name`, `uri`, `uri_still`, `stream_type`, and `is_flash` properties
- Add `async_get_cameras()` to `CameDomoticAPI` sending `tvcc_cameras_list_req` with `username` in payload
- Add 14 unit tests (10 model + 4 API), mocked reference data, fixtures, and docs

## Test plan
- [x] `pytest` — 438 passed, 100% coverage on camera.py, 99% overall
- [x] `mypy` — no issues
- [x] `pylint` — 9.67/10
- [x] `black` / `ruff-format` — all formatted
- [x] Pre-commit hooks all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added camera retrieval functionality to fetch connected cameras from your CAME Domotic system
  * Camera objects now expose properties including name, ID, streaming URI, and stream type information
  * Automatic detection of flash-based versus standard video streams

* **Documentation**
  * Added API documentation for the camera model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->