### PR TITLE
Bump workflow action versions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload built package as artifact
         if: ${{ github.event.inputs.publish_to_test == 'true' || github.event.inputs.publish_to_production == 'true' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: built-package
           path: dist/*

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -45,11 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v6 # v6.0.0
+      - uses: release-drafter/release-drafter@v7
         with:
           prerelease: true
           prerelease-identifier: alpha
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Autolabeler (split into dedicated action in v7)
+      - uses: release-drafter/release-drafter/autolabeler@v7


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` v6 → v7 in build-publish workflow
- Bump `release-drafter/release-drafter` v6 → v7 in release drafter workflow
  - `GITHUB_TOKEN` moved from `env` to `token` input (defaults to `github.token`)
  - Autolabeler split into dedicated `release-drafter/release-drafter/autolabeler` action

## Test plan
- [ ] Verify build-publish workflow still uploads artifacts correctly
- [ ] Verify release drafter creates draft releases on merge to main
- [ ] Verify autolabeler applies labels to PRs


🤖 Generated with [Claude Code](https://claude.com/claude-code)