### PR TITLE
Clean up docs and private APIs

### DIFF
--- a/aiocamedomotic/__init__.py
+++ b/aiocamedomotic/__init__.py
@@ -34,7 +34,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from .auth import Auth  # noqa: F401
 from .came_domotic_api import CameDomoticAPI  # noqa: F401
-from .const import CAME_MAC_PREFIXES  # noqa: F401
+from .const import CAME_MAC_PREFIXES, ServerFeature  # noqa: F401
 from .errors import CameDomoticServerTimeoutError  # noqa: F401
 from .utils import LOGGER, async_is_came_endpoint  # noqa: F401
 

--- a/aiocamedomotic/anonymizer.py
+++ b/aiocamedomotic/anonymizer.py
@@ -206,7 +206,7 @@ def _anonymize_dict(data: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def anonymize_payload(data: dict[str, Any]) -> dict[str, Any]:
+def _anonymize_payload(data: dict[str, Any]) -> dict[str, Any]:
     """Return a deep copy of *data* with sensitive fields anonymized.
 
     This function never modifies the original dictionary. The following
@@ -228,7 +228,7 @@ def anonymize_payload(data: dict[str, Any]) -> dict[str, Any]:
     return _anonymize_dict(copied)
 
 
-def log_traffic(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def _log_traffic(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     method: str,
     url: str,
     request_payload: dict[str, Any] | None,
@@ -259,12 +259,12 @@ def log_traffic(  # pylint: disable=too-many-arguments,too-many-positional-argum
         lines = [header]
 
         if request_payload is not None:
-            anon_request = anonymize_payload(request_payload)
+            anon_request = _anonymize_payload(request_payload)
             lines.append(f"--> {json.dumps(anon_request, separators=(',', ':'))}")
 
         if response_payload is not None:
             if isinstance(response_payload, dict):
-                anon_response = anonymize_payload(response_payload)
+                anon_response = _anonymize_payload(response_payload)
                 lines.append(f"<-- {json.dumps(anon_response, separators=(',', ':'))}")
             else:
                 lines.append(f"<-- {response_payload!s}")

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -45,6 +45,7 @@ from .const import (
     _DEFAULT_COMMAND_TIMEOUT,
     _KEEP_ALIVE_MAX_SEC,
     _KEEP_ALIVE_MIN_SEC,
+    AckErrorCode,
     _CommandType,
 )
 
@@ -498,8 +499,10 @@ class Auth:
             raise e
         except CameDomoticServerError as e:
             # Invalidate session on session-related ACK errors
-            # (7: no client ID, 8: wrong client ID)
-            if getattr(e, "ack_code", None) in {7, 8}:
+            if getattr(e, "ack_code", None) in {
+                AckErrorCode.NO_CLIENT_ID,
+                AckErrorCode.WRONG_CLIENT_ID,
+            }:
                 LOGGER.warning(
                     "Session invalidated due to ACK error %s,"
                     " will re-login on next command",

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -53,7 +53,7 @@ try:
     _LIBRARY_VERSION = version(__package__ or "aiocamedomotic")
 except PackageNotFoundError:
     _LIBRARY_VERSION = "unknown"
-from .anonymizer import log_traffic
+from .anonymizer import _log_traffic
 from .errors import (
     CameDomoticAuthError,
     CameDomoticServerError,
@@ -516,7 +516,7 @@ class Auth:
             raise CameDomoticServerError("Error sending command") from e
         finally:
             try:
-                log_traffic(
+                _log_traffic(
                     "POST",
                     self.get_endpoint_url(),
                     request_payload,
@@ -589,7 +589,7 @@ class Auth:
             ) from e
         finally:
             try:
-                log_traffic(
+                _log_traffic(
                     "GET",
                     endpoint_url,
                     None,

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -170,11 +170,6 @@ class CameDomoticAPI:
         Returns:
             User: A ``User`` object representing the newly created user.
 
-        .. warning::
-            This operation is based on reverse-engineered API documentation and
-            has not been verified against a real CAME Domotic server. Behaviour
-            may differ across firmware versions.
-
         Raises:
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
@@ -413,6 +408,10 @@ class CameDomoticAPI:
             :meth:`~aiocamedomotic.models.ThermoZone.async_set_mode` or
             :meth:`~aiocamedomotic.models.ThermoZone.async_set_config`.
 
+            If your application needs to restore zone operation after re-enabling a
+            season, you must track each zone's previous mode yourself and re-apply it
+            after changing the season.
+
         Args:
             season: The season to set. Valid values are ``WINTER``,
                 ``SUMMER``, and ``PLANT_OFF``.
@@ -536,11 +535,6 @@ class CameDomoticAPI:
         Cameras are read-only entities providing access to IP camera
         stream URIs. They do not support control commands.
 
-        .. note::
-            This method uses API commands documented in the CAME JS client
-            but not yet verified against a real server. Behaviour may differ
-            across firmware versions.
-
         Returns:
             list[Camera]: List of cameras.
 
@@ -621,11 +615,6 @@ class CameDomoticAPI:
         """Get the list of all relay devices defined on the server.
 
         Relays are simple on/off switches that can be controlled remotely.
-
-        .. note::
-            This method uses API commands documented in the CAME API
-            specification but not yet verified against a real server.
-            Behaviour may differ across firmware versions.
 
         Returns:
             list[Relay]: List of relays.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -30,10 +30,10 @@ from .const import (
     _DEFAULT_COMMAND_TIMEOUT,
     _FEATURE_TO_NESTED_CMD,
     _NESTED_3LEVEL_FEATURES,
+    ServerFeature,
     _CommandName,
     _CommandNameResponse,
     _CommandType,
-    _ServerFeature,
     _TopologicScope,
 )
 from .errors import CameDomoticAuthError
@@ -732,9 +732,9 @@ class CameDomoticAPI:
         self._merge_nested_results(nested_results, floors, rooms)
         return self._build_plant_topology(floors, rooms)
 
-    async def _build_nested_tasks(self) -> list[tuple[_ServerFeature, Any]]:
+    async def _build_nested_tasks(self) -> list[tuple[ServerFeature, Any]]:
         """Fetch server info and return (feature, coro) pairs for nested cmds."""
-        nested_tasks: list[tuple[_ServerFeature, Any]] = []
+        nested_tasks: list[tuple[ServerFeature, Any]] = []
         try:
             server_info = await self.async_get_server_info()
         except CameDomoticAuthError:
@@ -748,7 +748,7 @@ class CameDomoticAPI:
 
         for feature_str in server_info.features:
             try:
-                feature = _ServerFeature(feature_str)
+                feature = ServerFeature(feature_str)
             except ValueError:
                 continue
             if feature in _FEATURE_TO_NESTED_CMD:
@@ -786,7 +786,7 @@ class CameDomoticAPI:
 
     @staticmethod
     def _merge_nested_results(
-        nested_results: list[tuple[_ServerFeature, Any]],
+        nested_results: list[tuple[ServerFeature, Any]],
         floors: dict[int, str],
         rooms: dict[tuple[int, int], str],
     ) -> None:

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -20,22 +20,62 @@ from __future__ import annotations
 
 from enum import Enum, IntEnum
 
-# ACK error codes and their meanings from the CAME Domotic server
-ACK_ERROR_CODES = {
-    1: "Invalid user.",
-    3: "Too many sessions during login.",
-    4: "Error occurred in JSON Syntax.",
-    5: "No session layer command tag.",
-    6: "Unrecognized session layer command.",
-    7: "No client ID in request.",
-    8: "Wrong client ID in request.",
-    9: "Wrong application command.",
-    10: "No reply to application command, maybe service down.",
-    11: "Wrong application data.",
-}
 
-# Authentication-related error codes that should raise CameDomoticAuthError
-AUTH_ERROR_CODES = {1, 3}
+class AckErrorCode(IntEnum):
+    """ACK error codes returned by the CAME Domotic server.
+
+    Each member carries a human-readable ``message`` and an ``is_auth``
+    flag indicating whether the error is authentication-related.
+
+    Because ``AckErrorCode`` is an :class:`~enum.IntEnum`, members compare
+    equal to their integer value (e.g. ``AckErrorCode.INVALID_USER == 1``).
+
+    Values:
+
+    - ``INVALID_USER`` (1): Invalid user. **[auth]**
+    - ``TOO_MANY_SESSIONS`` (3): Too many sessions during login. **[auth]**
+    - ``JSON_SYNTAX_ERROR`` (4): Error occurred in JSON Syntax.
+    - ``NO_SESSION_COMMAND_TAG`` (5): No session layer command tag.
+    - ``UNRECOGNIZED_SESSION_COMMAND`` (6): Unrecognized session layer command.
+    - ``NO_CLIENT_ID`` (7): No client ID in request.
+    - ``WRONG_CLIENT_ID`` (8): Wrong client ID in request.
+    - ``WRONG_APPLICATION_COMMAND`` (9): Wrong application command.
+    - ``NO_REPLY`` (10): No reply to application command, maybe service down.
+    - ``WRONG_APPLICATION_DATA`` (11): Wrong application data.
+    """
+
+    def __new__(
+        cls, value: int, message: str = "", is_auth: bool = False
+    ) -> AckErrorCode:
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        return obj
+
+    def __init__(self, value: int, message: str = "", is_auth: bool = False) -> None:
+        self._message = message
+        self._is_auth = is_auth
+
+    @property
+    def message(self) -> str:
+        """Human-readable error message for this ACK code."""
+        return self._message
+
+    @property
+    def is_auth(self) -> bool:
+        """Whether this error code indicates an authentication failure."""
+        return self._is_auth
+
+    INVALID_USER = (1, "Invalid user.", True)
+    TOO_MANY_SESSIONS = (3, "Too many sessions during login.", True)
+    JSON_SYNTAX_ERROR = (4, "Error occurred in JSON Syntax.")
+    NO_SESSION_COMMAND_TAG = (5, "No session layer command tag.")
+    UNRECOGNIZED_SESSION_COMMAND = (6, "Unrecognized session layer command.")
+    NO_CLIENT_ID = (7, "No client ID in request.")
+    WRONG_CLIENT_ID = (8, "Wrong client ID in request.")
+    WRONG_APPLICATION_COMMAND = (9, "Wrong application command.")
+    NO_REPLY = (10, "No reply to application command, maybe service down.")
+    WRONG_APPLICATION_DATA = (11, "Wrong application data.")
+
 
 # Known MAC address OUI prefixes for CAME Domotic devices (BPT S.p.A.)
 # These can be used for network autodiscovery of CAME ETI/Domo servers.
@@ -48,30 +88,6 @@ _DEFAULT_COMMAND_TIMEOUT: int = 30
 # Prevents re-login storms on zero/very-low values and runaway sessions on huge values.
 _KEEP_ALIVE_MIN_SEC: int = 30
 _KEEP_ALIVE_MAX_SEC: int = 3600
-
-
-def get_ack_error_message(ack_code: int) -> str:
-    """Get human-readable message for ACK error code.
-
-    Args:
-        ack_code (int): The ACK error code from the server.
-
-    Returns:
-        str: Human-readable error message.
-    """
-    return ACK_ERROR_CODES.get(ack_code, f"Unknown error code: {ack_code}")
-
-
-def is_auth_error(ack_code: int) -> bool:
-    """Check if ACK error code is authentication-related.
-
-    Args:
-        ack_code (int): The ACK error code from the server.
-
-    Returns:
-        bool: True if the error code is authentication-related.
-    """
-    return ack_code in AUTH_ERROR_CODES
 
 
 class DeviceType(IntEnum):

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -18,7 +18,7 @@ Constants for the CAME Domotic API.
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import Enum, IntEnum, StrEnum
 
 
 class AckErrorCode(IntEnum):
@@ -222,7 +222,28 @@ class _TopologicScope(Enum):
     PLANT = "plant"
 
 
-class _ServerFeature(Enum):
+class ServerFeature(StrEnum):
+    """Server feature identifiers reported by the CAME Domotic server.
+
+    Each member corresponds to a functional block (e.g. lights, openings).
+    Because ``ServerFeature`` is a :class:`~enum.StrEnum`, each member **is**
+    its string value (e.g. ``ServerFeature.LIGHTS == "lights"`` is ``True``),
+    so members can be compared directly against the plain strings in
+    :attr:`~aiocamedomotic.models.base.ServerInfo.features`.
+
+    Values:
+        - ``LIGHTS`` ("lights") — on/off, dimmable and RGB lights
+        - ``OPENINGS`` ("openings") — shutters, awnings, and motorized covers
+        - ``RELAYS`` ("relays") — simple on/off relay switches
+        - ``THERMOREGULATION`` ("thermoregulation") — climate zones and analog sensors
+        - ``SCENARIOS`` ("scenarios") — pre-configured automation sequences
+        - ``DIGITALIN`` ("digitalin") — read-only binary sensors (buttons, contacts)
+        - ``ANALOGIN`` ("analogin") — read-only standalone analog sensors
+        - ``ENERGY`` ("energy") — energy meters
+        - ``LOADSCTRL`` ("loadsctrl") — load control / management
+        - ``TIMERS`` ("timers") — time-based scheduling entities
+    """
+
     LIGHTS = "lights"
     OPENINGS = "openings"
     RELAYS = "relays"
@@ -237,16 +258,16 @@ class _ServerFeature(Enum):
 
 # Mapping from server feature to (nested request cmd_name, expected response cmd_name).
 # Used by async_get_topology to determine which nested commands to send.
-_FEATURE_TO_NESTED_CMD: dict[_ServerFeature, tuple[str, str]] = {
-    _ServerFeature.LIGHTS: (
+_FEATURE_TO_NESTED_CMD: dict[ServerFeature, tuple[str, str]] = {
+    ServerFeature.LIGHTS: (
         _CommandName.NESTED_LIGHT_LIST.value,
         _CommandNameResponse.LIGHT_LIST.value,
     ),
-    _ServerFeature.OPENINGS: (
+    ServerFeature.OPENINGS: (
         _CommandName.NESTED_OPENINGS_LIST.value,
         _CommandNameResponse.OPENINGS_LIST.value,
     ),
-    _ServerFeature.THERMOREGULATION: (
+    ServerFeature.THERMOREGULATION: (
         _CommandName.NESTED_THERMO_LIST.value,
         _CommandNameResponse.THERMO_LIST.value,
     ),
@@ -254,8 +275,8 @@ _FEATURE_TO_NESTED_CMD: dict[_ServerFeature, tuple[str, str]] = {
 
 # Features whose nested response uses a 3-level hierarchy (Floor → Room → Device).
 # Other features (e.g. thermoregulation) use a 2-level hierarchy (Floor → Device).
-_NESTED_3LEVEL_FEATURES: frozenset[_ServerFeature] = frozenset(
-    {_ServerFeature.LIGHTS, _ServerFeature.OPENINGS}
+_NESTED_3LEVEL_FEATURES: frozenset[ServerFeature] = frozenset(
+    {ServerFeature.LIGHTS, ServerFeature.OPENINGS}
 )
 
 
@@ -347,14 +368,14 @@ _UPDATE_CMD_TO_DEVICE_TYPE: dict[str, DeviceType] = {
 }
 
 # Mapping from DeviceType to the corresponding server feature
-_DEVICE_TYPE_TO_FEATURE: dict[DeviceType, _ServerFeature] = {
-    DeviceType.LIGHT: _ServerFeature.LIGHTS,
-    DeviceType.OPENING: _ServerFeature.OPENINGS,
-    DeviceType.GENERIC_RELAY: _ServerFeature.RELAYS,
-    DeviceType.THERMOSTAT: _ServerFeature.THERMOREGULATION,
-    DeviceType.SCENARIO: _ServerFeature.SCENARIOS,
-    DeviceType.DIGITAL_INPUT: _ServerFeature.DIGITALIN,
-    DeviceType.ENERGY_SENSOR: _ServerFeature.ENERGY,
-    DeviceType.ANALOG_INPUT: _ServerFeature.ANALOGIN,
-    DeviceType.TIMER: _ServerFeature.TIMERS,
+_DEVICE_TYPE_TO_FEATURE: dict[DeviceType, ServerFeature] = {
+    DeviceType.LIGHT: ServerFeature.LIGHTS,
+    DeviceType.OPENING: ServerFeature.OPENINGS,
+    DeviceType.GENERIC_RELAY: ServerFeature.RELAYS,
+    DeviceType.THERMOSTAT: ServerFeature.THERMOREGULATION,
+    DeviceType.SCENARIO: ServerFeature.SCENARIOS,
+    DeviceType.DIGITAL_INPUT: ServerFeature.DIGITALIN,
+    DeviceType.ENERGY_SENSOR: ServerFeature.ENERGY,
+    DeviceType.ANALOG_INPUT: ServerFeature.ANALOGIN,
+    DeviceType.TIMER: ServerFeature.TIMERS,
 }

--- a/aiocamedomotic/errors.py
+++ b/aiocamedomotic/errors.py
@@ -28,13 +28,13 @@ Exception hierarchy and suggested Home Assistant mapping:
 
 from __future__ import annotations
 
-from .const import get_ack_error_message, is_auth_error
+from .const import AckErrorCode
 
 
 class CameDomoticError(Exception):
     """Base exception class for the CAME Domotic package."""
 
-    ack_code: int | None = None
+    ack_code: AckErrorCode | int | None = None
 
 
 class CameDomoticServerNotFoundError(CameDomoticError):
@@ -62,7 +62,10 @@ class CameDomoticServerError(CameDomoticError):
         Returns:
             str: The formatted error message.
         """
-        message = get_ack_error_message(ack_code)
+        try:
+            message = AckErrorCode(ack_code).message
+        except ValueError:
+            message = f"Unknown error code: {ack_code}"
         return f"ACK error {ack_code}: {message}"
 
     @staticmethod
@@ -77,8 +80,13 @@ class CameDomoticServerError(CameDomoticError):
         """
         message = CameDomoticServerError.format_ack_error(ack_code)
 
+        try:
+            is_auth = AckErrorCode(ack_code).is_auth
+        except ValueError:
+            is_auth = False
+
         exc: CameDomoticError
-        if is_auth_error(ack_code):
+        if is_auth:
             exc = CameDomoticAuthError(message)
         else:
             exc = CameDomoticServerError(message)

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -19,7 +19,7 @@ CAME Domotic API.
 
 from __future__ import annotations
 
-from ..const import DeviceType, UpdateIndicator  # noqa: F401
+from ..const import DeviceType, ServerFeature, UpdateIndicator  # noqa: F401
 from .analog_in import AnalogIn  # noqa: F401
 from .base import (  # noqa: F401
     CameEntity,
@@ -101,6 +101,7 @@ __all__ = [
     "Scenario",
     "ScenarioStatus",
     "ScenarioUpdate",
+    "ServerFeature",
     "ServerInfo",
     "TerminalGroup",
     "ThermoZone",

--- a/aiocamedomotic/models/analog_in.py
+++ b/aiocamedomotic/models/analog_in.py
@@ -50,10 +50,6 @@ class AnalogIn(CameEntity):
         ValueError: If ``name`` or ``act_id`` keys are missing from
             the input data.
 
-    Note:
-        Temperature values (``unit == "C"``) are stored as integers multiplied
-        by 10 (e.g. 215 = 21.5 °C). The :attr:`value` property applies the
-        conversion automatically.
     """
 
     raw_data: dict[str, Any]
@@ -77,12 +73,7 @@ class AnalogIn(CameEntity):
 
     @property
     def value(self) -> float:
-        """Sensor reading in the unit reported by :attr:`unit`.
-
-        Temperature readings (``unit == "C"``) are divided by 10 to convert
-        from the API's integer encoding to degrees Celsius. All other units
-        are returned as-is.
-        """
+        """Sensor reading in the unit reported by :attr:`unit`."""
         raw = self.raw_data.get("value", 0)
         if self.unit == "C":
             return raw / 10.0

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -190,20 +190,15 @@ class ServerInfo(CameEntity):
     """List of feature strings reported by the server.
 
     Each feature corresponds to a functional block (e.g. lights, openings).
-    Values are plain strings; compare directly against the known literals
-    listed below.
+    Values are plain strings whose known values are defined in
+    :class:`~aiocamedomotic.const.ServerFeature`. Because ``ServerFeature``
+    is a :class:`~enum.StrEnum`, you can compare entries against enum
+    members directly (e.g.
+    ``ServerFeature.LIGHTS in server_info.features``).
 
-    Known values (as of now) are:
-        - ``"lights"`` — on/off, dimmable and RGB lights
-        - ``"openings"`` — shutters, awnings, and motorized covers
-        - ``"relays"`` — simple on/off relay switches
-        - ``"thermoregulation"`` — climate zones and analog sensors
-        - ``"scenarios"`` — pre-configured automation sequences
-        - ``"digitalin"`` — read-only binary sensors (buttons, contacts)
-        - ``"analogin"`` — read-only standalone analog sensors
-        - ``"timers"`` — time-based scheduling entities
-        - ``"energy"`` — energy meters
-        - ``"loadsctrl"`` — load control / management
+    The return type is kept as ``list[str]`` so that features introduced by
+    newer firmware versions are preserved even if the library does not yet
+    define them in :class:`~aiocamedomotic.const.ServerFeature`.
     """
 
     swver: str | None = None

--- a/aiocamedomotic/models/base.py
+++ b/aiocamedomotic/models/base.py
@@ -70,7 +70,10 @@ class User(CameEntity):
 
         Note:
             This method logs out the current user and logs in with the new user.
-            In case of failure, the previous user is restored.
+            If login with the new credentials fails, a
+            ``CameDomoticAuthError`` is raised and the previous credentials
+            are restored so the API client remains connected as the
+            original user.
         """
 
         LOGGER.debug("Attempting to switch to user '%s'", self.name)
@@ -93,11 +96,6 @@ class User(CameEntity):
 
         Sends a delete-user request to the server for the user identified by
         this object's ``name`` property.
-
-        .. warning::
-            This operation is based on reverse-engineered API documentation and
-            has not been verified against a real CAME Domotic server. Behaviour
-            may differ across firmware versions.
 
         Raises:
             ValueError: If this user is the currently authenticated user.
@@ -125,12 +123,11 @@ class User(CameEntity):
             current_password (str): The user's current password.
             new_password (str): The desired new password.
 
-        .. warning::
-            This operation is based on reverse-engineered API documentation and
-            has not been verified against a real CAME Domotic server. Behaviour
-            may differ across firmware versions.
-
         Note:
+            Changing the password does not invalidate existing active sessions
+            for that user — they remain valid until they expire. The new
+            password will be required at the next login.
+
             If the changed user is the currently authenticated user, the stored
             credentials are updated automatically in the active session — no
             additional action is required.
@@ -190,16 +187,23 @@ class ServerInfo(CameEntity):
     """Serial number of the server."""
 
     features: list[str]
-    """List of features supported by the server.
+    """List of feature strings reported by the server.
+
+    Each feature corresponds to a functional block (e.g. lights, openings).
+    Values are plain strings; compare directly against the known literals
+    listed below.
 
     Known values (as of now) are:
-        - "lights"
-        - "openings"
-        - "thermoregulation"
-        - "scenarios"
-        - "digitalin"
-        - "energy"
-        - "loadsctrl"
+        - ``"lights"`` — on/off, dimmable and RGB lights
+        - ``"openings"`` — shutters, awnings, and motorized covers
+        - ``"relays"`` — simple on/off relay switches
+        - ``"thermoregulation"`` — climate zones and analog sensors
+        - ``"scenarios"`` — pre-configured automation sequences
+        - ``"digitalin"`` — read-only binary sensors (buttons, contacts)
+        - ``"analogin"`` — read-only standalone analog sensors
+        - ``"timers"`` — time-based scheduling entities
+        - ``"energy"`` — energy meters
+        - ``"loadsctrl"`` — load control / management
     """
 
     swver: str | None = None

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -300,8 +300,7 @@ class ThermoZone(CameEntity):
         """Configure the thermoregulation zone.
 
         .. note::
-            The season cannot be changed via this method. The CAME server
-            silently ignores any season value sent in a zone config request.
+            The season cannot be changed via this method.
             Use :meth:`CameDomoticAPI.async_set_thermo_season` to change the
             season at the plant level.
 
@@ -370,7 +369,7 @@ class ThermoZone(CameEntity):
         .. warning::
             This method only has an effect when the zone is in
             ``ThermoZoneMode.MANUAL`` mode. When the zone is in any other mode
-            (e.g. ``AUTO``), the server accepts the request without error but
+            (e.g. ``AUTO``, ``JOLLY``), the server accepts the request without error but
             silently discards the new setpoint. Use
             :meth:`async_set_config` with ``mode=ThermoZoneMode.MANUAL`` to
             guarantee that the setpoint is applied.

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -33,43 +33,6 @@ Entity models
 
 .. automodule:: aiocamedomotic.models
    :members:
-   :noindex:
-
-.. automodule:: aiocamedomotic.models.base
-   :members:
-
-.. automodule:: aiocamedomotic.models.analog_in
-   :members:
-
-.. automodule:: aiocamedomotic.models.camera
-   :members:
-
-.. automodule:: aiocamedomotic.models.digital_input
-   :members:
-
-.. automodule:: aiocamedomotic.models.light
-   :members:
-
-.. automodule:: aiocamedomotic.models.map_page
-   :members:
-
-.. automodule:: aiocamedomotic.models.opening
-   :members:
-
-.. automodule:: aiocamedomotic.models.relay
-   :members:
-
-.. automodule:: aiocamedomotic.models.scenario
-   :members:
-
-.. automodule:: aiocamedomotic.models.thermo_zone
-   :members:
-
-.. automodule:: aiocamedomotic.models.timer
-   :members:
-
-.. automodule:: aiocamedomotic.models.update
-   :members:
 
 
 Constants
@@ -85,7 +48,7 @@ Utilities
 .. autofunction:: aiocamedomotic.utils.async_is_came_endpoint
 
 .. automodule:: aiocamedomotic.anonymizer
-   :members: TRAFFIC_LOGGER, anonymize_payload
+   :members: TRAFFIC_LOGGER
 
 
 Errors

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -39,7 +39,7 @@ Constants
 ---------
 
 .. automodule:: aiocamedomotic.const
-   :members: CAME_MAC_PREFIXES, DeviceType, UpdateIndicator
+   :members: AckErrorCode, CAME_MAC_PREFIXES, DeviceType, UpdateIndicator
 
 
 Utilities

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -92,27 +92,9 @@ pass it via the ``websession`` parameter:
 
     async with await CameDomoticAPI.async_create(
         "192.168.x.x", "username", "password",
-        websession=my_existing_session,
-        close_websession_on_disposal=False,
+        websession=my_existing_session
     ) as api:
         ...
-
-.. important:: **Session ownership — read this carefully if you pass a** ``websession``.
-
-    The ``close_websession_on_disposal`` parameter controls whether the HTTP session is
-    closed when the ``CameDomoticAPI`` object is disposed (i.e. on exit from the
-    ``async with`` block).
-
-    - ``False`` **(default — use this when passing a shared session)**: the session is
-      preserved on disposal. This is almost always what you want in Home Assistant and
-      similar frameworks, where a single long-lived ``aiohttp.ClientSession`` is shared
-      across many integrations. Closing it here would silently break every other
-      component that depends on it.
-    - ``True``: the session is closed on disposal. Only use this if you explicitly
-      want this object to take ownership of the provided session.
-
-    When **no** ``websession`` is provided, this flag is irrelevant: the internally
-    created session is always closed on disposal.
 
 Handling connection errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +207,9 @@ Example output:
     Feature: energy
     Feature: loadsctrl
 
-You can use the features list to decide which device APIs to call:
+The ``features`` property returns plain strings (see
+:attr:`~aiocamedomotic.models.base.ServerInfo.features` for the full list of
+known values). You can use them to decide which device APIs to call:
 
 .. code-block:: python
 
@@ -281,12 +265,6 @@ Example output:
     Floor 1: First Floor
       Room 3: Bedroom
       Room 4: Bathroom
-
-.. note::
-    ``async_get_topology()`` issues all requests concurrently and produces a
-    :class:`~aiocamedomotic.models.base.PlantTopology` object with floors
-    and rooms already nested, so you don't need to cross-reference floor IDs
-    manually.
 
 Working with devices
 --------------------
@@ -358,11 +336,13 @@ Example output:
 Openings
 ^^^^^^^^
 
-Openings represent shutters, awnings, and similar motorized covers. They use
-a three-state control model: opening, closing, or stopped.
+Openings represent shutters, awnings, and similar motorized covers. They
+support opening, closing, stopping, and slat tilting (open/close) for
+covers with adjustable slats (e.g., venetian blinds).
 
 .. code-block:: python
 
+    import asyncio
     from aiocamedomotic.models import OpeningStatus
 
     openings = await api.async_get_openings()
@@ -374,8 +354,16 @@ a three-state control model: opening, closing, or stopped.
     shutter = next((o for o in openings if o.open_act_id == 10), None)
     if shutter:
         await shutter.async_set_status(OpeningStatus.OPENING)
+        await asyncio.sleep(5)
         await shutter.async_set_status(OpeningStatus.STOPPED)
+        await asyncio.sleep(5)
         await shutter.async_set_status(OpeningStatus.CLOSING)
+
+        # Tilt slats (for covers with adjustable slats)
+        await asyncio.sleep(5)
+        await shutter.async_set_status(OpeningStatus.SLAT_OPEN)
+        await asyncio.sleep(5)
+        await shutter.async_set_status(OpeningStatus.SLAT_CLOSE)
 
 Scenarios
 ^^^^^^^^^
@@ -391,7 +379,7 @@ activated (fire-and-forget); there is no bidirectional status control.
         print(f"ID: {scenario.id}, Name: {scenario.name}, Status: {scenario.scenario_status}")
 
     # Activate a scenario
-    good_morning = next((s for s in scenarios if s.name == "Good Morning"), None)
+    good_morning = next((s for s in scenarios if s.name == "Good morning"), None)
     if good_morning:
         await good_morning.async_activate()
 
@@ -438,7 +426,7 @@ Example output:
 
     # Full configuration with fan speed
     await zone.async_set_config(
-        mode=ThermoZoneMode.AUTO,
+        mode=ThermoZoneMode.MANUAL,
         set_point=21.5,
         fan_speed=ThermoZoneFanSpeed.MEDIUM,
     )
@@ -464,11 +452,12 @@ Example output:
     after changing the season.
 
 .. note::
-    Temperature values are returned as floats in degrees Celsius (the internal
-    integer-times-10 representation is converted automatically). The
-    ``fan_speed`` parameter in ``async_set_config`` is optional; when
-    provided, the ``extended_infos`` flag is set automatically. Season can
-    only be changed at the plant level via ``async_set_thermo_season()``.
+    Temperature values are returned as floats in degrees Celsius.
+
+    The ``fan_speed`` parameter in ``async_set_config`` is optional; when
+    provided, the ``extended_infos`` flag is set automatically.
+
+    Season can only be changed at the plant level via ``async_set_thermo_season()``.
 
 Analog sensors
 ^^^^^^^^^^^^^^
@@ -513,12 +502,6 @@ Example output:
     # Find a specific sensor by ID
     outdoor = next((s for s in sensors if s.act_id == 100), None)
 
-.. note::
-    Temperature sensor values are automatically scaled from the raw
-    integer-times-10 representation (e.g. ``215`` becomes ``21.5``).
-    Humidity and pressure values are returned as-is. The ``sensor_type``
-    property (an ``AnalogSensorType`` enum) determines the scaling behavior.
-
 Digital inputs (binary sensors)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -554,7 +537,7 @@ Example output:
     button = next((di for di in digital_inputs if di.act_id == 1), None)
 
     # By name
-    sensor = next((di for di in digital_inputs if di.name == "Front Door"), None)
+    sensor = next((di for di in digital_inputs if di.name == "Front door button"), None)
 
 .. note::
     Some digital inputs do not report a ``status`` until their first state
@@ -563,9 +546,8 @@ Example output:
 Analog inputs (standalone sensors)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Analog inputs are read-only standalone sensors such as hygrometers,
-thermometers, and barometers exposed via the ``analogin`` feature. They
-provide a numeric reading and a unit of measurement but cannot be
+Analog inputs are read-only standalone sensors exposed via the ``analogin`` feature.
+They provide a numeric reading and a unit of measurement and cannot be
 controlled remotely.
 
 .. note::
@@ -588,9 +570,9 @@ Example output:
 
 .. code-block:: text
 
-    ID: 89, Name: Igrometro, Value: 47.0, Unit: %
-    ID: 90, Name: Termometro esterno, Value: 21.5, Unit: C
-    ID: 91, Name: Barometro, Value: 1013.0, Unit: hPa
+    ID: 89, Name: Hygrometer, Value: 47.0, Unit: %
+    ID: 90, Name: Outdoor Thermometer, Value: 21.5, Unit: C
+    ID: 91, Name: Barometer, Value: 1013.0, Unit: hPa
 
 **Finding a specific analog input:**
 
@@ -600,18 +582,12 @@ Example output:
     thermo = next((ai for ai in analog_inputs if ai.act_id == 90), None)
 
     # By name
-    hygro = next((ai for ai in analog_inputs if ai.name == "Igrometro"), None)
-
-.. note::
-    Temperature values (``unit == "C"``) are automatically scaled from the
-    raw integer-times-10 representation (e.g. ``215`` becomes ``21.5``).
-    Humidity and pressure values are returned as-is.
+    hygro = next((ai for ai in analog_inputs if ai.name == "Hygrometer"), None)
 
 Relays
 ^^^^^^
 
-Relays are simple on/off switches that can be controlled remotely. Unlike
-lights, they have no brightness or color capabilities.
+Relays are simple on/off switches that can be controlled remotely.
 
 **Fetching and inspecting relays:**
 
@@ -647,12 +623,8 @@ Example output:
 
     if pump:
         await pump.async_set_status(RelayStatus.ON)
+        await asyncio.sleep(5)
         await pump.async_set_status(RelayStatus.OFF)
-
-.. note::
-    The relay API commands are documented in the CAME API specification but
-    have not been verified against a real server. If you encounter unexpected
-    behaviour, please report it to the library developers.
 
 Timers
 ^^^^^^
@@ -759,8 +731,15 @@ Each ``TimerTimeSlot`` exposes:
             stop = "N/A"
         print(f"  Slot {slot.index}: {start} → {stop}")
 
+Example output:
+
+.. code-block:: text
+
+      Slot 0: 10:00:00 → 18:30:00
+      Slot 2: 22:00:00 → N/A
+
 .. note::
-    On firmware version 3.0.1, the ``stop`` and ``active`` fields are not
+    The ``stop`` and ``active`` fields mayb be not
     present in the server response. The corresponding properties return
     ``None`` in that case. Your code should handle both cases.
 
@@ -946,6 +925,14 @@ processes each batch of updates as it arrives:
             # Brief pause to avoid tight looping on rapid server responses
             await asyncio.sleep(1)
 
+Example output:
+
+.. code-block:: text
+
+    [DeviceType.LIGHT] Living Room Chandelier (ID: 1)
+    [DeviceType.OPENING] Bedroom Shutter (ID: 10)
+    [DeviceType.THERMO_ZONE] Living Room (ID: 1)
+
 .. note::
     The ``asyncio.sleep(1)`` acts as a safety throttle in case the server
     returns immediately (e.g. errors or rapid update bursts). If you need to
@@ -955,8 +942,8 @@ processes each batch of updates as it arrives:
 Configuring timeouts
 ^^^^^^^^^^^^^^^^^^^^
 
-All commands use a default timeout of **30 seconds**, configurable via
-``command_timeout`` when creating the API instance:
+All API methods use a default timeout of **30 seconds**, configurable via
+the ``command_timeout`` parameter when creating the API instance:
 
 .. code-block:: python
 
@@ -965,17 +952,24 @@ All commands use a default timeout of **30 seconds**, configurable via
     ) as api:
         lights = await api.async_get_lights()  # uses 15s timeout
 
-For ``async_get_updates()``, a longer timeout is **strongly recommended**
-since the server holds the connection open until updates are available:
+``async_get_updates()`` is the only method that accepts its own ``timeout``
+parameter, allowing it to use a different timeout than the rest of the API.
+This is because ``async_get_updates()`` uses **long polling** — the server
+holds the connection open until updates are available, which can take
+much longer than a regular command round-trip. A longer timeout
+(e.g. 60--120 seconds) is **strongly recommended** to avoid premature
+disconnections:
 
 .. code-block:: python
 
+    # Instance-level timeout is 15s for regular commands,
+    # but async_get_updates uses its own 120s timeout
     updates = await api.async_get_updates(timeout=120)
 
 .. note::
-    If no ``timeout`` is passed to ``async_get_updates()``, the instance-level
-    ``command_timeout`` is used (default: 30s). For most real-time monitoring
-    use cases, a timeout of **60--120 seconds** is recommended.
+    If no ``timeout`` is passed to ``async_get_updates()``, it falls back to
+    the instance-level ``command_timeout`` (default: 30s). For most real-time
+    monitoring use cases, a timeout of **60--120 seconds** is recommended.
 
 Typed updates and filtering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -33,7 +33,7 @@ and controlling devices, and monitoring real-time changes. For a minimal
         from aiocamedomotic.models import (
             AnalogSensorType, DeviceType, DigitalInputStatus, LightStatus,
             LightType, OpeningStatus, RelayStatus, ScenarioStatus,
-            ThermoZoneFanSpeed,
+            ServerFeature, ThermoZoneFanSpeed,
             ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
             Timer, TimerTimeSlot, TimerUpdate,
             DeviceUpdate, LightUpdate, OpeningUpdate, RelayUpdate,
@@ -207,35 +207,37 @@ Example output:
     Feature: energy
     Feature: loadsctrl
 
-The ``features`` property returns plain strings (see
-:attr:`~aiocamedomotic.models.base.ServerInfo.features` for the full list of
-known values). You can use them to decide which device APIs to call:
+The ``features`` property returns plain strings whose known values are
+defined in :class:`~aiocamedomotic.models.ServerFeature`. You can compare
+entries against enum members to decide which device APIs to call:
 
 .. code-block:: python
 
-    if "lights" in server_info.features:
+    from aiocamedomotic.models import ServerFeature
+
+    if ServerFeature.LIGHTS in server_info.features:
         lights = await api.async_get_lights()
 
-    if "openings" in server_info.features:
+    if ServerFeature.OPENINGS in server_info.features:
         openings = await api.async_get_openings()
 
-    if "relays" in server_info.features:
+    if ServerFeature.RELAYS in server_info.features:
         relays = await api.async_get_relays()
 
-    if "thermoregulation" in server_info.features:
+    if ServerFeature.THERMOREGULATION in server_info.features:
         zones = await api.async_get_thermo_zones()
         sensors = await api.async_get_analog_sensors()
 
-    if "scenarios" in server_info.features:
+    if ServerFeature.SCENARIOS in server_info.features:
         scenarios = await api.async_get_scenarios()
 
-    if "digitalin" in server_info.features:
+    if ServerFeature.DIGITALIN in server_info.features:
         digital_inputs = await api.async_get_digital_inputs()
 
-    if "analogin" in server_info.features:
+    if ServerFeature.ANALOGIN in server_info.features:
         analog_inputs = await api.async_get_analog_inputs()
 
-    if "timers" in server_info.features:
+    if ServerFeature.TIMERS in server_info.features:
         timers = await api.async_get_timers()
 
 Floors and rooms
@@ -557,7 +559,7 @@ controlled remotely.
 
 .. code-block:: python
 
-    if "analogin" in server_info.features:
+    if ServerFeature.ANALOGIN in server_info.features:
         analog_inputs = await api.async_get_analog_inputs()
 
         for ai in analog_inputs:

--- a/tests/aiocamedomotic/test_anonymizer.py
+++ b/tests/aiocamedomotic/test_anonymizer.py
@@ -24,12 +24,12 @@ from unittest.mock import patch
 from aiocamedomotic.anonymizer import (
     TRAFFIC_LOGGER,
     _anonymize_host,
+    _anonymize_payload,
     _anonymize_uri,
     _anonymize_url,
     _anonymize_value,
+    _log_traffic,
     _partial_redact,
-    anonymize_payload,
-    log_traffic,
 )
 
 # ---------------------------------------------------------------------------
@@ -210,7 +210,7 @@ class TestAnonymizeValue:
 
 
 # ---------------------------------------------------------------------------
-# anonymize_payload
+# _anonymize_payload
 # ---------------------------------------------------------------------------
 
 
@@ -221,7 +221,7 @@ class TestAnonymizePayload:
             "sl_login": "admin",
             "sl_pwd": "secret123",
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["sl_cmd"] == "sl_registration_req"
         assert result["sl_login"] == "ad***"
         assert result["sl_pwd"] == "***"
@@ -237,7 +237,7 @@ class TestAnonymizePayload:
             "sl_cmd": "sl_data_req",
             "sl_appl_msg_type": "domo",
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["sl_client_id"] == "504***"
         assert result["sl_appl_msg"]["client"] == "504***"
         assert result["sl_appl_msg"]["cmd_name"] == "light_list_req"
@@ -250,7 +250,7 @@ class TestAnonymizePayload:
             "sl_pwd": "oldpass",
             "sl_new_pwd": "newpass",
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["sl_login"] == "ad***"
         assert result["sl_pwd"] == "***"
         assert result["sl_new_pwd"] == "***"
@@ -263,7 +263,7 @@ class TestAnonymizePayload:
             "swver": "1.2.3",
             "sl_data_ack_reason": 0,
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["keycode"] == "0000FFFF********"
         assert result["serial"] == "001*****"
         assert result["swver"] == "1.2.3"
@@ -275,7 +275,7 @@ class TestAnonymizePayload:
             "sl_client_id": "75c6c33a",
             "sl_users_list": [{"name": "admin"}],
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["sl_client_id"] == "75c***"
         assert result["sl_users_list"][0]["name"] == "ad***"
 
@@ -291,7 +291,7 @@ class TestAnonymizePayload:
                 }
             ],
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         cam = result["array"][0]
         assert "***:***@" in cam["uri"]
         assert "***:***@" in cam["uri_still"]
@@ -303,13 +303,13 @@ class TestAnonymizePayload:
             "sl_pwd": "secret",
             "nested": {"sl_client_id": "abc123"},
         }
-        anonymize_payload(payload)
+        _anonymize_payload(payload)
         assert payload["sl_login"] == "admin"
         assert payload["sl_pwd"] == "secret"
         assert payload["nested"]["sl_client_id"] == "abc123"
 
     def test_empty_dict(self):
-        assert anonymize_payload({}) == {}
+        assert _anonymize_payload({}) == {}
 
     def test_nested_list_of_dicts(self):
         payload = {
@@ -318,7 +318,7 @@ class TestAnonymizePayload:
                 {"cmd_name": "light_switch_ind", "act_id": 2, "status": 0},
             ]
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["result"][0]["act_id"] == 1
         assert result["result"][1]["status"] == 0
 
@@ -329,21 +329,21 @@ class TestAnonymizePayload:
             "sl_login": "newuser",
             "sl_pwd": "newpassword",
         }
-        result = anonymize_payload(payload)
+        result = _anonymize_payload(payload)
         assert result["sl_client_id"] == "abc***"
         assert result["sl_login"] == "ne***"
         assert result["sl_pwd"] == "***"
 
 
 # ---------------------------------------------------------------------------
-# log_traffic
+# _log_traffic
 # ---------------------------------------------------------------------------
 
 
 class TestLogTraffic:
     def test_post_with_request_and_response(self, caplog):
         with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
-            log_traffic(
+            _log_traffic(
                 "POST",
                 "http://192.168.1.100/domo/",
                 {"sl_cmd": "sl_registration_req", "sl_login": "admin", "sl_pwd": "x"},
@@ -364,7 +364,7 @@ class TestLogTraffic:
 
     def test_get_with_none_payloads(self, caplog):
         with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
-            log_traffic("GET", "http://192.168.1.100/domo/", None, None, None, 10.0)
+            _log_traffic("GET", "http://192.168.1.100/domo/", None, None, None, 10.0)
 
         assert len(caplog.records) == 1
         text = caplog.records[0].message
@@ -374,7 +374,7 @@ class TestLogTraffic:
 
     def test_elapsed_time_in_output(self, caplog):
         with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
-            log_traffic("POST", "http://host/domo/", {}, {}, 200, 123.456)
+            _log_traffic("POST", "http://host/domo/", {}, {}, 200, 123.456)
 
         text = caplog.records[0].message
         assert "123.5ms" in text
@@ -382,12 +382,12 @@ class TestLogTraffic:
     def test_exception_in_anonymization_swallowed(self, caplog):
         with (
             patch(
-                "aiocamedomotic.anonymizer.anonymize_payload",
+                "aiocamedomotic.anonymizer._anonymize_payload",
                 side_effect=RuntimeError("boom"),
             ),
             caplog.at_level(logging.WARNING, logger="aiocamedomotic.traffic"),
         ):
-            log_traffic("POST", "http://host/", {"sl_pwd": "x"}, None, 200, 1.0)
+            _log_traffic("POST", "http://host/", {"sl_pwd": "x"}, None, 200, 1.0)
 
         assert any("Traffic logging failed" in r.message for r in caplog.records)
 
@@ -396,7 +396,7 @@ class TestLogTraffic:
 
     def test_non_dict_response(self, caplog):
         with caplog.at_level(logging.DEBUG, logger="aiocamedomotic.traffic"):
-            log_traffic("POST", "http://host/domo/", None, "plain text", 200, 5.0)
+            _log_traffic("POST", "http://host/domo/", None, "plain text", 200, 5.0)
 
         text = caplog.records[0].message
         assert "<-- plain text" in text

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -1357,15 +1357,15 @@ class TestTrafficLogging:
             patch.object(
                 auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
             ) as mock_get_client_id,
-            patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic,
+            patch("aiocamedomotic.auth._log_traffic") as mock__log_traffic,
         ):
             mock_post.return_value = mock_response
             mock_get_client_id.return_value = "test_client_id"
 
             await auth_instance.async_send_command({"cmd_name": "test"})
 
-            mock_log_traffic.assert_called_once()
-            call_args = mock_log_traffic.call_args
+            mock__log_traffic.assert_called_once()
+            call_args = mock__log_traffic.call_args
             assert call_args[0][0] == "POST"
             assert "domo" in call_args[0][1]
             assert isinstance(call_args[0][2], dict)  # request payload
@@ -1385,11 +1385,11 @@ class TestTrafficLogging:
                 async with await Auth.async_create(
                     session, "192.168.x.x", "username", "password"
                 ) as auth:
-                    with patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic:
+                    with patch("aiocamedomotic.auth._log_traffic") as mock__log_traffic:
                         await auth.async_validate_host()
 
-                        mock_log_traffic.assert_called_once()
-                        call_args = mock_log_traffic.call_args
+                        mock__log_traffic.assert_called_once()
+                        call_args = mock__log_traffic.call_args
                         assert call_args[0][0] == "GET"
                         assert call_args[0][2] is None  # no request payload
                         assert call_args[0][3] is None  # no response payload
@@ -1408,7 +1408,7 @@ class TestTrafficLogging:
             patch.object(
                 auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
             ) as mock_get_client_id,
-            patch("aiocamedomotic.auth.log_traffic") as mock_log_traffic,
+            patch("aiocamedomotic.auth._log_traffic") as mock__log_traffic,
         ):
             mock_post.return_value = mock_response
             mock_get_client_id.return_value = "test_client_id"
@@ -1416,7 +1416,7 @@ class TestTrafficLogging:
             with pytest.raises(CameDomoticAuthError):
                 await auth_instance.async_send_command({"cmd_name": "test"})
 
-            mock_log_traffic.assert_called_once()
+            mock__log_traffic.assert_called_once()
 
     @freezegun.freeze_time("2020-01-01")
     async def test_traffic_logging_failure_does_not_affect_command(self, auth_instance):
@@ -1433,13 +1433,13 @@ class TestTrafficLogging:
                 auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
             ) as mock_get_client_id,
             patch(
-                "aiocamedomotic.auth.log_traffic",
+                "aiocamedomotic.auth._log_traffic",
                 side_effect=RuntimeError("logging broken"),
             ),
         ):
             mock_post.return_value = mock_response
             mock_get_client_id.return_value = "test_client_id"
 
-            # Command should succeed despite log_traffic raising
+            # Command should succeed despite _log_traffic raising
             result = await auth_instance.async_send_command({"cmd_name": "test"})
             assert result == {"sl_data_ack_reason": 0}

--- a/tests/aiocamedomotic/test_const.py
+++ b/tests/aiocamedomotic/test_const.py
@@ -18,130 +18,82 @@
 """Tests for aiocamedomotic constants."""
 
 
-def test_ack_error_codes_exist():
-    """Test that ACK_ERROR_CODES dictionary contains all expected error codes."""
-    from aiocamedomotic.const import ACK_ERROR_CODES
+def test_ack_error_code_members():
+    """Test that AckErrorCode contains all expected members with correct values."""
+    from aiocamedomotic.const import AckErrorCode
 
-    expected_codes = {1, 3, 4, 5, 6, 7, 8, 9, 10, 11}
-    assert set(ACK_ERROR_CODES.keys()) == expected_codes
+    expected = {
+        "INVALID_USER": 1,
+        "TOO_MANY_SESSIONS": 3,
+        "JSON_SYNTAX_ERROR": 4,
+        "NO_SESSION_COMMAND_TAG": 5,
+        "UNRECOGNIZED_SESSION_COMMAND": 6,
+        "NO_CLIENT_ID": 7,
+        "WRONG_CLIENT_ID": 8,
+        "WRONG_APPLICATION_COMMAND": 9,
+        "NO_REPLY": 10,
+        "WRONG_APPLICATION_DATA": 11,
+    }
+    assert len(AckErrorCode) == 10
+    for name, value in expected.items():
+        assert AckErrorCode[name] == value
 
 
-def test_ack_error_codes_messages():
-    """Test that ACK_ERROR_CODES contains correct error messages."""
-    from aiocamedomotic.const import ACK_ERROR_CODES
+def test_ack_error_code_messages():
+    """Test that each AckErrorCode member has the correct message."""
+    from aiocamedomotic.const import AckErrorCode
 
     expected_messages = {
-        1: "Invalid user.",
-        3: "Too many sessions during login.",
-        4: "Error occurred in JSON Syntax.",
-        5: "No session layer command tag.",
-        6: "Unrecognized session layer command.",
-        7: "No client ID in request.",
-        8: "Wrong client ID in request.",
-        9: "Wrong application command.",
-        10: "No reply to application command, maybe service down.",
-        11: "Wrong application data.",
+        AckErrorCode.INVALID_USER: "Invalid user.",
+        AckErrorCode.TOO_MANY_SESSIONS: "Too many sessions during login.",
+        AckErrorCode.JSON_SYNTAX_ERROR: "Error occurred in JSON Syntax.",
+        AckErrorCode.NO_SESSION_COMMAND_TAG: "No session layer command tag.",
+        AckErrorCode.UNRECOGNIZED_SESSION_COMMAND: (
+            "Unrecognized session layer command."
+        ),
+        AckErrorCode.NO_CLIENT_ID: "No client ID in request.",
+        AckErrorCode.WRONG_CLIENT_ID: "Wrong client ID in request.",
+        AckErrorCode.WRONG_APPLICATION_COMMAND: "Wrong application command.",
+        AckErrorCode.NO_REPLY: "No reply to application command, maybe service down.",
+        AckErrorCode.WRONG_APPLICATION_DATA: "Wrong application data.",
     }
-
-    assert expected_messages == ACK_ERROR_CODES
-
-
-def test_auth_error_codes():
-    """Test that AUTH_ERROR_CODES contains the correct authentication error codes."""
-    from aiocamedomotic.const import AUTH_ERROR_CODES
-
-    expected_auth_codes = {1, 3}
-    assert expected_auth_codes == AUTH_ERROR_CODES
+    for member, message in expected_messages.items():
+        assert member.message == message
 
 
-def test_get_ack_error_message_known_codes():
-    """Test get_ack_error_message function with known error codes."""
-    from aiocamedomotic.const import get_ack_error_message
+def test_ack_error_code_is_auth():
+    """Test that is_auth is True only for authentication-related codes."""
+    from aiocamedomotic.const import AckErrorCode
 
-    # Test known error codes
-    assert get_ack_error_message(1) == "Invalid user."
-    assert get_ack_error_message(3) == "Too many sessions during login."
-    assert get_ack_error_message(4) == "Error occurred in JSON Syntax."
-    assert get_ack_error_message(11) == "Wrong application data."
-
-
-def test_get_ack_error_message_unknown_code():
-    """Test get_ack_error_message function with unknown error code."""
-    from aiocamedomotic.const import get_ack_error_message
-
-    # Test unknown error code
-    assert get_ack_error_message(99) == "Unknown error code: 99"
-    assert get_ack_error_message(0) == "Unknown error code: 0"
-    assert get_ack_error_message(-1) == "Unknown error code: -1"
+    auth_members = {AckErrorCode.INVALID_USER, AckErrorCode.TOO_MANY_SESSIONS}
+    for member in AckErrorCode:
+        if member in auth_members:
+            assert member.is_auth is True, f"{member.name} should be auth"
+        else:
+            assert member.is_auth is False, f"{member.name} should not be auth"
 
 
-def test_get_ack_error_message_edge_cases():
-    """Test get_ack_error_message function with edge cases."""
-    from aiocamedomotic.const import get_ack_error_message
+def test_ack_error_code_int_comparison():
+    """Test that AckErrorCode members compare equal to their integer value."""
+    from aiocamedomotic.const import AckErrorCode
 
-    # Test edge cases
-    assert get_ack_error_message(1000) == "Unknown error code: 1000"
-    assert get_ack_error_message(2) == "Unknown error code: 2"  # Code 2 is not defined
-
-
-def test_is_auth_error_true_cases():
-    """Test is_auth_error function with authentication error codes."""
-    from aiocamedomotic.const import is_auth_error
-
-    # Test authentication error codes
-    assert is_auth_error(1) is True
-    assert is_auth_error(3) is True
+    assert AckErrorCode.INVALID_USER == 1
+    assert AckErrorCode.NO_CLIENT_ID == 7
+    assert isinstance(AckErrorCode.INVALID_USER, int)
 
 
-def test_is_auth_error_false_cases():
-    """Test is_auth_error function with non-authentication error codes."""
-    from aiocamedomotic.const import is_auth_error
+def test_ack_error_code_unknown_raises():
+    """Test that constructing AckErrorCode with an unknown value raises ValueError."""
+    import pytest
 
-    # Test non-authentication error codes
-    assert is_auth_error(4) is False
-    assert is_auth_error(5) is False
-    assert is_auth_error(6) is False
-    assert is_auth_error(7) is False
-    assert is_auth_error(8) is False
-    assert is_auth_error(9) is False
-    assert is_auth_error(10) is False
-    assert is_auth_error(11) is False
+    from aiocamedomotic.const import AckErrorCode
 
-    # Test unknown codes
-    assert is_auth_error(0) is False
-    assert is_auth_error(2) is False
-    assert is_auth_error(99) is False
-    assert is_auth_error(-1) is False
-
-
-def test_is_auth_error_edge_cases():
-    """Test is_auth_error function with edge cases."""
-    from aiocamedomotic.const import is_auth_error
-
-    # Test edge cases
-    assert is_auth_error(1000) is False
-    assert is_auth_error(2) is False  # Code 2 is not defined
-
-
-def test_constants_immutability():
-    """Test that constants can be imported and used without modification."""
-    from aiocamedomotic.const import ACK_ERROR_CODES, AUTH_ERROR_CODES
-
-    # Test that we can access the constants
-    assert len(ACK_ERROR_CODES) == 10
-    assert len(AUTH_ERROR_CODES) == 2
-
-    # Test that constants are the expected types
-    assert isinstance(ACK_ERROR_CODES, dict)
-    assert isinstance(AUTH_ERROR_CODES, set)
-
-
-def test_all_auth_codes_in_ack_codes():
-    """Test that all authentication error codes are also in ACK_ERROR_CODES."""
-    from aiocamedomotic.const import ACK_ERROR_CODES, AUTH_ERROR_CODES
-
-    for auth_code in AUTH_ERROR_CODES:
-        assert auth_code in ACK_ERROR_CODES
+    with pytest.raises(ValueError):
+        AckErrorCode(99)
+    with pytest.raises(ValueError):
+        AckErrorCode(0)
+    with pytest.raises(ValueError):
+        AckErrorCode(2)
 
 
 def test_came_mac_prefixes_type():

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -27,8 +27,8 @@ from aiocamedomotic.const import (
     _DEVICE_TYPE_TO_FEATURE,
     _UPDATE_CMD_TO_DEVICE_TYPE,
     DeviceType,
+    ServerFeature,
     UpdateIndicator,
-    _ServerFeature,
 )
 from aiocamedomotic.errors import CameDomoticAuthError, CameDomoticServerError
 from aiocamedomotic.models import (
@@ -142,23 +142,18 @@ class TestDeviceType:
         assert _UPDATE_CMD_TO_DEVICE_TYPE["scenario_user_ind"] == DeviceType.SCENARIO
 
     def test_device_type_to_feature_mapping(self):
-        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.LIGHT] == _ServerFeature.LIGHTS
-        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.OPENING] == _ServerFeature.OPENINGS
-        assert (
-            _DEVICE_TYPE_TO_FEATURE[DeviceType.GENERIC_RELAY] == _ServerFeature.RELAYS
-        )
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.LIGHT] == ServerFeature.LIGHTS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.OPENING] == ServerFeature.OPENINGS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.GENERIC_RELAY] == ServerFeature.RELAYS
         assert (
             _DEVICE_TYPE_TO_FEATURE[DeviceType.THERMOSTAT]
-            == _ServerFeature.THERMOREGULATION
+            == ServerFeature.THERMOREGULATION
         )
-        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.SCENARIO] == _ServerFeature.SCENARIOS
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.SCENARIO] == ServerFeature.SCENARIOS
         assert (
-            _DEVICE_TYPE_TO_FEATURE[DeviceType.DIGITAL_INPUT]
-            == _ServerFeature.DIGITALIN
+            _DEVICE_TYPE_TO_FEATURE[DeviceType.DIGITAL_INPUT] == ServerFeature.DIGITALIN
         )
-        assert (
-            _DEVICE_TYPE_TO_FEATURE[DeviceType.ENERGY_SENSOR] == _ServerFeature.ENERGY
-        )
+        assert _DEVICE_TYPE_TO_FEATURE[DeviceType.ENERGY_SENSOR] == ServerFeature.ENERGY
 
 
 class TestServerInfo:


### PR DESCRIPTION
## Summary
- Make anonymizer helpers (`anonymize_payload`, `log_traffic`) private as they are internal implementation details
- Refactor ACK error codes from a dict + helper functions to a single `AckErrorCode` IntEnum with message and auth metadata
- Rename `_ServerFeature` to `ServerFeature` (public `StrEnum`) for idiomatic string comparisons
- Improve documentation: expand usage examples, simplify API reference, clean up docstrings

## Test plan
- [x] All existing tests pass (updated for renamed functions and new enums)
- [x] Verify documentation builds correctly (`cd docs && make html`)
- [x] Confirm `ServerFeature` and `AckErrorCode` enums work as expected in downstream integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `AckErrorCode` enum now available for strongly-typed error code handling with message and authentication properties.
  * `ServerFeature` enum now available for type-safe server feature comparisons.

* **Bug Fixes**
  * Improved error handling with typed enums for better robustness.

* **Documentation**
  * Updated usage examples with clearer feature comparison patterns.
  * Enhanced method docstrings with better guidance on session management, thermostat configuration, and zone operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->