### PR TITLE
Add analog-in (standalone sensor) device support

### DIFF
--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -432,10 +432,9 @@ class Auth:
 
         cmd_name = (command or {}).get("cmd_name", command_type)
         LOGGER.debug(
-            "Sending command '%s' (type: %s) to %s",
+            "Sending command '%s' (type: %s)",
             cmd_name,
             command_type,
-            self.get_endpoint_url(),
         )
 
         _traffic_start = time.monotonic()

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -38,6 +38,7 @@ from .const import (
 )
 from .errors import CameDomoticAuthError
 from .models import (
+    AnalogIn,
     AnalogSensor,
     AnalogSensorType,
     Camera,
@@ -499,6 +500,34 @@ class CameDomoticAPI:
         return [
             DigitalInput(digitalin_data, self.auth) for digitalin_data in digitalin_list
         ]
+
+    async def async_get_analog_inputs(self) -> list[AnalogIn]:
+        """Get the list of all standalone analog input sensors on the server.
+
+        Analog inputs are read-only sensors (e.g. hygrometers, thermometers,
+        barometers) exposed via the ``analogin`` feature. They are independent
+        of the thermoregulation system's analog sensors.
+
+        Returns:
+            list[AnalogIn]: List of analog input sensors.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching analog inputs list")
+        payload = {
+            "cmd_name": _CommandName.ANALOGIN_LIST.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.ANALOGIN_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        analogin_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d analog input(s)", len(analogin_list))
+        return [AnalogIn(analogin_data) for analogin_data in analogin_list]
 
     async def async_get_cameras(self) -> list[Camera]:
         """Get the list of all TVCC cameras defined on the server.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -81,6 +81,7 @@ class DeviceType(IntEnum):
     identifiers. Not all device types are currently supported by this library.
 
     Values:
+        - ANALOG_INPUT (-3)
         - ENERGY_SENSOR (-2)
         - ANALOG_SENSOR (-1)
         - LIGHT (0)
@@ -100,6 +101,7 @@ class DeviceType(IntEnum):
         - DIGITAL_INPUT (14)
     """
 
+    ANALOG_INPUT = -3
     ENERGY_SENSOR = -2
     ANALOG_SENSOR = -1
     LIGHT = 0
@@ -149,6 +151,7 @@ class _CommandName(Enum):
     THERMO_LIST = "thermo_list_req"
     METERS_LIST = "meters_list_req"
     DIGITALIN_LIST = "digitalin_list_req"
+    ANALOGIN_LIST = "analogin_list_req"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_req"
     # Nested lists (topology-aware)
     NESTED_LIGHT_LIST = "nested_light_list_req"
@@ -181,6 +184,7 @@ class _CommandNameResponse(Enum):
     THERMO_LIST = "thermo_list_resp"
     METERS_LIST = "meters_list_resp"
     DIGITALIN_LIST = "digitalin_list_resp"
+    ANALOGIN_LIST = "analogin_list_resp"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_resp"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
     MAP_DESCR = "map_descr_resp"
@@ -202,6 +206,7 @@ class _ServerFeature(Enum):
     THERMOREGULATION = "thermoregulation"
     SCENARIOS = "scenarios"
     DIGITALIN = "digitalin"
+    ANALOGIN = "analogin"
     ENERGY = "energy"
     LOADSCTRL = "loadsctrl"
 
@@ -247,6 +252,7 @@ class UpdateIndicator(Enum):
         - RELAY ("relay_status_ind")
         - THERMOSTAT ("thermo_zone_info_ind")
         - DIGITAL_INPUT ("digitalin_status_ind")
+        - ANALOG_INPUT ("analogin_status_ind")
         - SCENARIO_STATUS ("scenario_status_ind")
         - SCENARIO_ACTIVATION ("scenario_activation_ind")
         - ENERGY_METER ("meter_instant_power_ind")
@@ -258,6 +264,7 @@ class UpdateIndicator(Enum):
         - THERMOSTAT_LEGACY ("thermo_update_ind")
         - RELAY_LEGACY ("relay_update_ind")
         - DIGITAL_INPUT_LEGACY ("digitalin_update_ind")
+        - ANALOG_INPUT_LEGACY ("analogin_update_ind")
         - SCENARIO_USER_LEGACY ("scenario_user_ind")
     """
 
@@ -267,6 +274,7 @@ class UpdateIndicator(Enum):
     RELAY = "relay_status_ind"
     THERMOSTAT = "thermo_zone_info_ind"
     DIGITAL_INPUT = "digitalin_status_ind"
+    ANALOG_INPUT = "analogin_status_ind"
     SCENARIO_STATUS = "scenario_status_ind"
     SCENARIO_ACTIVATION = "scenario_activation_ind"
     ENERGY_METER = "meter_instant_power_ind"
@@ -279,6 +287,7 @@ class UpdateIndicator(Enum):
     THERMOSTAT_LEGACY = "thermo_update_ind"
     RELAY_LEGACY = "relay_update_ind"
     DIGITAL_INPUT_LEGACY = "digitalin_update_ind"
+    ANALOG_INPUT_LEGACY = "analogin_update_ind"
     SCENARIO_USER_LEGACY = "scenario_user_ind"
 
 
@@ -289,6 +298,7 @@ _UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
     "opening_move_ind": DeviceType.OPENING,
     "thermo_zone_info_ind": DeviceType.THERMOSTAT,
     "digitalin_status_ind": DeviceType.DIGITAL_INPUT,
+    "analogin_status_ind": DeviceType.ANALOG_INPUT,
     "scenario_status_ind": DeviceType.SCENARIO,
     "scenario_activation_ind": DeviceType.SCENARIO,
     "meter_instant_power_ind": DeviceType.ENERGY_SENSOR,
@@ -299,6 +309,7 @@ _UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
     "thermo_update_ind": DeviceType.THERMOSTAT,
     "relay_update_ind": DeviceType.GENERIC_RELAY,
     "digitalin_update_ind": DeviceType.DIGITAL_INPUT,
+    "analogin_update_ind": DeviceType.ANALOG_INPUT,
     "scenario_user_ind": DeviceType.SCENARIO,
     # plant_update_ind intentionally omitted: it requires full cache
     # invalidation, not a per-device update
@@ -313,4 +324,5 @@ _DEVICE_TYPE_TO_FEATURE: dict[DeviceType, _ServerFeature] = {
     DeviceType.SCENARIO: _ServerFeature.SCENARIOS,
     DeviceType.DIGITAL_INPUT: _ServerFeature.DIGITALIN,
     DeviceType.ENERGY_SENSOR: _ServerFeature.ENERGY,
+    DeviceType.ANALOG_INPUT: _ServerFeature.ANALOGIN,
 }

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -20,6 +20,7 @@ CAME Domotic API.
 from __future__ import annotations
 
 from ..const import DeviceType, UpdateIndicator  # noqa: F401
+from .analog_in import AnalogIn  # noqa: F401
 from .base import (  # noqa: F401
     CameEntity,
     Floor,
@@ -52,6 +53,7 @@ from .thermo_zone import (  # noqa: F401
     ThermoZoneStatus,
 )
 from .update import (  # noqa: F401
+    AnalogInUpdate,
     DeviceUpdate,
     DigitalInputUpdate,
     LightUpdate,
@@ -66,6 +68,8 @@ from .update import (  # noqa: F401
 )
 
 __all__ = [
+    "AnalogIn",
+    "AnalogInUpdate",
     "AnalogSensor",
     "AnalogSensorType",
     "Camera",

--- a/aiocamedomotic/models/analog_in.py
+++ b/aiocamedomotic/models/analog_in.py
@@ -1,0 +1,94 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic analog input entity models.
+
+This module implements the class for working with standalone analog input
+sensors in a CAME Domotic system. Analog inputs represent read-only analog
+sensors such as hygrometers, thermometers, and barometers exposed via the
+``analogin`` feature. They provide sensor readings but do not support
+control commands.
+
+These sensors are independent of the thermoregulation system's
+:class:`~aiocamedomotic.models.thermo_zone.AnalogSensor`, which is retrieved
+from the ``thermo_list_resp`` endpoint. The same physical sensor may appear
+in both endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..utils import EntityValidator
+from .base import CameEntity
+
+
+@dataclass
+class AnalogIn(CameEntity):
+    """Standalone analog input sensor from the ``analogin_list_resp`` endpoint.
+
+    Represents a read-only analog sensor (e.g. hygrometer, thermometer,
+    barometer) exposed via the ``analogin`` feature.
+
+    Args:
+        raw_data: Dictionary containing the sensor data from the API.
+
+    Raises:
+        ValueError: If ``name`` or ``act_id`` keys are missing from
+            the input data.
+
+    Note:
+        Temperature values (``unit == "C"``) are stored as integers multiplied
+        by 10 (e.g. 215 = 21.5 °C). The :attr:`value` property applies the
+        conversion automatically.
+    """
+
+    raw_data: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "act_id"],
+            typed_keys={"act_id": int},
+        )
+
+    @property
+    def act_id(self) -> int:
+        """Unique actuator/sensor identifier."""
+        return self.raw_data["act_id"]
+
+    @property
+    def name(self) -> str:
+        """Display name of the sensor."""
+        return self.raw_data["name"]
+
+    @property
+    def value(self) -> float:
+        """Sensor reading in the unit reported by :attr:`unit`.
+
+        Temperature readings (``unit == "C"``) are divided by 10 to convert
+        from the API's integer encoding to degrees Celsius. All other units
+        are returned as-is.
+        """
+        raw = self.raw_data.get("value", 0)
+        if self.unit == "C":
+            return raw / 10.0
+        return float(raw)
+
+    @property
+    def unit(self) -> str:
+        """Unit of measurement (e.g. ``'C'``, ``'%'``, ``'hPa'``)."""
+        return self.raw_data.get("unit", "")

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -384,6 +384,31 @@ class DigitalInputUpdate(DeviceUpdate):
 
 
 @dataclass
+class AnalogInUpdate(DeviceUpdate):
+    """Typed update for an analog input sensor (``analogin_status_ind`` /
+    ``analogin_update_ind``).
+    """
+
+    @property
+    def act_id(self) -> int:
+        """Analog input actuator ID."""
+        return self.raw_data["act_id"]
+
+    @property
+    def value(self) -> float:
+        """Sensor reading, with temperature scaling applied for unit ``'C'``."""
+        raw = self.raw_data.get("value", 0)
+        if self.raw_data.get("unit") == "C":
+            return raw / 10.0
+        return float(raw)
+
+    @property
+    def unit(self) -> str:
+        """Unit of measurement."""
+        return self.raw_data.get("unit", "")
+
+
+@dataclass
 class PlantUpdate(DeviceUpdate):
     """Marker update for ``plant_update_ind``.
 
@@ -415,6 +440,8 @@ _INDICATOR_TO_UPDATE_CLASS: dict[str, type[DeviceUpdate]] = {
     "relay_update_ind": RelayUpdate,
     "digitalin_status_ind": DigitalInputUpdate,
     "digitalin_update_ind": DigitalInputUpdate,
+    "analogin_status_ind": AnalogInUpdate,
+    "analogin_update_ind": AnalogInUpdate,
     "plant_update_ind": PlantUpdate,
 }
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -38,6 +38,9 @@ Entity models
 .. automodule:: aiocamedomotic.models.base
    :members:
 
+.. automodule:: aiocamedomotic.models.analog_in
+   :members:
+
 .. automodule:: aiocamedomotic.models.camera
    :members:
 

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -220,6 +220,7 @@ Example output:
     Feature: thermoregulation
     Feature: scenarios
     Feature: digitalin
+    Feature: analogin
     Feature: energy
     Feature: loadsctrl
 
@@ -245,6 +246,9 @@ You can use the features list to decide which device APIs to call:
 
     if "digitalin" in server_info.features:
         digital_inputs = await api.async_get_digital_inputs()
+
+    if "analogin" in server_info.features:
+        analog_inputs = await api.async_get_analog_inputs()
 
 Floors and rooms
 ^^^^^^^^^^^^^^^^
@@ -551,6 +555,53 @@ Example output:
 .. note::
     Some digital inputs do not report a ``status`` until their first state
     change. In that case, ``status`` returns ``DigitalInputStatus.UNKNOWN``.
+
+Analog inputs (standalone sensors)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Analog inputs are read-only standalone sensors such as hygrometers,
+thermometers, and barometers exposed via the ``analogin`` feature. They
+provide a numeric reading and a unit of measurement but cannot be
+controlled remotely.
+
+.. note::
+    These sensors are independent of the thermoregulation system's
+    :class:`~aiocamedomotic.models.AnalogSensor`. The same physical sensor
+    may appear in both endpoints.
+
+.. code-block:: python
+
+    if "analogin" in server_info.features:
+        analog_inputs = await api.async_get_analog_inputs()
+
+        for ai in analog_inputs:
+            print(
+                f"ID: {ai.act_id}, Name: {ai.name}, "
+                f"Value: {ai.value}, Unit: {ai.unit}"
+            )
+
+Example output:
+
+.. code-block:: text
+
+    ID: 89, Name: Igrometro, Value: 47.0, Unit: %
+    ID: 90, Name: Termometro esterno, Value: 21.5, Unit: C
+    ID: 91, Name: Barometro, Value: 1013.0, Unit: hPa
+
+**Finding a specific analog input:**
+
+.. code-block:: python
+
+    # By ID
+    thermo = next((ai for ai in analog_inputs if ai.act_id == 90), None)
+
+    # By name
+    hygro = next((ai for ai in analog_inputs if ai.name == "Igrometro"), None)
+
+.. note::
+    Temperature values (``unit == "C"``) are automatically scaled from the
+    raw integer-times-10 representation (e.g. ``215`` becomes ``21.5``).
+    Humidity and pressure values are returned as-is.
 
 Relays
 ^^^^^^

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -341,6 +341,39 @@ def analog_sensor_data_humidity():
 
 
 @pytest.fixture
+def analog_in_data_temperature():
+    """Mock data for a standalone analog input temperature sensor."""
+    return {
+        "name": "Termometro esterno",
+        "act_id": 90,
+        "value": 215,
+        "unit": "C",
+    }
+
+
+@pytest.fixture
+def analog_in_data_humidity():
+    """Mock data for a standalone analog input humidity sensor."""
+    return {
+        "name": "Igrometro",
+        "act_id": 89,
+        "value": 47,
+        "unit": "%",
+    }
+
+
+@pytest.fixture
+def analog_in_data_pressure():
+    """Mock data for a standalone analog input barometric pressure sensor."""
+    return {
+        "name": "Barometro",
+        "act_id": 91,
+        "value": 1013,
+        "unit": "hPa",
+    }
+
+
+@pytest.fixture
 def digital_input_data_with_status():
     """Mock data for a digital input that reports a status."""
     return {

--- a/tests/aiocamedomotic/mocked_requests.py
+++ b/tests/aiocamedomotic/mocked_requests.py
@@ -264,6 +264,17 @@ SL_CHANGE_USER_PASSWORD_REQ = {
     "sl_new_pwd": "new_password",
 }
 
+ANALOGIN_LIST_REQ = {
+    "sl_appl_msg": {
+        "client": "my_session_id",
+        "cmd_name": "analogin_list_req",
+        "cseq": 1,
+    },
+    "sl_appl_msg_type": "domo",
+    "sl_client_id": "my_session_id",
+    "sl_cmd": "sl_data_req",
+}
+
 TERMINALS_GROUPS_LIST_REQ = {
     "sl_appl_msg": {
         "client": "my_session_id",

--- a/tests/aiocamedomotic/mocked_responses.py
+++ b/tests/aiocamedomotic/mocked_responses.py
@@ -570,6 +570,32 @@ MAPS_LIST_RESP = {
     "sl_data_ack_reason": 0,
 }
 
+ANALOGIN_LIST_RESP = {
+    "cseq": 3,
+    "cmd_name": "analogin_list_resp",
+    "array": [
+        {
+            "name": "Igrometro",
+            "act_id": 89,
+            "value": 47,
+            "unit": "%",
+        },
+        {
+            "name": "Termometro esterno",
+            "act_id": 90,
+            "value": 215,
+            "unit": "C",
+        },
+        {
+            "name": "Barometro",
+            "act_id": 91,
+            "value": 1013,
+            "unit": "hPa",
+        },
+    ],
+    "sl_data_ack_reason": 0,
+}
+
 GENERIC_REPLY = {
     "cseq": 4,
     "cmd_name": "generic_reply",

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -29,6 +29,7 @@ from aiocamedomotic.errors import (
     CameDomoticServerTimeoutError,
 )
 from aiocamedomotic.models import (
+    AnalogIn,
     AnalogSensor,
     AnalogSensorType,
     Camera,
@@ -49,6 +50,7 @@ from aiocamedomotic.models import (
     User,
 )
 from tests.aiocamedomotic.mocked_responses import (
+    ANALOGIN_LIST_RESP,
     DIGITALIN_LIST_RESP,
     FEATURE_LIST_RESP,
     LIGHT_LIST_RESP,
@@ -1485,6 +1487,95 @@ class TestAPIDigitalInputs:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_digital_inputs()
+
+
+class TestAPIAnalogInputs:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = ANALOGIN_LIST_RESP
+
+        analog_inputs = await api.async_get_analog_inputs()
+        assert len(analog_inputs) == 3
+        assert isinstance(analog_inputs[0], AnalogIn)
+        assert isinstance(analog_inputs[1], AnalogIn)
+        assert isinstance(analog_inputs[2], AnalogIn)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "analogin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        analog_inputs = await api.async_get_analog_inputs()
+        assert len(analog_inputs) == 0
+        assert isinstance(analog_inputs, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "analogin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        analog_inputs = await api.async_get_analog_inputs()
+        assert len(analog_inputs) == 0
+        assert isinstance(analog_inputs, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs_null_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "analogin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        analog_inputs = await api.async_get_analog_inputs()
+        assert analog_inputs == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs_missing_act_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [{"name": "Test Sensor", "value": 215, "unit": "C"}],
+            "cmd_name": "analogin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            await api.async_get_analog_inputs()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_analog_inputs_missing_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [{"act_id": 90, "value": 215, "unit": "C"}],
+            "cmd_name": "analogin_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            await api.async_get_analog_inputs()
 
 
 class TestAPICameras:

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -32,6 +32,8 @@ from aiocamedomotic.const import (
 )
 from aiocamedomotic.errors import CameDomoticAuthError, CameDomoticServerError
 from aiocamedomotic.models import (
+    AnalogIn,
+    AnalogInUpdate,
     AnalogSensor,
     AnalogSensorType,
     Camera,
@@ -2626,6 +2628,112 @@ class TestAnalogSensor:
         sensor = AnalogSensor(sensor_data, AnalogSensorType.PRESSURE)
         assert sensor.sensor_type == AnalogSensorType.PRESSURE
         assert sensor.value == 1013.0
+
+
+class TestAnalogIn:
+    def test_init_temperature(self, analog_in_data_temperature):
+        sensor = AnalogIn(analog_in_data_temperature)
+        assert sensor.act_id == 90
+        assert sensor.name == "Termometro esterno"
+        assert sensor.value == 21.5
+        assert sensor.unit == "C"
+
+    def test_init_humidity(self, analog_in_data_humidity):
+        sensor = AnalogIn(analog_in_data_humidity)
+        assert sensor.act_id == 89
+        assert sensor.name == "Igrometro"
+        assert sensor.value == 47.0
+        assert sensor.unit == "%"
+
+    def test_init_pressure(self, analog_in_data_pressure):
+        sensor = AnalogIn(analog_in_data_pressure)
+        assert sensor.act_id == 91
+        assert sensor.name == "Barometro"
+        assert sensor.value == 1013.0
+        assert sensor.unit == "hPa"
+
+    def test_missing_name_raises(self):
+        data = {"act_id": 90, "value": 215, "unit": "C"}
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            AnalogIn(data)
+
+    def test_missing_act_id_raises(self):
+        data = {"name": "Test Sensor", "value": 215, "unit": "C"}
+        with pytest.raises(ValueError, match="Data is missing required keys: act_id"):
+            AnalogIn(data)
+
+    def test_optional_fields_defaults(self):
+        data = {"name": "Minimal Sensor", "act_id": 200}
+        sensor = AnalogIn(data)
+        assert sensor.name == "Minimal Sensor"
+        assert sensor.act_id == 200
+        assert sensor.value == 0.0
+        assert sensor.unit == ""
+
+    def test_temperature_scaling(self):
+        data = {"name": "Temp", "act_id": 1, "value": 215, "unit": "C"}
+        sensor = AnalogIn(data)
+        assert sensor.value == 21.5
+
+    def test_non_temperature_no_scaling(self):
+        data = {"name": "Humidity", "act_id": 2, "value": 47, "unit": "%"}
+        sensor = AnalogIn(data)
+        assert sensor.value == 47.0
+
+
+class TestAnalogInUpdate:
+    def test_parse_analogin_status_ind(self):
+        raw = {
+            "cmd_name": "analogin_status_ind",
+            "act_id": 90,
+            "name": "Termometro esterno",
+            "value": 215,
+            "unit": "C",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, AnalogInUpdate)
+        assert update.act_id == 90
+        assert update.value == 21.5
+        assert update.unit == "C"
+
+    def test_parse_analogin_update_ind(self):
+        raw = {
+            "cmd_name": "analogin_update_ind",
+            "act_id": 89,
+            "name": "Igrometro",
+            "value": 55,
+            "unit": "%",
+        }
+        update = parse_update(raw)
+        assert isinstance(update, AnalogInUpdate)
+        assert update.act_id == 89
+        assert update.value == 55.0
+        assert update.unit == "%"
+
+    def test_device_id(self):
+        raw = {
+            "cmd_name": "analogin_status_ind",
+            "act_id": 90,
+            "value": 215,
+            "unit": "C",
+        }
+        update = parse_update(raw)
+        assert update.device_id == 90
+
+    def test_value_temperature_scaling(self):
+        raw = {
+            "cmd_name": "analogin_status_ind",
+            "act_id": 1,
+            "value": 215,
+            "unit": "C",
+        }
+        update = parse_update(raw)
+        assert update.value == 21.5
+
+    def test_value_no_scaling(self):
+        raw = {"cmd_name": "analogin_status_ind", "act_id": 1, "value": 47, "unit": "%"}
+        update = parse_update(raw)
+        assert update.value == 47.0
 
 
 class TestDigitalInput:


### PR DESCRIPTION
## Summary
- Add full support for standalone analog input sensors (hygrometers, thermometers, barometers) via the CAME Domotic `analogin` feature, including model, API method, constants, tests, and documentation
- Remove endpoint URL from command debug log output to avoid exposing sensitive network information

## Test plan
- [x] Unit tests added for AnalogIn model and API integration
- [x] All existing tests pass
- [x] Pre-push hooks (ruff, mypy, bandit, pytest) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analog input sensors are now supported as standalone read-only devices.
  * Added new method to retrieve analog input sensor data and measurements.
  * Automatic temperature unit conversion for temperature sensors.

* **Documentation**
  * Added usage documentation and code examples for analog inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->