### PR TITLE
ci: streamline workflows and extend Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
       interval: "monthly"
     labels:
       - "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "chore"

--- a/.github/workflows/build-llms-docs.yml
+++ b/.github/workflows/build-llms-docs.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -32,7 +32,7 @@ on:
           - preminor # update minor number and adds a0
           - premajor # update major number and adds a0
           - prerelease # if final updates patch and adds a0, otherwise add +1 to the pre-release number
-          - prerelease –next-phase # steps a > b > rc > final
+          - prerelease --next-phase # steps a > b > rc > final
           - none
         default: prerelease
       publish_to_test:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           token: ${{ secrets.WORKFLOW_MERGE_PR_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload built package as artifact
         if: ${{ github.event.inputs.publish_to_test == 'true' || github.event.inputs.publish_to_production == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: built-package
           path: dist/*
@@ -196,13 +196,13 @@ jobs:
       id-token: write
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: built-package
           path: dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -219,16 +219,16 @@ jobs:
 
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: built-package
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Checkout repository for tag lookup
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           fetch-depth: 0
@@ -262,7 +262,7 @@ jobs:
           echo "$NOTES" > release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.build.outputs.version }}
           draft: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -61,7 +61,7 @@ jobs:
         run: pipx install poetry
 
       - name: Cache Poetry virtualenv
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cache/pypoetry
@@ -74,7 +74,7 @@ jobs:
           poetry install --with code-quality
 
       - name: Cache mypy results
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .mypy_cache
           key: mypy-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('aiocamedomotic/**/*.py') }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,11 +34,19 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR; never cancel runs on main or schedule
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   PYTHON_VERSION: "3.14"
 
 jobs:
-  setup:
+  # Single job: the linters run in seconds on this codebase, so parallel jobs
+  # would only multiply the checkout/install overhead. Job name must stay
+  # "code-quality" (required status check for branch protection).
+  code-quality:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -53,7 +61,6 @@ jobs:
         run: pipx install poetry
 
       - name: Cache Poetry virtualenv
-        id: cache-venv
         uses: actions/cache@v4
         with:
           path: |
@@ -62,69 +69,6 @@ jobs:
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
-
-  ruff:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
-
-      - name: Check formatting with ruff
-        run: poetry run ruff format aiocamedomotic --check
-
-      - name: Check linting with ruff
-        run: poetry run ruff check aiocamedomotic
-
-  mypy:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
         run: |
           poetry config virtualenvs.in-project true
           poetry install --with code-quality
@@ -137,51 +81,17 @@ jobs:
           restore-keys: |
             mypy-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
 
+      - name: Check formatting with ruff
+        run: poetry run ruff format aiocamedomotic --check
+
+      - name: Check linting with ruff
+        run: poetry run ruff check aiocamedomotic
+
       - name: Run mypy
         run: poetry run mypy aiocamedomotic
-
-  pylint:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Restore cached virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-
-      - name: Install dependencies (cache miss fallback)
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --with code-quality
 
       - name: Run pylint
         run: poetry run pylint --disable=W,R,C aiocamedomotic
 
-  # Gate job: single required status check for branch protection
-  code-quality:
-    if: always()
-    needs: [ruff, mypy, pylint]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check results
-        run: |
-          if [[ "${{ needs.ruff.result }}" != "success" || \
-                "${{ needs.mypy.result }}" != "success" || \
-                "${{ needs.pylint.result }}" != "success" ]]; then
-            echo "One or more checks failed"
-            exit 1
-          fi
+      - name: Check spelling with codespell
+        run: pipx run codespell

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -45,10 +45,10 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -57,7 +57,7 @@ jobs:
         run: pipx install poetry
 
       - name: Cache Poetry virtualenv
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cache/pypoetry
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: "pytest-${{ matrix.python-version }}"

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -31,6 +31,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR; never cancel runs on main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR; never cancel runs on main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14" # Set this to your required version of Python
 

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         with:
           prerelease: true
           prerelease-identifier: alpha
 
       # Autolabeler (split into dedicated action in v7)
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1

--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply stale policy
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: 90
           stale-issue-message: >

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run Bandit
         run: |
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
 
       - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1.48.0
+        uses: GitGuardian/ggshield-action@50c99a7fbe0e313f962dc5bb74d8271e02543c3a # v1.48.0
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,11 @@ permissions:
   contents: read
   security-events: write # For reporting security issues
 
+# Cancel superseded runs on the same PR; never cancel runs on main or schedule
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   bandit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add github-actions ecosystem to Dependabot so action versions are
  kept up to date (auto-merge already covers minor/patch updates)
- Consolidate code-quality workflow into a single job: the linters run
  in seconds, so parallel jobs only multiplied setup overhead; job name
  stays 'code-quality' to preserve the required status check
- Add codespell check to CI, aligning with the pre-commit hooks
- Add concurrency groups to PR-triggered workflows to cancel superseded
  runs on new pushes
- Fix en-dash typo in the 'prerelease --next-phase' version option of
  the build-publish workflow