### PR TITLE
Add anonymized traffic logging for HTTP debugging

### DIFF
--- a/aiocamedomotic/anonymizer.py
+++ b/aiocamedomotic/anonymizer.py
@@ -1,0 +1,273 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anonymization utilities for HTTP traffic logging.
+
+This module provides automatic redaction of sensitive fields in CAME Domotic
+API request and response payloads, enabling safe sharing of traffic logs
+for debugging purposes.
+
+The traffic logger (``aiocamedomotic.traffic``) is a child of the main
+library logger and can be configured independently::
+
+    import logging
+    logging.getLogger("aiocamedomotic.traffic").setLevel(logging.DEBUG)
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+TRAFFIC_LOGGER = logging.getLogger(f"{__package__}.traffic")
+"""Dedicated logger for HTTP traffic. Enable at DEBUG level to see
+anonymized request/response payloads with elapsed times."""
+
+# ---------------------------------------------------------------------------
+# Sensitive field definitions
+# ---------------------------------------------------------------------------
+
+# Fields whose values are fully replaced with "***"
+_FULL_REDACT_FIELDS: frozenset[str] = frozenset({"sl_pwd", "sl_new_pwd"})
+
+# Fields whose values are partially shown: (chars_to_keep, mask_suffix)
+_PARTIAL_REDACT_FIELDS: dict[str, tuple[int, str]] = {
+    "sl_login": (2, "***"),
+    "sl_client_id": (3, "***"),
+    "client": (3, "***"),
+    "keycode": (8, "********"),
+    "serial": (3, "*****"),
+}
+
+# Fields that may contain URIs with embedded credentials
+_URI_FIELDS: frozenset[str] = frozenset({"uri", "uri_still"})
+
+# IPv4 pattern for host anonymization
+_IPV4_RE = re.compile(r"^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)\d{1,3}$")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _partial_redact(value: str, keep: int, mask: str) -> str:
+    """Return a partially redacted string.
+
+    If the value is shorter than *keep*, it is fully redacted to ``"***"``
+    to avoid leaking short values entirely.
+    """
+    if len(value) < keep:
+        return "***"
+    return value[:keep] + mask
+
+
+def _anonymize_uri(uri: str) -> str:
+    """Redact embedded credentials in a URI.
+
+    If the URI contains ``user:pass@host``, the userinfo portion is replaced
+    with ``***:***``. URIs without credentials are returned unchanged.
+    """
+    if not uri:
+        return uri
+    try:
+        parts = urlsplit(uri)
+        if "@" in (parts.netloc or ""):
+            # Rebuild netloc without credentials
+            host_port = parts.netloc.rsplit("@", 1)[1]
+            clean_netloc = f"***:***@{host_port}"
+            return urlunsplit(
+                (parts.scheme, clean_netloc, parts.path, parts.query, parts.fragment)
+            )
+        return uri
+    except Exception:  # pylint: disable=broad-except
+        return "<uri-redacted>"
+
+
+def _anonymize_host(host: str) -> str:
+    """Partially redact a host string.
+
+    - IPv4: replaces the last octet (``192.168.1.100`` → ``192.168.1.***``).
+    - Hostname: keeps the first segment (``came-server.local`` → ``came-server.***``).
+    - Single-segment, empty, or unparsable: returns ``***``.
+    """
+    if not host:
+        return "***"
+
+    ipv4_match = _IPV4_RE.match(host)
+    if ipv4_match:
+        return ipv4_match.group(1) + "***"
+
+    if "." in host:
+        first_segment = host.split(".", 1)[0]
+        return f"{first_segment}.***"
+
+    return "***"
+
+
+def _anonymize_url(url: str) -> str:
+    """Redact the host portion of a URL while preserving scheme, port, and path."""
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url)
+        hostname = parts.hostname or ""
+        anon_host = _anonymize_host(hostname)
+
+        # Reconstruct netloc with anonymized host but preserve port
+        anon_netloc = f"{anon_host}:{parts.port}" if parts.port else anon_host
+
+        return urlunsplit(
+            (parts.scheme, anon_netloc, parts.path, parts.query, parts.fragment)
+        )
+    except Exception:  # pylint: disable=broad-except
+        return "<url-redacted>"
+
+
+def _anonymize_value(key: str, value: Any) -> Any:  # pylint: disable=too-many-return-statements
+    """Return an anonymized version of *value* based on *key*.
+
+    Dispatches to full redaction, partial redaction, URI sanitization, or
+    special-case handling for ``sl_users_list``.
+    """
+    if key in _FULL_REDACT_FIELDS:
+        return "***" if isinstance(value, str) else value
+
+    if key in _PARTIAL_REDACT_FIELDS:
+        if isinstance(value, str):
+            keep, mask = _PARTIAL_REDACT_FIELDS[key]
+            return _partial_redact(value, keep, mask)
+        return value
+
+    if key in _URI_FIELDS:
+        if isinstance(value, str):
+            return _anonymize_uri(value)
+        return value
+
+    # Context-aware: only redact "name" inside sl_users_list items
+    if key == "sl_users_list" and isinstance(value, list):
+        result = []
+        for item in value:
+            if isinstance(item, dict):
+                item_copy = item.copy()
+                if "name" in item_copy and isinstance(item_copy["name"], str):
+                    item_copy["name"] = _partial_redact(item_copy["name"], 2, "***")
+                if "sl_login" in item_copy and isinstance(item_copy["sl_login"], str):
+                    item_copy["sl_login"] = _partial_redact(
+                        item_copy["sl_login"], 2, "***"
+                    )
+                result.append(item_copy)
+            else:
+                result.append(item)
+        return result
+
+    return value
+
+
+def _anonymize_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Recursively anonymize sensitive fields in a dictionary (in-place)."""
+    for key in list(data.keys()):
+        value = data[key]
+
+        # Apply field-level anonymization first
+        value = _anonymize_value(key, value)
+        data[key] = value
+
+        # Recurse into nested structures
+        if isinstance(value, dict):
+            _anonymize_dict(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _anonymize_dict(item)
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def anonymize_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of *data* with sensitive fields anonymized.
+
+    This function never modifies the original dictionary. The following
+    fields are redacted:
+
+    - ``sl_pwd``, ``sl_new_pwd``: fully replaced with ``"***"``
+    - ``sl_login``, ``sl_client_id``, ``client``, ``keycode``, ``serial``:
+      partially masked (first N characters preserved)
+    - ``uri``, ``uri_still``: embedded credentials redacted
+    - ``sl_users_list`` items: ``name`` / ``sl_login`` partially masked
+
+    Args:
+        data: The request or response payload dictionary.
+
+    Returns:
+        A new dictionary with sensitive values redacted.
+    """
+    copied = copy.deepcopy(data)
+    return _anonymize_dict(copied)
+
+
+def log_traffic(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    method: str,
+    url: str,
+    request_payload: dict[str, Any] | None,
+    response_payload: dict[str, Any] | None,
+    http_status: int | None,
+    elapsed_ms: float,
+) -> None:
+    """Log an HTTP request/response exchange with anonymized payloads.
+
+    This function is fail-safe: any exception during anonymization or
+    formatting is caught and logged as a warning, never propagated to
+    the caller.
+
+    Args:
+        method: HTTP method (e.g., ``"POST"``, ``"GET"``).
+        url: The full endpoint URL.
+        request_payload: The request body dict, or ``None``.
+        response_payload: The parsed response dict, or ``None``.
+        http_status: The HTTP response status code, or ``None``.
+        elapsed_ms: Elapsed time in milliseconds.
+    """
+    try:
+        anon_url = _anonymize_url(url)
+
+        status_part = f"status={http_status}, " if http_status is not None else ""
+        header = f"HTTP {method} {anon_url} [{status_part}{elapsed_ms:.1f}ms]"
+
+        lines = [header]
+
+        if request_payload is not None:
+            anon_request = anonymize_payload(request_payload)
+            lines.append(f"--> {json.dumps(anon_request, separators=(',', ':'))}")
+
+        if response_payload is not None:
+            if isinstance(response_payload, dict):
+                anon_response = anonymize_payload(response_payload)
+                lines.append(f"<-- {json.dumps(anon_response, separators=(',', ':'))}")
+            else:
+                lines.append(f"<-- {response_payload!s}")
+
+        TRAFFIC_LOGGER.debug("\n".join(lines))
+
+    except Exception:  # pylint: disable=broad-except
+        TRAFFIC_LOGGER.warning("Traffic logging failed", exc_info=True)

--- a/aiocamedomotic/anonymizer.py
+++ b/aiocamedomotic/anonymizer.py
@@ -139,7 +139,9 @@ def _anonymize_url(url: str) -> str:
         return "<url-redacted>"
 
 
-def _anonymize_value(key: str, value: Any) -> Any:  # pylint: disable=too-many-return-statements
+def _anonymize_value(  # pylint: disable=too-many-return-statements
+    key: str, value: Any
+) -> Any:
     """Return an anonymized version of *value* based on *key*.
 
     Dispatches to full redaction, partial redaction, URI sanitization, or

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -544,10 +544,12 @@ class Auth:
         LOGGER.debug("Validating host at '%s'", endpoint_url)
 
         _traffic_start = time.monotonic()
+        _traffic_status: int | None = None
         try:
             async with self.websession.get(
                 endpoint_url, timeout=client_timeout
             ) as resp:
+                _traffic_status = resp.status
                 # Ensure that the server URL is available
                 resp.raise_for_status()
                 if resp.status != 200:
@@ -593,7 +595,7 @@ class Auth:
                     endpoint_url,
                     None,
                     None,
-                    None,
+                    _traffic_status,
                     (time.monotonic() - _traffic_start) * 1000,
                 )
             except Exception:  # pylint: disable=broad-except

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -53,6 +53,7 @@ try:
     _LIBRARY_VERSION = version(__package__ or "aiocamedomotic")
 except PackageNotFoundError:
     _LIBRARY_VERSION = "unknown"
+from .anonymizer import log_traffic
 from .errors import (
     CameDomoticAuthError,
     CameDomoticServerError,
@@ -347,7 +348,7 @@ class Auth:
             return self.client_id
 
     @handle_came_domotic_errors
-    async def async_send_command(  # pylint: disable=too-many-branches
+    async def async_send_command(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         self,
         command: dict[str, Any],
         *,
@@ -437,6 +438,10 @@ class Auth:
             self.get_endpoint_url(),
         )
 
+        _traffic_start = time.monotonic()
+        _traffic_response: dict[str, Any] | None = None
+        _traffic_status: int | None = None
+
         try:
             response = await self.websession.post(
                 self.get_endpoint_url(),
@@ -447,6 +452,7 @@ class Auth:
                 ),
             )
 
+            _traffic_status = response.status
             LOGGER.debug("HTTP response status: %s", response.status)
 
             if not skip_ack_check:
@@ -470,6 +476,8 @@ class Auth:
                 raise CameDomoticServerError(
                     "Error decoding the response to JSON"
                 ) from e
+
+            _traffic_response = json_response
 
             resp_cmd_name = json_response.get("cmd_name")
             if response_command is not None and resp_cmd_name != response_command:
@@ -507,6 +515,18 @@ class Auth:
             cmd_name = (command or {}).get("cmd_name")
             LOGGER.exception("Error sending command '%s': %s", cmd_name, e)
             raise CameDomoticServerError("Error sending command") from e
+        finally:
+            try:
+                log_traffic(
+                    "POST",
+                    self.get_endpoint_url(),
+                    request_payload,
+                    _traffic_response,
+                    _traffic_status,
+                    (time.monotonic() - _traffic_start) * 1000,
+                )
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.debug("Traffic logging failed", exc_info=True)
 
     # The following method is not async because it is used in the __init__ method
     async def async_validate_host(self, timeout: int = 10) -> None:
@@ -523,6 +543,7 @@ class Auth:
         client_timeout = aiohttp.ClientTimeout(total=timeout)
         LOGGER.debug("Validating host at '%s'", endpoint_url)
 
+        _traffic_start = time.monotonic()
         try:
             async with self.websession.get(
                 endpoint_url, timeout=client_timeout
@@ -565,6 +586,18 @@ class Auth:
             raise CameDomoticServerNotFoundError(
                 f"HTTP GET of '{endpoint_url}' resulted in an unexpected error ({e})'"
             ) from e
+        finally:
+            try:
+                log_traffic(
+                    "GET",
+                    endpoint_url,
+                    None,
+                    None,
+                    None,
+                    (time.monotonic() - _traffic_start) * 1000,
+                )
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.debug("Traffic logging failed", exc_info=True)
 
     async def async_login(self) -> None:
         """Login to the CAME Domotic server.

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -78,6 +78,9 @@ Utilities
 
 .. autofunction:: aiocamedomotic.utils.async_is_came_endpoint
 
+.. automodule:: aiocamedomotic.anonymizer
+   :members: TRAFFIC_LOGGER, anonymize_payload
+
 
 Errors
 ------

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -797,5 +797,69 @@ credentials:
     lowercase ``00:1c:b2:aa:bb:cc`` will **not** match directly — normalize
     to uppercase colon-separated format first, as shown in the example above.
 
+Debugging with traffic logging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The library includes a built-in traffic logger that records every HTTP
+request and response exchanged with the CAME server. **Sensitive data
+(passwords, session tokens, server identifiers) is automatically
+anonymized**, so the output is safe to share publicly — for example, when
+reporting issues on GitHub.
+
+The traffic logger uses the ``aiocamedomotic.traffic`` logger name (a child
+of the main ``aiocamedomotic`` logger). Since it is a child logger, it
+inherits the handler and formatter already configured by the library — you
+only need to lower its level to ``DEBUG``:
+
+.. code-block:: python
+
+    import logging
+
+    # Enable traffic logging (anonymized request/response payloads)
+    logging.getLogger("aiocamedomotic.traffic").setLevel(logging.DEBUG)
+
+That single line is all you need. The traffic log messages will appear
+alongside the normal library output, using the same format.
+
+Example output:
+
+.. code-block:: text
+
+    2025-03-15 10:23:01.123 DEBUG (MainThread) [aiocamedomotic.traffic] HTTP POST http://192.168.1.***/domo/ [status=200, 42.5ms]
+    --> {"sl_cmd":"sl_registration_req","sl_login":"ad***","sl_pwd":"***"}
+    <-- {"sl_client_id":"504***","sl_keep_alive_timeout_sec":900,"sl_data_ack_reason":0}
+
+The following fields are redacted automatically:
+
+- ``sl_pwd``, ``sl_new_pwd`` → fully replaced with ``***``
+- ``sl_login`` → first 2 characters preserved (e.g. ``ad***``)
+- ``sl_client_id``, ``client`` → first 3 characters preserved (e.g. ``504***``)
+- ``keycode`` → first 8 characters preserved (e.g. ``61305E97********``)
+- ``serial`` → first 3 characters preserved (e.g. ``037***``)
+- Camera URIs (``uri``, ``uri_still``) → embedded credentials redacted
+- Host IP in the URL → last octet masked (e.g. ``192.168.1.***``)
+- Usernames inside ``sl_users_list`` items → partially masked
+
+.. note::
+    The traffic logger level is independent from the main library logger.
+    Setting ``aiocamedomotic`` to ``WARNING`` and
+    ``aiocamedomotic.traffic`` to ``DEBUG`` is a valid configuration —
+    you will see only the HTTP traffic, without the library's internal
+    debug messages.
+
+.. tip::
+    To write the traffic log to a **file** for later analysis, add a
+    dedicated ``FileHandler``. Use ``propagate = False`` if you want the
+    traffic to go *only* to the file and not to the console:
+
+    .. code-block:: python
+
+        import logging
+
+        traffic_logger = logging.getLogger("aiocamedomotic.traffic")
+        traffic_logger.setLevel(logging.DEBUG)
+        traffic_logger.addHandler(logging.FileHandler("came_traffic.log"))
+        traffic_logger.propagate = False  # file only, no console output
+
 .. seealso::
     For full API details, see the :doc:`api_reference`.

--- a/tests/aiocamedomotic/test_anonymizer.py
+++ b/tests/aiocamedomotic/test_anonymizer.py
@@ -1,0 +1,402 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-class-docstring
+
+"""Tests for the anonymizer module."""
+
+import logging
+from unittest.mock import patch
+
+from aiocamedomotic.anonymizer import (
+    TRAFFIC_LOGGER,
+    _anonymize_host,
+    _anonymize_uri,
+    _anonymize_url,
+    _anonymize_value,
+    _partial_redact,
+    anonymize_payload,
+    log_traffic,
+)
+
+# ---------------------------------------------------------------------------
+# _partial_redact
+# ---------------------------------------------------------------------------
+
+
+class TestPartialRedact:
+    def test_normal_string(self):
+        assert _partial_redact("admin", 2, "***") == "ad***"
+
+    def test_exact_length(self):
+        assert _partial_redact("ab", 2, "***") == "ab***"
+
+    def test_short_string_fully_redacted(self):
+        assert _partial_redact("a", 2, "***") == "***"
+
+    def test_empty_string_fully_redacted(self):
+        assert _partial_redact("", 2, "***") == "***"
+
+    def test_long_keycode(self):
+        assert _partial_redact("61305E975DE3F469", 8, "********") == "61305E97********"
+
+
+# ---------------------------------------------------------------------------
+# _anonymize_host
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizeHost:
+    def test_ipv4_address(self):
+        assert _anonymize_host("192.168.1.100") == "192.168.1.***"
+
+    def test_ipv4_short_octets(self):
+        assert _anonymize_host("10.0.0.1") == "10.0.0.***"
+
+    def test_hostname_with_domain(self):
+        assert _anonymize_host("came-server.local") == "came-server.***"
+
+    def test_hostname_with_multiple_segments(self):
+        assert _anonymize_host("came.server.example.com") == "came.***"
+
+    def test_single_segment_hostname(self):
+        assert _anonymize_host("localhost") == "***"
+
+    def test_empty_string(self):
+        assert _anonymize_host("") == "***"
+
+
+# ---------------------------------------------------------------------------
+# _anonymize_url
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizeUrl:
+    def test_http_url_with_ipv4(self):
+        result = _anonymize_url("http://192.168.1.100/domo/")
+        assert result == "http://192.168.1.***/domo/"
+
+    def test_url_with_port(self):
+        result = _anonymize_url("http://192.168.1.100:8080/domo/")
+        assert result == "http://192.168.1.***:8080/domo/"
+
+    def test_url_with_hostname(self):
+        result = _anonymize_url("http://came-server.local/domo/")
+        assert result == "http://came-server.***/domo/"
+
+    def test_empty_url(self):
+        assert _anonymize_url("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _anonymize_uri
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizeUri:
+    def test_uri_with_credentials(self):
+        result = _anonymize_uri("http://user:pass@192.168.1.100:8080/stream")
+        assert result == "http://***:***@192.168.1.100:8080/stream"
+
+    def test_uri_with_user_only(self):
+        result = _anonymize_uri("http://user@192.168.1.100/stream")
+        assert result == "http://***:***@192.168.1.100/stream"
+
+    def test_uri_without_credentials(self):
+        uri = "http://192.168.1.100/stream"
+        assert _anonymize_uri(uri) == uri
+
+    def test_empty_uri(self):
+        assert _anonymize_uri("") == ""
+
+    def test_uri_with_query_and_fragment(self):
+        result = _anonymize_uri("http://user:pass@host/path?t=123#frag")
+        assert "***:***@host" in result
+        assert "?t=123" in result
+        assert "#frag" in result
+
+
+# ---------------------------------------------------------------------------
+# _anonymize_value
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizeValue:
+    # Full redaction
+    def test_sl_pwd_fully_redacted(self):
+        assert _anonymize_value("sl_pwd", "my_secret") == "***"
+
+    def test_sl_new_pwd_fully_redacted(self):
+        assert _anonymize_value("sl_new_pwd", "new_secret") == "***"
+
+    def test_sl_pwd_non_string_unchanged(self):
+        assert _anonymize_value("sl_pwd", 12345) == 12345
+
+    # Partial redaction
+    def test_sl_login_partial(self):
+        assert _anonymize_value("sl_login", "admin") == "ad***"
+
+    def test_sl_login_short(self):
+        assert _anonymize_value("sl_login", "a") == "***"
+
+    def test_sl_client_id_partial(self):
+        assert _anonymize_value("sl_client_id", "5046b5a9") == "504***"
+
+    def test_client_partial(self):
+        assert _anonymize_value("client", "5046b5a9") == "504***"
+
+    def test_keycode_partial(self):
+        assert _anonymize_value("keycode", "61305E975DE3F469") == "61305E97********"
+
+    def test_serial_partial(self):
+        assert _anonymize_value("serial", "03718b9a") == "037***"
+
+    def test_partial_non_string_unchanged(self):
+        assert _anonymize_value("sl_client_id", 12345) == 12345
+
+    # URI fields
+    def test_uri_with_credentials(self):
+        result = _anonymize_value("uri", "http://user:pass@host/stream")
+        assert "***:***@host" in result
+
+    def test_uri_still_with_credentials(self):
+        result = _anonymize_value("uri_still", "http://user:pass@host/snap.jpg")
+        assert "***:***@host" in result
+
+    def test_uri_non_string_unchanged(self):
+        assert _anonymize_value("uri", None) is None
+
+    # Non-sensitive fields
+    def test_non_sensitive_field_unchanged(self):
+        assert _anonymize_value("cmd_name", "light_list_req") == "light_list_req"
+
+    def test_device_name_not_redacted(self):
+        assert _anonymize_value("name", "Living Room Light") == "Living Room Light"
+
+    # sl_users_list context-aware handling
+    def test_sl_users_list_name_redacted(self):
+        users = [{"name": "admin"}, {"name": "guest"}]
+        result = _anonymize_value("sl_users_list", users)
+        assert result[0]["name"] == "ad***"
+        assert result[1]["name"] == "gu***"
+
+    def test_sl_users_list_sl_login_redacted(self):
+        users = [{"sl_login": "admin"}]
+        result = _anonymize_value("sl_users_list", users)
+        assert result[0]["sl_login"] == "ad***"
+
+    def test_sl_users_list_non_dict_items_preserved(self):
+        users = ["admin", 42]
+        result = _anonymize_value("sl_users_list", users)
+        assert result == ["admin", 42]
+
+    def test_sl_users_list_does_not_modify_original(self):
+        users = [{"name": "admin"}]
+        _anonymize_value("sl_users_list", users)
+        assert users[0]["name"] == "admin"
+
+
+# ---------------------------------------------------------------------------
+# anonymize_payload
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizePayload:
+    def test_login_request(self):
+        payload = {
+            "sl_cmd": "sl_registration_req",
+            "sl_login": "admin",
+            "sl_pwd": "secret123",
+        }
+        result = anonymize_payload(payload)
+        assert result["sl_cmd"] == "sl_registration_req"
+        assert result["sl_login"] == "ad***"
+        assert result["sl_pwd"] == "***"
+
+    def test_data_request_with_nested_client(self):
+        payload = {
+            "sl_appl_msg": {
+                "cseq": 5,
+                "client": "5046b5a9",
+                "cmd_name": "light_list_req",
+            },
+            "sl_client_id": "5046b5a9",
+            "sl_cmd": "sl_data_req",
+            "sl_appl_msg_type": "domo",
+        }
+        result = anonymize_payload(payload)
+        assert result["sl_client_id"] == "504***"
+        assert result["sl_appl_msg"]["client"] == "504***"
+        assert result["sl_appl_msg"]["cmd_name"] == "light_list_req"
+        assert result["sl_appl_msg"]["cseq"] == 5
+
+    def test_password_change_request(self):
+        payload = {
+            "sl_cmd": "sl_user_pwd_change_req",
+            "sl_login": "admin",
+            "sl_pwd": "oldpass",
+            "sl_new_pwd": "newpass",
+        }
+        result = anonymize_payload(payload)
+        assert result["sl_login"] == "ad***"
+        assert result["sl_pwd"] == "***"
+        assert result["sl_new_pwd"] == "***"
+
+    def test_feature_list_response(self):
+        payload = {
+            "cmd_name": "feature_list_resp",
+            "keycode": "0000FFFF9999AAAA",
+            "serial": "0011ffee",
+            "swver": "1.2.3",
+            "sl_data_ack_reason": 0,
+        }
+        result = anonymize_payload(payload)
+        assert result["keycode"] == "0000FFFF********"
+        assert result["serial"] == "001***"
+        assert result["swver"] == "1.2.3"
+
+    def test_users_list_response(self):
+        payload = {
+            "sl_cmd": "sl_users_list_resp",
+            "sl_data_ack_reason": 0,
+            "sl_client_id": "75c6c33a",
+            "sl_users_list": [{"name": "admin"}],
+        }
+        result = anonymize_payload(payload)
+        assert result["sl_client_id"] == "75c***"
+        assert result["sl_users_list"][0]["name"] == "ad***"
+
+    def test_camera_response_with_credentials(self):
+        payload = {
+            "cmd_name": "tvcc_cameras_list_resp",
+            "array": [
+                {
+                    "id": 1,
+                    "name": "Front Door Camera",
+                    "uri": "http://user:pass@192.168.1.100:8080/stream.swf",
+                    "uri_still": "http://user:pass@192.168.1.100:8080/snapshot.jpg",
+                }
+            ],
+        }
+        result = anonymize_payload(payload)
+        cam = result["array"][0]
+        assert "***:***@" in cam["uri"]
+        assert "***:***@" in cam["uri_still"]
+        assert cam["name"] == "Front Door Camera"  # device name NOT redacted
+
+    def test_deep_copy_no_mutation(self):
+        payload = {
+            "sl_login": "admin",
+            "sl_pwd": "secret",
+            "nested": {"sl_client_id": "abc123"},
+        }
+        anonymize_payload(payload)
+        assert payload["sl_login"] == "admin"
+        assert payload["sl_pwd"] == "secret"
+        assert payload["nested"]["sl_client_id"] == "abc123"
+
+    def test_empty_dict(self):
+        assert anonymize_payload({}) == {}
+
+    def test_nested_list_of_dicts(self):
+        payload = {
+            "result": [
+                {"cmd_name": "light_switch_ind", "act_id": 1, "status": 1},
+                {"cmd_name": "light_switch_ind", "act_id": 2, "status": 0},
+            ]
+        }
+        result = anonymize_payload(payload)
+        assert result["result"][0]["act_id"] == 1
+        assert result["result"][1]["status"] == 0
+
+    def test_add_user_request(self):
+        payload = {
+            "sl_client_id": "abcdef12",
+            "sl_cmd": "sl_add_user_req",
+            "sl_login": "newuser",
+            "sl_pwd": "newpassword",
+        }
+        result = anonymize_payload(payload)
+        assert result["sl_client_id"] == "abc***"
+        assert result["sl_login"] == "ne***"
+        assert result["sl_pwd"] == "***"
+
+
+# ---------------------------------------------------------------------------
+# log_traffic
+# ---------------------------------------------------------------------------
+
+
+class TestLogTraffic:
+    def test_post_with_request_and_response(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
+            log_traffic(
+                "POST",
+                "http://192.168.1.100/domo/",
+                {"sl_cmd": "sl_registration_req", "sl_login": "admin", "sl_pwd": "x"},
+                {"sl_client_id": "5046b5a9", "sl_data_ack_reason": 0},
+                200,
+                42.5,
+            )
+
+        assert len(caplog.records) == 1
+        text = caplog.records[0].message
+        assert "HTTP POST" in text
+        assert "192.168.1.***" in text
+        assert "status=200" in text
+        assert "42.5ms" in text
+        assert '"sl_login":"ad***"' in text
+        assert '"sl_pwd":"***"' in text
+        assert '"sl_client_id":"504***"' in text
+
+    def test_get_with_none_payloads(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
+            log_traffic("GET", "http://192.168.1.100/domo/", None, None, None, 10.0)
+
+        assert len(caplog.records) == 1
+        text = caplog.records[0].message
+        assert "HTTP GET" in text
+        assert "-->" not in text
+        assert "<--" not in text
+
+    def test_elapsed_time_in_output(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
+            log_traffic("POST", "http://host/domo/", {}, {}, 200, 123.456)
+
+        text = caplog.records[0].message
+        assert "123.5ms" in text
+
+    def test_exception_in_anonymization_swallowed(self, caplog):
+        with (
+            patch(
+                "aiocamedomotic.anonymizer.anonymize_payload",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.WARNING, logger="aiocamedomotic.traffic"),
+        ):
+            log_traffic("POST", "http://host/", {"sl_pwd": "x"}, None, 200, 1.0)
+
+        assert any("Traffic logging failed" in r.message for r in caplog.records)
+
+    def test_logger_name(self):
+        assert TRAFFIC_LOGGER.name == "aiocamedomotic.traffic"
+
+    def test_non_dict_response(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
+            log_traffic("POST", "http://host/domo/", None, "plain text", 200, 5.0)
+
+        text = caplog.records[0].message
+        assert "<-- plain text" in text

--- a/tests/aiocamedomotic/test_anonymizer.py
+++ b/tests/aiocamedomotic/test_anonymizer.py
@@ -162,7 +162,7 @@ class TestAnonymizeValue:
         assert _anonymize_value("keycode", "61305E975DE3F469") == "61305E97********"
 
     def test_serial_partial(self):
-        assert _anonymize_value("serial", "03718b9a") == "037***"
+        assert _anonymize_value("serial", "03718b9a") == "037*****"
 
     def test_partial_non_string_unchanged(self):
         assert _anonymize_value("sl_client_id", 12345) == 12345
@@ -265,7 +265,7 @@ class TestAnonymizePayload:
         }
         result = anonymize_payload(payload)
         assert result["keycode"] == "0000FFFF********"
-        assert result["serial"] == "001***"
+        assert result["serial"] == "001*****"
         assert result["swver"] == "1.2.3"
 
     def test_users_list_response(self):

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -1338,3 +1338,108 @@ class TestKeepAliveClamping:
                 auth_instance_not_logged_in.keep_alive_timeout_sec
                 == _KEEP_ALIVE_MAX_SEC
             )
+
+
+class TestTrafficLogging:
+    """Tests for traffic logging integration in Auth methods."""
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_send_command_logs_traffic(self, auth_instance):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 0}
+
+        with (
+            patch.object(
+                auth_instance.websession, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id,
+            patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic,
+        ):
+            mock_post.return_value = mock_response
+            mock_get_client_id.return_value = "test_client_id"
+
+            await auth_instance.async_send_command({"cmd_name": "test"})
+
+            mock_log_traffic.assert_called_once()
+            call_args = mock_log_traffic.call_args
+            assert call_args[0][0] == "POST"
+            assert "domo" in call_args[0][1]
+            assert isinstance(call_args[0][2], dict)  # request payload
+            assert call_args[0][3] == {"sl_data_ack_reason": 0}  # response
+            assert call_args[0][4] == 200  # HTTP status
+            assert isinstance(call_args[0][5], float)  # elapsed_ms
+
+    async def test_validate_host_logs_traffic(self):
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+
+        async with aiohttp.ClientSession() as session:
+            with patch("aiohttp.ClientSession.get") as mock_get:
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                async with await Auth.async_create(
+                    session, "192.168.x.x", "username", "password"
+                ) as auth:
+                    with patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic:
+                        await auth.async_validate_host()
+
+                        mock_log_traffic.assert_called_once()
+                        call_args = mock_log_traffic.call_args
+                        assert call_args[0][0] == "GET"
+                        assert call_args[0][2] is None  # no request payload
+                        assert call_args[0][3] is None  # no response payload
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_send_command_logs_on_error(self, auth_instance):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 1}
+
+        with (
+            patch.object(
+                auth_instance.websession, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id,
+            patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic,
+        ):
+            mock_post.return_value = mock_response
+            mock_get_client_id.return_value = "test_client_id"
+
+            with pytest.raises(CameDomoticAuthError):
+                await auth_instance.async_send_command({"cmd_name": "test"})
+
+            mock_log_traffic.assert_called_once()
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_traffic_logging_failure_does_not_affect_command(self, auth_instance):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 0}
+
+        with (
+            patch.object(
+                auth_instance.websession, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id,
+            patch(
+                "aiocamedomotic.auth.log_traffic",
+                side_effect=RuntimeError("logging broken"),
+            ),
+        ):
+            mock_post.return_value = mock_response
+            mock_get_client_id.return_value = "test_client_id"
+
+            # Command should succeed despite log_traffic raising
+            result = await auth_instance.async_send_command({"cmd_name": "test"})
+            assert result == {"sl_data_ack_reason": 0}


### PR DESCRIPTION
## Summary
- Add a new `anonymizer` module that provides privacy-safe HTTP traffic logging (request/response payloads with sensitive fields like passwords, client IDs, and serial numbers redacted)
- Integrate traffic logging into `Auth.async_send_command` and `Auth.async_validate_host` for all API interactions
- Capture HTTP status in `async_validate_host` traffic logs (was previously always `None`)
- Fix serial field redaction mask assertions in anonymizer tests

## Test plan
- [x] All 540 tests pass (including 55 new anonymizer tests)
- [x] Pre-commit hooks pass (ruff, bandit, mypy, codespell, pytest)
- [ ] Verify traffic logs appear at DEBUG level with anonymized payloads
- [ ] Confirm no sensitive data leaks in log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in traffic logging for HTTP requests/responses with automatic anonymization of sensitive fields, hosts, and URIs; safe failure handling ensures logging won’t affect operations.
* **Documentation**
  * Added a guide on debugging with traffic logging: enable via logging config, example output, and list of redacted fields.
* **Tests**
  * Added comprehensive tests validating anonymization, logging output, nested payload handling, and resilience to anonymization/logging errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->