### PR TITLE
Add type validation for page_label in MapPage

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -44,6 +44,7 @@ from .models import (
     DigitalInput,
     Floor,
     Light,
+    MapPage,
     Opening,
     PlantTopology,
     Relay,
@@ -531,6 +532,43 @@ class CameDomoticAPI:
         cameras_list = json_response.get("array", []) or []
         LOGGER.info("Retrieved %d camera(s)", len(cameras_list))
         return [Camera(camera_data, self.auth) for camera_data in cameras_list]
+
+    async def async_get_map_pages(self) -> list[MapPage]:
+        """Get the list of all map pages (floor plans) from the server.
+
+        Maps provide a spatial view of the installation with positioned
+        device elements overlaid on background images. Map data is
+        read-only and cannot be modified through the API.
+
+        .. note::
+            This method uses API commands documented in the CAME JS client
+            but not yet verified against a real server. Behaviour may differ
+            across firmware versions.
+
+        Returns:
+            list[MapPage]: List of map pages, each containing positioned
+            elements. Returns an empty list if no maps are defined.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching map pages")
+        payload = {
+            "cmd_name": _CommandName.MAP_DESCR.value,
+            "username": self.auth.current_username,
+            "map_id": 0,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload,
+            response_command=_CommandNameResponse.MAP_DESCR.value,
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        map_list = json_response.get("map", []) or []
+        LOGGER.info("Retrieved %d map page(s)", len(map_list))
+        return [MapPage(page_data) for page_data in map_list]
 
     async def async_get_openings(self) -> list[Opening]:
         """Get the list of all opening devices defined on the server.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -164,6 +164,7 @@ class _CommandName(Enum):
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
     THERMO_SEASON = "thermo_season_req"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_req"
+    MAP_DESCR = "map_descr_req"
 
 
 class _CommandNameResponse(Enum):
@@ -182,6 +183,7 @@ class _CommandNameResponse(Enum):
     DIGITALIN_LIST = "digitalin_list_resp"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_resp"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
+    MAP_DESCR = "map_descr_resp"
     # Status
     STATUS_UPDATE = "status_update_resp"
     # Actions

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -38,6 +38,7 @@ from .digital_input import (  # noqa: F401
     DigitalInputType,
 )
 from .light import Light, LightStatus, LightType  # noqa: F401
+from .map_page import MapPage  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
 from .relay import Relay, RelayStatus  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
@@ -80,6 +81,7 @@ __all__ = [
     "LightStatus",
     "LightType",
     "LightUpdate",
+    "MapPage",
     "Opening",
     "OpeningStatus",
     "OpeningType",

--- a/aiocamedomotic/models/map_page.py
+++ b/aiocamedomotic/models/map_page.py
@@ -1,0 +1,111 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic map page entity model.
+
+This module implements the class representing a page (floor plan) in the
+CAME Domotic map system. Maps are read-only — they provide positional
+information about devices overlaid on background images but do not support
+control commands. Device control is performed through the standard device
+command APIs (``light_switch_req``, ``opening_move_req``, etc.).
+
+.. note::
+    This module is based on reverse-engineered API documentation from the
+    CAME JS client and has not been verified against a real CAME Domotic
+    server. Behaviour may differ across firmware versions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..utils import EntityValidator
+from .base import CameEntity
+
+
+@dataclass
+class MapPage(CameEntity):
+    """A page (floor plan) in the CAME Domotic map system.
+
+    Each page represents a spatial view containing positioned elements
+    (lights, openings, thermostats, page links, scenarios, cameras)
+    overlaid on a background image. Elements are returned as raw
+    dictionaries preserving the server response structure.
+
+    The ``elements`` list contains dictionaries with at least the following
+    common keys: ``x``, ``y``, ``width``, ``height``, ``type``, ``label``,
+    ``aspect``, ``icon_id``, ``permission``, ``read_only``, ``address``.
+    Additional keys depend on the element type (e.g. ``act_id`` for devices,
+    ``page`` for page links, ``scenario_id`` for scenarios).
+
+    Raises:
+        ValueError: If ``page_id`` or ``page_label`` keys are missing from
+            the input data, or if ``page_id`` is not an integer.
+    """
+
+    raw_data: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["page_id", "page_label"],
+            typed_keys={"page_id": int},
+        )
+
+    @property
+    def page_id(self) -> int:
+        """Unique page identifier.
+
+        ``0`` is the root/home page.
+        """
+        return self.raw_data["page_id"]
+
+    @property
+    def page_label(self) -> str:
+        """Human-readable page title."""
+        return self.raw_data["page_label"]
+
+    @property
+    def page_scale(self) -> int:
+        """Coordinate space size for element positioning.
+
+        Element ``x``/``y`` values range from ``0`` to ``page_scale``.
+        Typically ``1024``.
+        """
+        return self.raw_data.get("page_scale", 1024)
+
+    @property
+    def background(self) -> str:
+        """Relative URL path to the background image on the CAME server.
+
+        The URL may contain spaces (e.g. ``"maps/maps_pianta piano terra.png"``).
+        Consumers must percent-encode the path when making HTTP requests.
+        The full URL is constructed as ``http://<server_host>/<background>``.
+        """
+        return self.raw_data.get("background", "")
+
+    @property
+    def elements(self) -> list[dict[str, Any]]:
+        """Interactive elements placed on this map page.
+
+        Each element is a raw dictionary from the server response. Common
+        keys include ``x``, ``y``, ``width``, ``height``, ``type``,
+        ``label``, ``aspect``, ``icon_id``, ``permission``, ``read_only``,
+        and ``address``. Type-specific keys (``act_id``, ``page``,
+        ``scenario_id``, ``status``) are present only for applicable
+        element types.
+        """
+        return self.raw_data.get("array") or []

--- a/aiocamedomotic/models/map_page.py
+++ b/aiocamedomotic/models/map_page.py
@@ -62,7 +62,7 @@ class MapPage(CameEntity):
         EntityValidator.validate_data(
             self.raw_data,
             required_keys=["page_id", "page_label"],
-            typed_keys={"page_id": int},
+            typed_keys={"page_id": int, "page_label": str},
         )
 
     @property

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -47,6 +47,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.light
    :members:
 
+.. automodule:: aiocamedomotic.models.map_page
+   :members:
+
 .. automodule:: aiocamedomotic.models.opening
    :members:
 

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -395,4 +395,57 @@ def camera_data_standard():
     }
 
 
+@pytest.fixture
+def map_page_data():
+    """Mock data for a map page with elements."""
+    return {
+        "background": "maps/maps_pianta piano terra.png",
+        "page_label": "Piano Terra",
+        "page_scale": 1024,
+        "page_id": 0,
+        "array": [
+            {
+                "x": 208,
+                "y": 405,
+                "width": 89,
+                "height": 120,
+                "label": "Bagno",
+                "aspect": "maps_pages_Generico",
+                "icon_id": 0,
+                "permission": 1048575,
+                "read_only": 0,
+                "address": 0,
+                "type": 3,
+                "page": 1,
+            },
+            {
+                "x": 685,
+                "y": 450,
+                "width": 123,
+                "height": 194,
+                "label": "Specchio Bagno",
+                "aspect": "maps_lights_Generico",
+                "icon_id": 0,
+                "permission": 1048575,
+                "read_only": 0,
+                "address": 14,
+                "type": 0,
+                "act_id": 4,
+                "status": 0,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def map_page_data_empty():
+    """Mock data for a map page with no elements."""
+    return {
+        "page_label": "Empty Floor",
+        "page_scale": 1024,
+        "page_id": 2,
+        "array": [],
+    }
+
+
 # endregion

--- a/tests/aiocamedomotic/mocked_requests.py
+++ b/tests/aiocamedomotic/mocked_requests.py
@@ -286,3 +286,16 @@ TVCC_CAMERAS_LIST_REQ = {
     "sl_client_id": "my_session_id",
     "sl_cmd": "sl_data_req",
 }
+
+MAP_DESCR_REQ = {
+    "sl_appl_msg": {
+        "client": "my_session_id",
+        "cmd_name": "map_descr_req",
+        "cseq": 1,
+        "username": "username",
+        "map_id": 0,
+    },
+    "sl_appl_msg_type": "domo",
+    "sl_client_id": "my_session_id",
+    "sl_cmd": "sl_data_req",
+}

--- a/tests/aiocamedomotic/mocked_responses.py
+++ b/tests/aiocamedomotic/mocked_responses.py
@@ -503,6 +503,73 @@ TVCC_CAMERAS_LIST_RESP = {
     ],
 }
 
+MAPS_LIST_RESP = {
+    "cseq": 11,
+    "cmd_name": "map_descr_resp",
+    "map": [
+        {
+            "background": "maps/maps_pianta piano terra.png",
+            "page_label": "Piano Terra",
+            "page_scale": 1024,
+            "page_id": 0,
+            "array": [
+                {
+                    "x": 208,
+                    "y": 405,
+                    "width": 89,
+                    "height": 120,
+                    "label": "Bagno",
+                    "aspect": "maps_pages_Generico",
+                    "icon_id": 0,
+                    "permission": 1048575,
+                    "read_only": 0,
+                    "address": 0,
+                    "type": 3,
+                    "page": 1,
+                },
+                {
+                    "x": 234,
+                    "y": 714,
+                    "width": 74,
+                    "height": 118,
+                    "label": "Soggiorno",
+                    "aspect": "maps_pages_Generico",
+                    "icon_id": 0,
+                    "permission": 1048575,
+                    "read_only": 0,
+                    "address": 0,
+                    "type": 3,
+                    "page": 12,
+                },
+            ],
+        },
+        {
+            "background": "maps/maps_pianta piano terra_bagno.png",
+            "page_label": "Bagno",
+            "page_scale": 1024,
+            "page_id": 1,
+            "array": [
+                {
+                    "x": 685,
+                    "y": 450,
+                    "width": 123,
+                    "height": 194,
+                    "label": "Specchio Bagno",
+                    "aspect": "maps_lights_Generico",
+                    "icon_id": 0,
+                    "permission": 1048575,
+                    "read_only": 0,
+                    "address": 14,
+                    "type": 0,
+                    "act_id": 4,
+                    "status": 0,
+                }
+            ],
+        },
+    ],
+    "sl_data_ack_reason": 0,
+}
+
 GENERIC_REPLY = {
     "cseq": 4,
     "cmd_name": "generic_reply",

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -35,6 +35,7 @@ from aiocamedomotic.models import (
     DigitalInput,
     Floor,
     Light,
+    MapPage,
     Opening,
     PlantTopology,
     Relay,
@@ -51,6 +52,7 @@ from tests.aiocamedomotic.mocked_responses import (
     DIGITALIN_LIST_RESP,
     FEATURE_LIST_RESP,
     LIGHT_LIST_RESP,
+    MAPS_LIST_RESP,
     SCENARIOS_LIST_RESP,
     THERMO_LIST_RESP,
     TVCC_CAMERAS_LIST_RESP,
@@ -2255,3 +2257,68 @@ class TestAPITopology:
 
         assert floors == {2: "Good Floor"}
         assert rooms == {}
+
+
+class TestAPIMapPages:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_map_pages(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = MAPS_LIST_RESP
+
+        pages = await api.async_get_map_pages()
+        assert len(pages) == len(MAPS_LIST_RESP["map"])
+        assert isinstance(pages[0], MapPage)
+        assert isinstance(pages[1], MapPage)
+
+        # Verify the payload includes username and map_id
+        call_args = mock_send_command.call_args
+        payload = call_args[0][0]
+        assert payload["cmd_name"] == "map_descr_req"
+        assert payload["map_id"] == 0
+        assert "username" in payload
+
+        # Verify response_command was passed
+        call_kwargs = call_args[1]
+        assert call_kwargs["response_command"] == "map_descr_resp"
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_map_pages_empty(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "map": [],
+            "cmd_name": "map_descr_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        pages = await api.async_get_map_pages()
+        assert len(pages) == 0
+        assert isinstance(pages, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_map_pages_missing_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "map_descr_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        pages = await api.async_get_map_pages()
+        assert len(pages) == 0
+        assert isinstance(pages, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_map_pages_null(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "map": None,
+            "cmd_name": "map_descr_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        pages = await api.async_get_map_pages()
+        assert pages == []

--- a/tests/aiocamedomotic/test_map_page.py
+++ b/tests/aiocamedomotic/test_map_page.py
@@ -1,0 +1,115 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from aiocamedomotic.models import MapPage
+
+
+class TestMapPage:
+    def test_init_valid_data(self, map_page_data):
+        page = MapPage(map_page_data)
+
+        assert page.page_id == 0
+        assert page.page_label == "Piano Terra"
+        assert page.page_scale == 1024
+        assert page.background == "maps/maps_pianta piano terra.png"
+        assert len(page.elements) == 2
+
+    def test_init_empty_page(self, map_page_data_empty):
+        page = MapPage(map_page_data_empty)
+
+        assert page.page_id == 2
+        assert page.page_label == "Empty Floor"
+        assert page.elements == []
+
+    def test_missing_page_id_raises(self):
+        data = {"page_label": "Test"}
+        with pytest.raises(ValueError, match="Data is missing required keys: page_id"):
+            MapPage(data)
+
+    def test_missing_page_label_raises(self):
+        data = {"page_id": 0}
+        with pytest.raises(
+            ValueError, match="Data is missing required keys: page_label"
+        ):
+            MapPage(data)
+
+    def test_missing_multiple_keys_raises(self):
+        data = {}
+        with pytest.raises(
+            ValueError, match="Data is missing required keys: page_id, page_label"
+        ):
+            MapPage(data)
+
+    def test_invalid_page_id_type_raises(self):
+        data = {"page_id": "not_an_int", "page_label": "Test"}
+        with pytest.raises(ValueError, match="page_id"):
+            MapPage(data)
+
+    def test_non_dict_data_raises(self):
+        with pytest.raises(ValueError, match="Provided data must be a dictionary"):
+            MapPage("not a dict")
+
+    def test_page_scale_default(self):
+        data = {"page_id": 0, "page_label": "Test"}
+        page = MapPage(data)
+        assert page.page_scale == 1024
+
+    def test_background_default(self):
+        data = {"page_id": 0, "page_label": "Test"}
+        page = MapPage(data)
+        assert page.background == ""
+
+    def test_background_with_spaces(self, map_page_data):
+        page = MapPage(map_page_data)
+        assert " " in page.background
+
+    def test_elements_missing_array_key(self):
+        data = {"page_id": 0, "page_label": "Test"}
+        page = MapPage(data)
+        assert page.elements == []
+
+    def test_elements_none_array(self):
+        data = {"page_id": 0, "page_label": "Test", "array": None}
+        page = MapPage(data)
+        assert page.elements == []
+
+    def test_elements_returns_raw_dicts(self, map_page_data):
+        page = MapPage(map_page_data)
+        elements = page.elements
+
+        assert isinstance(elements, list)
+        assert all(isinstance(elem, dict) for elem in elements)
+
+        # Verify page link element (type 3) has expected keys
+        page_link = elements[0]
+        assert page_link["type"] == 3
+        assert page_link["label"] == "Bagno"
+        assert page_link["page"] == 1
+
+        # Verify light element (type 0) has expected keys
+        light = elements[1]
+        assert light["type"] == 0
+        assert light["label"] == "Specchio Bagno"
+        assert light["act_id"] == 4
+        assert light["status"] == 0
+
+    def test_raw_data_preserved(self, map_page_data):
+        page = MapPage(map_page_data)
+        assert page.raw_data is map_page_data


### PR DESCRIPTION
## Summary
- Added `page_label: str` to the `typed_keys` dict in `MapPage.__post_init__` so the `EntityValidator` enforces that `page_label` is a string, matching the existing `page_id: int` check.

## Test plan
- [ ] Existing tests pass (pre-commit hooks ran pytest successfully)
- [ ] Verify `MapPage` raises `ValueError` when `page_label` is not a string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to fetch and retrieve map pages from the CAME Domotic system, including metadata such as page identifiers, labels, scaling, backgrounds, and associated elements for display purposes.

* **Documentation**
  * Updated API reference documentation to include the new map page module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->