### PR TITLE
Bump Pygments to 2.20.0 to fix CVE-2026-4539

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -27,7 +27,7 @@ markupsafe==3.0.2
     # via jinja2
 packaging==24.2
     # via sphinx
-pygments==2.19.1
+pygments==2.20.0
     # via sphinx
 readthedocs-sphinx-search==0.3.2
     # via -r requirements.in

--- a/poetry.lock
+++ b/poetry.lock
@@ -1588,14 +1588,14 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev", "docs", "tests"]
 files = [
-    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
-    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -2374,4 +2374,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "78981c79bdce97105a909c2c6ee89fb9a36eb58ce3d321538c355e7aac396367"
+content-hash = "a94dfbdd762585857d3d48e7ff9c1bd4ba4b02bf9c2873c2c6205f9fabad0a0e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ sphinx_rtd_theme = ">=2,<4"
 readthedocs-sphinx-search = "^0.3.2"
 jinja2 = "^3.1.6"
 sphinx-markdown-builder = "^0.6.9"
+pygments = ">=2.20.0,<3.0.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- Bumps Pygments from 2.19.1 to 2.20.0 to address [Dependabot alert #53](https://github.com/camedomotic-unofficial/aiocamedomotic/security/dependabot/53)
- Fixes CVE-2026-4539: ReDoS vulnerability due to inefficient regex in `AdlLexer` (GHSA-5239-wwwm-4pmq, low severity)
- Adds explicit `pygments >= 2.20.0` constraint in the docs dependency group

## Changes
- `pyproject.toml`: Added `pygments = ">=2.20.0,<3.0.0"` to `[tool.poetry.group.docs.dependencies]`
- `docs/source/requirements.txt`: Bumped pin from 2.19.1 to 2.20.0
- `poetry.lock`: Re-locked with Pygments 2.20.0

## Test plan
- [x] `poetry install --with docs` succeeds
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the documentation syntax-highlighting dependency: pinned to 2.20.0 in docs requirements and added pygments (>=2.20.0,<3.0.0) to the documentation dependency group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->