### PR TITLE
ci: consolidate code-quality, pin actions to SHA, add concurrency

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,0 +1,58 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Set up Python and Poetry"
+description: >
+  Install Poetry, set up Python with the built-in Poetry dependency cache, and
+  install the project dependencies (optionally a specific Poetry group).
+
+inputs:
+  python-version:
+    description: "Python version to set up"
+    required: true
+  group:
+    description: "Optional Poetry dependency group to install (e.g. 'tests')"
+    required: false
+    default: ""
+  allow-prereleases:
+    description: "Allow setup-python to install pre-release Python versions"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    # Poetry must be installed before setup-python so that its built-in
+    # `cache: poetry` support can locate it and hash poetry.lock.
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow-prereleases }}
+        cache: "poetry"
+        cache-dependency-path: poetry.lock
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        poetry config virtualenvs.in-project true
+        if [ -n "${{ inputs.group }}" ]; then
+          poetry install --with "${{ inputs.group }}"
+        else
+          poetry install
+        fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,12 @@ updates:
       interval: "monthly"
     labels:
       - "chore"
+
+  # Keep the GitHub Actions (pinned to commit SHA) up to date. Dependabot
+  # updates the SHA while preserving the trailing version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "chore"

--- a/.github/workflows/build-llms-docs.yml
+++ b/.github/workflows/build-llms-docs.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           token: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload built package as artifact
         if: ${{ github.event.inputs.publish_to_test == 'true' || github.event.inputs.publish_to_production == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: built-package
           path: dist/*
@@ -196,12 +196,15 @@ jobs:
       id-token: write
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: built-package
           path: dist
 
       - name: Publish to TestPyPI
+        # Intentionally tracks the release/v1 branch (PyPA's recommended,
+        # OIDC-trusted-publishing pin); not pinned to a SHA to keep trusted
+        # publishing working.
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -219,16 +222,19 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: built-package
           path: dist
 
       - name: Publish to PyPI
+        # Intentionally tracks the release/v1 branch (PyPA's recommended,
+        # OIDC-trusted-publishing pin); not pinned to a SHA to keep trusted
+        # publishing working.
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Checkout repository for tag lookup
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           fetch-depth: 0
@@ -262,7 +268,7 @@ jobs:
           echo "$NOTES" > release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.build.outputs.version }}
           draft: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,7 +21,7 @@ on:
       - "aiocamedomotic/**/*.py"
       - "pyproject.toml"
       - ".github/workflows/code-quality.yml"
-      # - 'mypy.ini'
+      - ".github/actions/setup-poetry/action.yml"
   pull_request:
     # Always run for PRs to satisfy required status checks
     branches: [main, update-version]
@@ -34,66 +34,30 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs on PRs only; keep the full history on main.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   PYTHON_VERSION: "3.14"
 
 jobs:
-  setup:
+  # Single required status check for branch protection.
+  # ruff, mypy and pylint all run in one job: on a small library they finish in
+  # seconds, so a single runner is faster end-to-end than a fan-out that pays
+  # checkout + Python + Poetry setup several times over.
+  code-quality:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and Poetry
+        uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Cache Poetry virtualenv
-        id: cache-venv
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
-
-  ruff:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
+          group: code-quality
 
       - name: Check formatting with ruff
         run: poetry run ruff format aiocamedomotic --check
@@ -101,36 +65,8 @@ jobs:
       - name: Check linting with ruff
         run: poetry run ruff check aiocamedomotic
 
-  mypy:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
-
       - name: Cache mypy results
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .mypy_cache
           key: mypy-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('aiocamedomotic/**/*.py') }}
@@ -140,48 +76,7 @@ jobs:
       - name: Run mypy
         run: poetry run mypy aiocamedomotic
 
-  pylint:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
-
+      # pylint is kept for its error-only checks (W/R/C disabled); it partially
+      # overlaps with ruff + mypy strict but still catches a few extra cases.
       - name: Run pylint
         run: poetry run pylint --disable=W,R,C aiocamedomotic
-
-  # Gate job: single required status check for branch protection
-  code-quality:
-    if: always()
-    needs: [ruff, mypy, pylint]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check results
-        run: |
-          if [[ "${{ needs.ruff.result }}" != "success" || \
-                "${{ needs.mypy.result }}" != "success" || \
-                "${{ needs.pylint.result }}" != "success" ]]; then
-            echo "One or more checks failed"
-            exit 1
-          fi

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -22,6 +22,7 @@ on:
       - "tests/**/*.py"
       - "pyproject.toml"
       - ".github/workflows/code-tests.yml"
+      - ".github/actions/setup-poetry/action.yml"
   pull_request:
     # Always run for PRs to satisfy required status checks
     branches: [main, update-version]
@@ -30,6 +31,11 @@ on:
 # Define minimal required permissions at workflow level
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs on PRs only; keep the full history on main.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -40,36 +46,20 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - name: Set up Python ${{ matrix.python-version }} and Poetry
+        uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install package and its dependencies
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with tests
+          group: tests
 
       - name: Run pytest with coverage
         run: poetry run pytest --timeout 10 --cov=aiocamedomotic --cov-report xml --cov-report term-missing
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: "pytest-${{ matrix.python-version }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14" # Set this to your required version of Python
 

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
         with:
           prerelease: true
           prerelease-identifier: alpha
 
       # Autolabeler (split into dedicated action in v7)
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7

--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply stale policy
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           days-before-stale: 90
           stale-issue-message: >

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,12 +36,17 @@ permissions:
   contents: read
   security-events: write # For reporting security issues
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs on PRs only; keep the full history on main.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Bandit
         run: |
@@ -51,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
 
       - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1.48.0
+        uses: GitGuardian/ggshield-action@50c99a7fbe0e313f962dc5bb74d8271e02543c3a # v1.48.0
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}


### PR DESCRIPTION
Consolidate and harden the CI/CD pipeline without touching the release flow:

- Add a reusable composite action (.github/actions/setup-poetry) that installs
  Poetry, sets up Python with the built-in Poetry cache and installs deps.
- Collapse code-quality.yml from setup+ruff+mypy+pylint fan-out (whose cache
  was defeated by an unconditional reinstall step) into a single code-quality
  job; the required status check name is preserved.
- Reuse the composite action in code-tests.yml.
- Add concurrency (cancel-in-progress on PRs only) to the three CI workflows to
  avoid wasting minutes on superseded runs.
- Pin all third-party GitHub Actions to commit SHA with a version comment;
  pypa/gh-action-pypi-publish is intentionally left on release/v1 for trusted
  publishing.
- Add the github-actions ecosystem to Dependabot so those SHAs stay current.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HWBJW88SU5nRqY1ANdkHMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable Python/Poetry setup action for workflows, with support for optional dependency groups and pre-release installs.

* **Bug Fixes**
  * Improved workflow reliability by reducing duplicate runs and adding better concurrency handling.
  * Updated test and security jobs to use more consistent checkout behavior.

* **Chores**
  * Pinned multiple GitHub Actions to fixed versions for more predictable workflow runs.
  * Expanded Dependabot coverage to keep GitHub Actions updates current.
  * Simplified the code quality workflow structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->