### PR TITLE
test: close remaining coverage gaps to reach 100%

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest --timeout=9 -p no:sugar --cov=aiocamedomotic --cov-fail-under=90 tests
+        entry: pytest --timeout=9 -p no:sugar --cov=aiocamedomotic --cov-fail-under=100 tests
         language: system
         types: [python]
         pass_filenames: false

--- a/aiocamedomotic/auth.py
+++ b/aiocamedomotic/auth.py
@@ -52,7 +52,11 @@ from .const import (
 # Get package version to avoid circular imports
 try:
     _LIBRARY_VERSION = version(__package__ or "aiocamedomotic")
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
+    # Only reachable if the package metadata is missing at import time (e.g. run
+    # from source without installation). Not exercised by tests: forcing it would
+    # require importlib.reload(), which would create a second Auth class object
+    # and break isinstance/patch.object identity for every other test module.
     _LIBRARY_VERSION = "unknown"
 from .anonymizer import _log_traffic
 from .errors import (

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -381,7 +381,11 @@ class CameDomoticAPI:
             if sensor_data and isinstance(sensor_data, dict):
                 try:
                     sensor_type = AnalogSensorType(key)
-                except ValueError:
+                except ValueError:  # pragma: no cover
+                    # Unreachable: the loop above only ever passes "temperature",
+                    # "humidity" or "pressure", which are all valid
+                    # AnalogSensorType members. Kept as a defensive guard in case
+                    # either the loop or the enum changes independently.
                     LOGGER.warning(
                         "Unknown analog sensor type '%s'. "
                         "Returning AnalogSensorType.UNKNOWN. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 100
 
 [tool.mypy]
 python_version = "3.14"

--- a/tests/aiocamedomotic/test_anonymizer.py
+++ b/tests/aiocamedomotic/test_anonymizer.py
@@ -100,6 +100,12 @@ class TestAnonymizeUrl:
     def test_empty_url(self):
         assert _anonymize_url("") == ""
 
+    def test_urlsplit_raises_returns_redacted_placeholder(self):
+        with patch(
+            "aiocamedomotic.anonymizer.urlsplit", side_effect=AttributeError("boom")
+        ):
+            assert _anonymize_url("http://host:8080/path") == "<url-redacted>"
+
 
 # ---------------------------------------------------------------------------
 # _anonymize_uri
@@ -127,6 +133,12 @@ class TestAnonymizeUri:
         assert "***:***@host" in result
         assert "?t=123" in result
         assert "#frag" in result
+
+    def test_urlsplit_raises_returns_redacted_placeholder(self):
+        with patch(
+            "aiocamedomotic.anonymizer.urlsplit", side_effect=AttributeError("boom")
+        ):
+            assert _anonymize_uri("http://user:pass@host/path") == "<uri-redacted>"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aiocamedomotic/test_auth.py
+++ b/tests/aiocamedomotic/test_auth.py
@@ -33,6 +33,7 @@ from aiocamedomotic.const import (
     _DEFAULT_COMMAND_TIMEOUT,
     _KEEP_ALIVE_MAX_SEC,
     _KEEP_ALIVE_MIN_SEC,
+    _CommandType,
 )
 from aiocamedomotic.errors import (
     CameDomoticAuthError,
@@ -624,6 +625,98 @@ class TestAuthSendCommand:
 
         with pytest.raises(CameDomoticServerError):
             await Auth.async_raise_for_status_and_ack(mock_response)
+
+    @freezegun.freeze_time("2020-01-01")
+    async def test_caller_holds_lock_uses_existing_client_id(self, auth_instance):
+        """When _caller_holds_lock=True, the current client_id is used directly
+        instead of calling async_get_valid_client_id (which would deadlock if the
+        caller already holds self._lock)."""
+        auth_instance.client_id = "already_held_client_id"
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 0}
+
+        payload = {"command": "test_command"}
+
+        with (
+            patch.object(
+                auth_instance.websession, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id,
+        ):
+            mock_post.return_value = mock_response
+
+            await auth_instance.async_send_command(payload, _caller_holds_lock=True)
+
+            mock_get_client_id.assert_not_called()
+
+            expected_appl_msg = {
+                **payload,
+                "cseq": 1,
+                "client": "already_held_client_id",
+            }
+            expected_request_payload = {
+                "sl_appl_msg": expected_appl_msg,
+                "sl_client_id": "already_held_client_id",
+                "sl_cmd": "sl_data_req",
+                "sl_appl_msg_type": "domo",
+            }
+            mock_post.assert_called_once_with(
+                "http://192.168.x.x/domo/",
+                data={"command": json.dumps(expected_request_payload)},
+                headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
+                timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
+            )
+
+    async def test_change_password_payload_omits_client_id(self, auth_instance):
+        """The change-password protocol payload must not include sl_client_id
+        or sl_appl_msg, matching the real CAME protocol (which authenticates
+        via the credentials passed as additional_payload, not a session
+        token)."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"sl_data_ack_reason": 0}
+
+        additional_payload = {
+            "sl_login": "user",
+            "sl_pwd": "old_pwd",
+            "sl_new_pwd": "new_pwd",
+        }
+
+        with (
+            patch.object(
+                auth_instance.websession, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                auth_instance, "async_get_valid_client_id", new_callable=AsyncMock
+            ) as mock_get_client_id,
+        ):
+            mock_post.return_value = mock_response
+
+            await auth_instance.async_send_command(
+                {"cmd_name": "test"},
+                command_type=_CommandType.CHANGE_USER_PASSWORD_REQUEST.value,
+                additional_payload=additional_payload,
+                skip_ack_check=True,
+            )
+
+            mock_get_client_id.assert_not_called()
+
+            expected_request_payload = {
+                "sl_cmd": _CommandType.CHANGE_USER_PASSWORD_REQUEST.value,
+                **additional_payload,
+            }
+            mock_post.assert_called_once_with(
+                "http://192.168.x.x/domo/",
+                data={"command": json.dumps(expected_request_payload)},
+                headers=Auth._DEFAULT_HTTP_HEADERS,  # pylint: disable=protected-access
+                timeout=aiohttp.ClientTimeout(total=_DEFAULT_COMMAND_TIMEOUT),
+            )
 
 
 class TestAuthValidateHost:
@@ -1393,6 +1486,25 @@ class TestTrafficLogging:
                         assert call_args[0][0] == "GET"
                         assert call_args[0][2] is None  # no request payload
                         assert call_args[0][3] is None  # no response payload
+
+    async def test_validate_host_traffic_logging_failure_does_not_affect_result(self):
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.raise_for_status = Mock()
+
+        async with aiohttp.ClientSession() as session:
+            with patch("aiohttp.ClientSession.get") as mock_get:
+                mock_get.return_value.__aenter__.return_value = mock_response
+
+                async with await Auth.async_create(
+                    session, "192.168.x.x", "username", "password"
+                ) as auth:
+                    with patch(
+                        "aiocamedomotic.auth._log_traffic",
+                        side_effect=RuntimeError("logging broken"),
+                    ):
+                        # Host validation should succeed despite _log_traffic raising
+                        await auth.async_validate_host()
 
     @freezegun.freeze_time("2020-01-01")
     async def test_send_command_logs_on_error(self, auth_instance):

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -2678,6 +2678,28 @@ class TestAnalogIn:
         assert sensor.value == 47.0
 
 
+class TestThermoZoneUpdate:
+    def test_unknown_status(self):
+        raw = {"cmd_name": "thermo_zone_info_ind", "act_id": 1, "status": 99}
+        update = parse_update(raw)
+        assert update.status == ThermoZoneStatus.OFF
+
+    def test_unknown_mode(self):
+        raw = {"cmd_name": "thermo_zone_info_ind", "act_id": 1, "mode": 99}
+        update = parse_update(raw)
+        assert update.mode == ThermoZoneMode.UNKNOWN
+
+    def test_unknown_season(self):
+        raw = {"cmd_name": "thermo_zone_info_ind", "act_id": 1, "season": "foo"}
+        update = parse_update(raw)
+        assert update.season == ThermoZoneSeason.UNKNOWN
+
+    def test_unknown_fan_speed(self):
+        raw = {"cmd_name": "thermo_zone_info_ind", "act_id": 1, "fan_speed": 99}
+        update = parse_update(raw)
+        assert update.fan_speed == ThermoZoneFanSpeed.UNKNOWN
+
+
 class TestAnalogInUpdate:
     def test_parse_analogin_status_ind(self):
         raw = {


### PR DESCRIPTION
## Summary
- Adds tests for the last unreached branches: traffic-logging failure tolerance on the GET path, the `_caller_holds_lock` fast path, the `CHANGE_USER_PASSWORD_REQUEST` payload shape, and `ThermoZoneUpdate` unknown-value fallbacks
- Marks two genuinely unreachable defensive branches with `# pragma: no cover` (dead enum lookup in `async_get_analog_sensors`, and the module-import-time `_LIBRARY_VERSION` fallback)
- Raises the coverage gate to 100% in `pyproject.toml` and the pre-commit `pytest` hook (was 95%/90%)

## Test plan
- [x] `pytest --cov=aiocamedomotic --cov-report=term-missing --cov-fail-under=100` → 100.00%, 591 passed, 28 skipped
- [x] `mypy aiocamedomotic` → no issues
- [x] `pylint aiocamedomotic tests` → no new issues
- [x] pre-commit hooks (ruff, ruff-format, bandit, codespell, mypy, prettier, pytest) → all passed