### PR TITLE
Fix build-publish automerge by using PAT for gh CLI

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -59,7 +59,7 @@ jobs:
       pull-requests: write # Needed to create a pull request
 
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Use `WORKFLOW_MERGE_PR_PAT` instead of `github.token` for `GH_TOKEN` in the build job
- This allows `gh pr create` to fire `pull_request` events that trigger the required `code-quality` and `code-tests` checks, which previously never ran — causing automerge to wait indefinitely

## Test plan
- [ ] Run the build-publish workflow with a version bump and verify the PR's required checks are triggered automatically
- [ ] Verify automerge completes without manual intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->