### PR TITLE
docs: update LLM documentation files

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1148,6 +1148,28 @@ Get the list of all the light devices defined on the server.
   * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
   * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
 
+##### *async* async_get_map_pages() → list[[MapPage](#aiocamedomotic.models.map_page.MapPage)]
+
+Get the list of all map pages (floor plans) from the server.
+
+Maps provide a spatial view of the installation with positioned
+device elements overlaid on background images. Map data is
+read-only and cannot be modified through the API.
+
+##### NOTE
+This method uses API commands documented in the CAME JS client
+but not yet verified against a real server. Behaviour may differ
+across firmware versions.
+
+* **Returns:**
+  List of map pages, each containing positioned
+  elements. Returns an empty list if no maps are defined.
+* **Return type:**
+  list[[MapPage](#aiocamedomotic.models.map_page.MapPage)]
+* **Raises:**
+  * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
+  * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
+
 ##### *async* async_get_openings() → list[[Opening](#aiocamedomotic.models.opening.Opening)]
 
 Get the list of all opening devices defined on the server.
@@ -1752,6 +1774,61 @@ Room index.
 ##### *property* status *: [LightStatus](#aiocamedomotic.models.light.LightStatus)*
 
 Light status (OFF, ON, AUTO).
+
+#### *class* aiocamedomotic.models.MapPage(raw_data: dict[str, Any])
+
+A page (floor plan) in the CAME Domotic map system.
+
+Each page represents a spatial view containing positioned elements
+(lights, openings, thermostats, page links, scenarios, cameras)
+overlaid on a background image. Elements are returned as raw
+dictionaries preserving the server response structure.
+
+The `elements` list contains dictionaries with at least the following
+common keys: `x`, `y`, `width`, `height`, `type`, `label`,
+`aspect`, `icon_id`, `permission`, `read_only`, `address`.
+Additional keys depend on the element type (e.g. `act_id` for devices,
+`page` for page links, `scenario_id` for scenarios).
+
+* **Raises:**
+  **ValueError** – If `page_id` or `page_label` keys are missing from
+      the input data, or if `page_id` is not an integer.
+
+##### *property* background *: str*
+
+Relative URL path to the background image on the CAME server.
+
+The URL may contain spaces (e.g. `"maps/maps_pianta piano terra.png"`).
+Consumers must percent-encode the path when making HTTP requests.
+The full URL is constructed as `http://<server_host>/<background>`.
+
+##### *property* elements *: list[dict[str, Any]]*
+
+Interactive elements placed on this map page.
+
+Each element is a raw dictionary from the server response. Common
+keys include `x`, `y`, `width`, `height`, `type`,
+`label`, `aspect`, `icon_id`, `permission`, `read_only`,
+and `address`. Type-specific keys (`act_id`, `page`,
+`scenario_id`, `status`) are present only for applicable
+element types.
+
+##### *property* page_id *: int*
+
+Unique page identifier.
+
+`0` is the root/home page.
+
+##### *property* page_label *: str*
+
+Human-readable page title.
+
+##### *property* page_scale *: int*
+
+Coordinate space size for element positioning.
+
+Element `x`/`y` values range from `0` to `page_scale`.
+Typically `1024`.
 
 #### *class* aiocamedomotic.models.Opening(raw_data: dict[str, Any], auth: [Auth](#aiocamedomotic.auth.Auth))
 
@@ -3002,6 +3079,74 @@ Allowed values are:
 : - STEP_STEP (normal lights)
   - DIMMER (dimmable lights)
   - RGB (color lights with brightness via HSV V channel)
+
+CAME Domotic map page entity model.
+
+This module implements the class representing a page (floor plan) in the
+CAME Domotic map system. Maps are read-only — they provide positional
+information about devices overlaid on background images but do not support
+control commands. Device control is performed through the standard device
+command APIs (`light_switch_req`, `opening_move_req`, etc.).
+
+##### NOTE
+This module is based on reverse-engineered API documentation from the
+CAME JS client and has not been verified against a real CAME Domotic
+server. Behaviour may differ across firmware versions.
+
+#### *class* aiocamedomotic.models.map_page.MapPage(raw_data: dict[str, Any])
+
+A page (floor plan) in the CAME Domotic map system.
+
+Each page represents a spatial view containing positioned elements
+(lights, openings, thermostats, page links, scenarios, cameras)
+overlaid on a background image. Elements are returned as raw
+dictionaries preserving the server response structure.
+
+The `elements` list contains dictionaries with at least the following
+common keys: `x`, `y`, `width`, `height`, `type`, `label`,
+`aspect`, `icon_id`, `permission`, `read_only`, `address`.
+Additional keys depend on the element type (e.g. `act_id` for devices,
+`page` for page links, `scenario_id` for scenarios).
+
+* **Raises:**
+  **ValueError** – If `page_id` or `page_label` keys are missing from
+      the input data, or if `page_id` is not an integer.
+
+##### *property* background *: str*
+
+Relative URL path to the background image on the CAME server.
+
+The URL may contain spaces (e.g. `"maps/maps_pianta piano terra.png"`).
+Consumers must percent-encode the path when making HTTP requests.
+The full URL is constructed as `http://<server_host>/<background>`.
+
+##### *property* elements *: list[dict[str, Any]]*
+
+Interactive elements placed on this map page.
+
+Each element is a raw dictionary from the server response. Common
+keys include `x`, `y`, `width`, `height`, `type`,
+`label`, `aspect`, `icon_id`, `permission`, `read_only`,
+and `address`. Type-specific keys (`act_id`, `page`,
+`scenario_id`, `status`) are present only for applicable
+element types.
+
+##### *property* page_id *: int*
+
+Unique page identifier.
+
+`0` is the root/home page.
+
+##### *property* page_label *: str*
+
+Human-readable page title.
+
+##### *property* page_scale *: int*
+
+Coordinate space size for element positioning.
+
+Element `x`/`y` values range from `0` to `page_scale`.
+Typically `1024`.
 
 CAME Domotic opening entity models and control functionality.
 


### PR DESCRIPTION
Automated update of `llms.txt` and `llms-full.txt` triggered by changes
to source code or documentation.

These files are auto-generated by `scripts/build_llms_docs.py` from the
Sphinx documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new MapPage model providing access to floor plan data, including background imagery, page elements, identifiers, labels, and scale information
  * Added new API method to retrieve all available map pages with built-in error handling for authentication and server errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->