### PR TITLE
feat: add energy meter support (model, API method, typed updates)

### DIFF
--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -539,7 +539,7 @@ class CameDomoticAPI:
 
         Energy meters are read-only, plant-level entities exposed via the
         ``energy`` feature. They report the instantaneous power measured on
-        a line and cumulative energy counters, and have no floor/room
+        a line and energy values, and have no floor/room
         placement.
 
         Returns:

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -43,6 +43,7 @@ from .models import (
     AnalogSensorType,
     Camera,
     DigitalInput,
+    EnergyMeter,
     Floor,
     Light,
     MapPage,
@@ -532,6 +533,37 @@ class CameDomoticAPI:
         analogin_list = json_response.get("array", []) or []
         LOGGER.info("Retrieved %d analog input(s)", len(analogin_list))
         return [AnalogIn(analogin_data) for analogin_data in analogin_list]
+
+    async def async_get_energy_meters(self) -> list[EnergyMeter]:
+        """Get the list of all energy meters defined on the server.
+
+        Energy meters are read-only, plant-level entities exposed via the
+        ``energy`` feature. They report the instantaneous power measured on
+        a line and cumulative energy counters, and have no floor/room
+        placement.
+
+        Returns:
+            list[EnergyMeter]: List of energy meters. Returns an empty list
+            if none are defined or the server response lacks the ``array``
+            key.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching energy meters list")
+        payload = {
+            "cmd_name": _CommandName.METERS_LIST.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.METERS_LIST.value
+        )
+
+        # Defaults to an empty list if the key is missing from the response JSON
+        meters_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d energy meter(s)", len(meters_list))
+        return [EnergyMeter(meter_data) for meter_data in meters_list]
 
     async def async_get_cameras(self) -> list[Camera]:
         """Get the list of all TVCC cameras defined on the server.

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -38,6 +38,7 @@ from .digital_input import (  # noqa: F401
     DigitalInputStatus,
     DigitalInputType,
 )
+from .energy_meter import EnergyMeter, EnergyMeterType  # noqa: F401
 from .light import Light, LightStatus, LightType  # noqa: F401
 from .map_page import MapPage  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
@@ -57,6 +58,7 @@ from .update import (  # noqa: F401
     AnalogInUpdate,
     DeviceUpdate,
     DigitalInputUpdate,
+    EnergyMeterUpdate,
     LightUpdate,
     OpeningUpdate,
     PlantUpdate,
@@ -82,6 +84,9 @@ __all__ = [
     "DigitalInputStatus",
     "DigitalInputType",
     "DigitalInputUpdate",
+    "EnergyMeter",
+    "EnergyMeterType",
+    "EnergyMeterUpdate",
     "Floor",
     "Light",
     "LightStatus",

--- a/aiocamedomotic/models/energy_meter.py
+++ b/aiocamedomotic/models/energy_meter.py
@@ -1,0 +1,165 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAME Domotic energy meter entity models.
+
+This module implements the class for working with energy meters in a CAME
+Domotic system. Energy meters are read-only, plant-level entities exposed via
+the ``energy`` feature: they report the instantaneous power measured on a
+line together with cumulative energy counters. They have no ``act_id`` and
+no floor/room placement — the ``id`` field is their identifier, and it is
+also the matching key for ``meter_instant_power_ind`` push updates.
+
+Energy meters provide readings but do not support control commands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ..utils import (
+    LOGGER,
+    EntityValidator,
+)
+from .base import CameEntity
+
+
+class EnergyMeterType(Enum):
+    """Type of an energy meter, as reported in the ``meter_type`` field.
+
+    Allowed values are:
+        - POWER (1): Power meter (the only value observed on real servers).
+        - UNKNOWN (-1): Returned when the server reports an unrecognised
+          ``meter_type`` value.
+    """
+
+    POWER = 1
+    UNKNOWN = -1
+
+
+@dataclass
+class EnergyMeter(CameEntity):
+    """Read-only energy meter from the ``meters_list_resp`` endpoint.
+
+    Represents an energy meter exposed via the ``energy`` feature. Energy
+    meters are plant-level entities keyed by :attr:`id` (they have no
+    ``act_id``, floor, or room). They report the current power reading and
+    cumulative energy counters, and cannot be controlled.
+
+    Args:
+        raw_data: Dictionary containing the meter data from the API.
+
+    Raises:
+        ValueError: If ``name`` or ``id`` keys are missing from the input
+            data, or if ``id`` is not an integer.
+    """
+
+    raw_data: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["name", "id"],
+            typed_keys={"id": int},
+        )
+
+    @property
+    def id(self) -> int:
+        """Unique meter identifier.
+
+        This is also the matching key for ``meter_instant_power_ind``
+        push updates (energy meters have no ``act_id``).
+        """
+        return self.raw_data["id"]
+
+    @property
+    def name(self) -> str:
+        """Display name of the meter."""
+        return self.raw_data["name"]
+
+    @property
+    def meter_type(self) -> EnergyMeterType:
+        """Type of the meter (POWER is the only value observed so far)."""
+        try:
+            return EnergyMeterType(self.raw_data["meter_type"])
+        except (ValueError, KeyError):
+            LOGGER.warning(
+                "Unknown energy meter type '%s' encountered for meter '%s' "
+                "(ID: %s). Returning EnergyMeterType.UNKNOWN. Please report "
+                "this to the library developers.",
+                self.raw_data.get("meter_type"),
+                self.name,
+                self.id,
+            )
+            return EnergyMeterType.UNKNOWN
+
+    @property
+    def instant_power(self) -> float:
+        """Current power reading, in the unit reported by :attr:`unit`.
+
+        The value is passed through exactly as reported by the server
+        (no unit conversion is applied).
+        """
+        return self.raw_data.get("instant_power", 0)
+
+    @property
+    def unit(self) -> str:
+        """Unit of measurement for :attr:`instant_power` (``'W'`` observed)."""
+        return self.raw_data.get("unit", "W")
+
+    @property
+    def energy_unit(self) -> str:
+        """Unit of measurement for the energy counters (``'Wh'`` observed)."""
+        return self.raw_data.get("energy_unit", "Wh")
+
+    @property
+    def produced(self) -> int:
+        """Raw ``produced`` field from the server.
+
+        ``0`` observed on consumption meters; semantics for production
+        meters are unverified.
+        """
+        return self.raw_data.get("produced", 0)
+
+    @property
+    def last_24h_avg(self) -> int:
+        """Raw ``last_24h_avg`` field from the server, in :attr:`energy_unit`.
+
+        .. note::
+            Despite the field name, on observed firmware this behaves as a
+            **cumulative energy counter** (total Wh, monotonically
+            increasing), not as an average. Do not present it as an average;
+            its counter-like behavior makes it suitable as a
+            ``total_increasing`` energy source (e.g. for Home Assistant's
+            Energy dashboard).
+        """
+        return self.raw_data.get("last_24h_avg", 0)
+
+    @property
+    def last_month_avg(self) -> int:
+        """Raw ``last_month_avg`` field from the server, in :attr:`energy_unit`.
+
+        .. note::
+            Despite the field name, on observed firmware this behaves as a
+            **cumulative energy counter** (total Wh, monotonically
+            increasing), not as an average — it held the same value as
+            :attr:`last_24h_avg` at all times in captured traffic. Do not
+            present it as an average; its counter-like behavior makes it
+            suitable as a ``total_increasing`` energy source (e.g. for Home
+            Assistant's Energy dashboard).
+        """
+        return self.raw_data.get("last_month_avg", 0)

--- a/aiocamedomotic/models/energy_meter.py
+++ b/aiocamedomotic/models/energy_meter.py
@@ -18,7 +18,7 @@ CAME Domotic energy meter entity models.
 This module implements the class for working with energy meters in a CAME
 Domotic system. Energy meters are read-only, plant-level entities exposed via
 the ``energy`` feature: they report the instantaneous power measured on a
-line together with cumulative energy counters. They have no ``act_id`` and
+line together with energy values. They have no ``act_id`` and
 no floor/room placement — the ``id`` field is their identifier, and it is
 also the matching key for ``meter_instant_power_ind`` push updates.
 
@@ -58,7 +58,7 @@ class EnergyMeter(CameEntity):
     Represents an energy meter exposed via the ``energy`` feature. Energy
     meters are plant-level entities keyed by :attr:`id` (they have no
     ``act_id``, floor, or room). They report the current power reading and
-    cumulative energy counters, and cannot be controlled.
+    energy values, and cannot be controlled.
 
     Args:
         raw_data: Dictionary containing the meter data from the API.
@@ -108,7 +108,7 @@ class EnergyMeter(CameEntity):
             return EnergyMeterType.UNKNOWN
 
     @property
-    def instant_power(self) -> float:
+    def instant_power(self) -> int:
         """Current power reading, in the unit reported by :attr:`unit`.
 
         The value is passed through exactly as reported by the server
@@ -123,7 +123,8 @@ class EnergyMeter(CameEntity):
 
     @property
     def energy_unit(self) -> str:
-        """Unit of measurement for the energy counters (``'Wh'`` observed)."""
+        """Unit of measurement (``'Wh'`` observed) for the
+        :attr:`last_24h_avg` and :attr:`last_month_avg` values."""
         return self.raw_data.get("energy_unit", "Wh")
 
     @property
@@ -139,13 +140,7 @@ class EnergyMeter(CameEntity):
     def last_24h_avg(self) -> int:
         """Raw ``last_24h_avg`` field from the server, in :attr:`energy_unit`.
 
-        .. note::
-            Despite the field name, on observed firmware this behaves as a
-            **cumulative energy counter** (total Wh, monotonically
-            increasing), not as an average. Do not present it as an average;
-            its counter-like behavior makes it suitable as a
-            ``total_increasing`` energy source (e.g. for Home Assistant's
-            Energy dashboard).
+        The value is passed through exactly as reported by the server.
         """
         return self.raw_data.get("last_24h_avg", 0)
 
@@ -153,13 +148,6 @@ class EnergyMeter(CameEntity):
     def last_month_avg(self) -> int:
         """Raw ``last_month_avg`` field from the server, in :attr:`energy_unit`.
 
-        .. note::
-            Despite the field name, on observed firmware this behaves as a
-            **cumulative energy counter** (total Wh, monotonically
-            increasing), not as an average — it held the same value as
-            :attr:`last_24h_avg` at all times in captured traffic. Do not
-            present it as an average; its counter-like behavior makes it
-            suitable as a ``total_increasing`` energy source (e.g. for Home
-            Assistant's Energy dashboard).
+        The value is passed through exactly as reported by the server.
         """
         return self.raw_data.get("last_month_avg", 0)

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -452,7 +452,7 @@ class EnergyMeterUpdate(DeviceUpdate):
 
     Pushed by the server when the power measured by a meter changes. The
     payload is a complete snapshot of the meter state (same shape as a
-    ``meters_list_resp`` item), including refreshed energy counters.
+    ``meters_list_resp`` item), including refreshed energy values.
     """
 
     @property
@@ -469,7 +469,7 @@ class EnergyMeterUpdate(DeviceUpdate):
             return EnergyMeterType.UNKNOWN
 
     @property
-    def instant_power(self) -> float:
+    def instant_power(self) -> int:
         """Current power reading, in the unit reported by :attr:`unit`.
 
         The value is passed through exactly as reported by the server
@@ -484,7 +484,8 @@ class EnergyMeterUpdate(DeviceUpdate):
 
     @property
     def energy_unit(self) -> str:
-        """Unit of measurement for the energy counters (``'Wh'`` observed)."""
+        """Unit of measurement (``'Wh'`` observed) for the
+        :attr:`last_24h_avg` and :attr:`last_month_avg` values."""
         return self.raw_data.get("energy_unit", "Wh")
 
     @property
@@ -496,9 +497,7 @@ class EnergyMeterUpdate(DeviceUpdate):
     def last_24h_avg(self) -> int:
         """Raw ``last_24h_avg`` field, in :attr:`energy_unit`.
 
-        On observed firmware this behaves as a **cumulative energy
-        counter**, not as an average — see
-        :attr:`~aiocamedomotic.models.energy_meter.EnergyMeter.last_24h_avg`.
+        The value is passed through exactly as reported by the server.
         """
         return self.raw_data.get("last_24h_avg", 0)
 
@@ -506,9 +505,7 @@ class EnergyMeterUpdate(DeviceUpdate):
     def last_month_avg(self) -> int:
         """Raw ``last_month_avg`` field, in :attr:`energy_unit`.
 
-        On observed firmware this behaves as a **cumulative energy
-        counter**, not as an average — see
-        :attr:`~aiocamedomotic.models.energy_meter.EnergyMeter.last_month_avg`.
+        The value is passed through exactly as reported by the server.
         """
         return self.raw_data.get("last_month_avg", 0)
 

--- a/aiocamedomotic/models/update.py
+++ b/aiocamedomotic/models/update.py
@@ -31,6 +31,7 @@ from typing import Any
 from ..const import _UPDATE_CMD_TO_DEVICE_TYPE, DeviceType, UpdateIndicator
 from ..utils import LOGGER
 from .base import CameEntity
+from .energy_meter import EnergyMeterType
 from .light import LightStatus, LightType
 from .opening import OpeningStatus
 from .relay import RelayStatus
@@ -446,6 +447,78 @@ class TimerUpdate(DeviceUpdate):
 
 
 @dataclass
+class EnergyMeterUpdate(DeviceUpdate):
+    """Typed update for an energy meter (``meter_instant_power_ind``).
+
+    Pushed by the server when the power measured by a meter changes. The
+    payload is a complete snapshot of the meter state (same shape as a
+    ``meters_list_resp`` item), including refreshed energy counters.
+    """
+
+    @property
+    def id(self) -> int:
+        """Meter identifier (energy meters have no ``act_id``)."""
+        return self.raw_data["id"]
+
+    @property
+    def meter_type(self) -> EnergyMeterType:
+        """Type of the meter (POWER is the only value observed so far)."""
+        try:
+            return EnergyMeterType(self.raw_data["meter_type"])
+        except (ValueError, KeyError):
+            return EnergyMeterType.UNKNOWN
+
+    @property
+    def instant_power(self) -> float:
+        """Current power reading, in the unit reported by :attr:`unit`.
+
+        The value is passed through exactly as reported by the server
+        (no unit conversion is applied).
+        """
+        return self.raw_data.get("instant_power", 0)
+
+    @property
+    def unit(self) -> str:
+        """Unit of measurement for :attr:`instant_power` (``'W'`` observed)."""
+        return self.raw_data.get("unit", "W")
+
+    @property
+    def energy_unit(self) -> str:
+        """Unit of measurement for the energy counters (``'Wh'`` observed)."""
+        return self.raw_data.get("energy_unit", "Wh")
+
+    @property
+    def produced(self) -> int:
+        """Raw ``produced`` field (``0`` observed on consumption meters)."""
+        return self.raw_data.get("produced", 0)
+
+    @property
+    def last_24h_avg(self) -> int:
+        """Raw ``last_24h_avg`` field, in :attr:`energy_unit`.
+
+        On observed firmware this behaves as a **cumulative energy
+        counter**, not as an average — see
+        :attr:`~aiocamedomotic.models.energy_meter.EnergyMeter.last_24h_avg`.
+        """
+        return self.raw_data.get("last_24h_avg", 0)
+
+    @property
+    def last_month_avg(self) -> int:
+        """Raw ``last_month_avg`` field, in :attr:`energy_unit`.
+
+        On observed firmware this behaves as a **cumulative energy
+        counter**, not as an average — see
+        :attr:`~aiocamedomotic.models.energy_meter.EnergyMeter.last_month_avg`.
+        """
+        return self.raw_data.get("last_month_avg", 0)
+
+    @property
+    def device_id(self) -> int | None:
+        """For energy meters the primary ID is ``id``."""
+        return self.raw_data.get("id")
+
+
+@dataclass
 class PlantUpdate(DeviceUpdate):
     """Marker update for ``plant_update_ind``.
 
@@ -479,6 +552,7 @@ _INDICATOR_TO_UPDATE_CLASS: dict[str, type[DeviceUpdate]] = {
     "digitalin_update_ind": DigitalInputUpdate,
     "analogin_status_ind": AnalogInUpdate,
     "analogin_update_ind": AnalogInUpdate,
+    "meter_instant_power_ind": EnergyMeterUpdate,
     "timer_info_ind": TimerUpdate,
     "timer_update_ind": TimerUpdate,
     "plant_update_ind": PlantUpdate,

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -898,7 +898,7 @@ Energy meters
 
 Energy meters are read-only sensors exposed via the ``energy`` feature. They
 report the instantaneous power measured on a line (e.g. the whole-home
-consumption) together with cumulative energy counters. Unlike lights or
+consumption) together with energy values. Unlike lights or
 openings, energy meters are **plant-level entities keyed by** ``id``: they
 have no ``act_id`` and no floor/room placement. The number of meters and
 their names are entirely plant-specific — always discover them via the API.
@@ -930,7 +930,7 @@ Example output:
     # By name
     consumption = next((m for m in meters if m.name == "Consumed Energy"), None)
 
-**Reading the energy counters:**
+**Reading the energy values:**
 
 Each meter also exposes the raw ``last_24h_avg`` and ``last_month_avg``
 fields, expressed in ``energy_unit`` (typically ``Wh``):
@@ -938,17 +938,8 @@ fields, expressed in ``energy_unit`` (typically ``Wh``):
 .. code-block:: python
 
     if main_meter:
-        print(f"Counter: {main_meter.last_24h_avg} {main_meter.energy_unit}")
-
-.. note::
-    **Despite their names,** ``last_24h_avg`` **and** ``last_month_avg``
-    **behave as cumulative energy counters on observed firmware, not as
-    averages.** In captured traffic both fields held the same value and
-    increased monotonically, in step with the energy actually consumed
-    (e.g. +20 Wh over ~2 minutes at ~636 W). Do not present them as
-    averages. On the plus side, this counter-like behavior makes them
-    suitable as a ``total_increasing`` energy source — for example to feed
-    Home Assistant's Energy dashboard.
+        print(f"last_24h_avg: {main_meter.last_24h_avg} {main_meter.energy_unit}")
+        print(f"last_month_avg: {main_meter.last_month_avg} {main_meter.energy_unit}")
 
 Real-time power readings are delivered as push updates — see
 :ref:`energy-meter-updates` in the monitoring section below.
@@ -1193,7 +1184,7 @@ Energy meter updates
 When the power measured by an energy meter changes, the server pushes a
 ``meter_instant_power_ind`` indication — one per meter, each containing a
 **complete snapshot** of the meter state (the same fields as the meter list
-response), with the energy counters refreshed in the same push. The library
+response), with the energy values refreshed in the same push. The library
 parses it into an :class:`~aiocamedomotic.models.update.EnergyMeterUpdate`
 object whose ``device_id`` is the meter's ``id``.
 
@@ -1213,7 +1204,7 @@ instead of repeatedly calling ``async_get_energy_meters()``:
                 print(
                     f"Meter '{update.name}' (ID: {update.device_id}): "
                     f"{update.instant_power} {update.unit}, "
-                    f"counter={update.last_24h_avg} {update.energy_unit}"
+                    f"last_24h_avg={update.last_24h_avg} {update.energy_unit}"
                 )
 
         await asyncio.sleep(1)
@@ -1222,15 +1213,8 @@ Example output:
 
 .. code-block:: text
 
-    Meter 'Line 1 + Line 2' (ID: 3): 636 W, counter=7788947 Wh
-    Meter 'Consumed Energy' (ID: 4): 636 W, counter=5813290 Wh
-
-.. note::
-    The exact power-change threshold that triggers a push is not documented;
-    in captured traffic a change of roughly 40 W was enough. The
-    ``last_24h_avg`` / ``last_month_avg`` counters carried by the update
-    have the same cumulative-counter semantics described in the
-    `Energy meters`_ section above.
+    Meter 'Line 1 + Line 2' (ID: 3): 636 W, last_24h_avg=7788947 Wh
+    Meter 'Consumed Energy' (ID: 4): 636 W, last_24h_avg=5813290 Wh
 
 
 Advanced topics

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -37,7 +37,8 @@ and controlling devices, and monitoring real-time changes. For a minimal
             ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
             Timer, TimerTimeSlot, TimerUpdate,
             DeviceUpdate, LightUpdate, OpeningUpdate, RelayUpdate,
-            ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
+            ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate,
+            EnergyMeterUpdate, PlantUpdate,
         )
         from aiocamedomotic.errors import (
             CameDomoticError,
@@ -239,6 +240,9 @@ entries against enum members to decide which device APIs to call:
 
     if ServerFeature.TIMERS in server_info.features:
         timers = await api.async_get_timers()
+
+    if ServerFeature.ENERGY in server_info.features:
+        meters = await api.async_get_energy_meters()
 
 Floors and rooms
 ^^^^^^^^^^^^^^^^
@@ -889,6 +893,66 @@ state, adds a day, sets a time slot, and reverts everything:
 
     asyncio.run(main())
 
+Energy meters
+^^^^^^^^^^^^^
+
+Energy meters are read-only sensors exposed via the ``energy`` feature. They
+report the instantaneous power measured on a line (e.g. the whole-home
+consumption) together with cumulative energy counters. Unlike lights or
+openings, energy meters are **plant-level entities keyed by** ``id``: they
+have no ``act_id`` and no floor/room placement. The number of meters and
+their names are entirely plant-specific — always discover them via the API.
+
+**Fetching and inspecting energy meters:**
+
+.. code-block:: python
+
+    meters = await api.async_get_energy_meters()
+
+    for meter in meters:
+        print(f"ID: {meter.id}, Name: {meter.name}, "
+              f"Power: {meter.instant_power} {meter.unit}")
+
+Example output:
+
+.. code-block:: text
+
+    ID: 4, Name: Consumed Energy, Power: 595 W
+    ID: 3, Name: Line 1 + Line 2, Power: 595 W
+
+**Finding a specific energy meter:**
+
+.. code-block:: python
+
+    # By ID
+    main_meter = next((m for m in meters if m.id == 4), None)
+
+    # By name
+    consumption = next((m for m in meters if m.name == "Consumed Energy"), None)
+
+**Reading the energy counters:**
+
+Each meter also exposes the raw ``last_24h_avg`` and ``last_month_avg``
+fields, expressed in ``energy_unit`` (typically ``Wh``):
+
+.. code-block:: python
+
+    if main_meter:
+        print(f"Counter: {main_meter.last_24h_avg} {main_meter.energy_unit}")
+
+.. note::
+    **Despite their names,** ``last_24h_avg`` **and** ``last_month_avg``
+    **behave as cumulative energy counters on observed firmware, not as
+    averages.** In captured traffic both fields held the same value and
+    increased monotonically, in step with the energy actually consumed
+    (e.g. +20 Wh over ~2 minutes at ~636 W). Do not present them as
+    averages. On the plus side, this counter-like behavior makes them
+    suitable as a ``total_increasing`` energy source — for example to feed
+    Home Assistant's Energy dashboard.
+
+Real-time power readings are delivered as push updates — see
+:ref:`energy-meter-updates` in the monitoring section below.
+
 
 Monitoring real-time updates
 ----------------------------
@@ -1022,6 +1086,9 @@ compatibility. For **typed** update objects with convenient properties, use
                 f"days={update.days}, slots={len(update.timetable)}"
             )
 
+        elif isinstance(update, EnergyMeterUpdate):
+            print(f"Meter '{update.name}': {update.instant_power} {update.unit}")
+
         elif isinstance(update, PlantUpdate):
             print("Plant configuration changed, re-fetching devices...")
 
@@ -1117,6 +1184,53 @@ without needing to merge changes.
     The ``timer_info_ind`` indication name was confirmed from real server
     traffic (firmware 3.0.1). A legacy variant ``timer_update_ind`` is also
     handled for firmware compatibility.
+
+.. _energy-meter-updates:
+
+Energy meter updates
+^^^^^^^^^^^^^^^^^^^^
+
+When the power measured by an energy meter changes, the server pushes a
+``meter_instant_power_ind`` indication — one per meter, each containing a
+**complete snapshot** of the meter state (the same fields as the meter list
+response), with the energy counters refreshed in the same push. The library
+parses it into an :class:`~aiocamedomotic.models.update.EnergyMeterUpdate`
+object whose ``device_id`` is the meter's ``id``.
+
+This is the recommended way to track power consumption in real time,
+instead of repeatedly calling ``async_get_energy_meters()``:
+
+.. code-block:: python
+
+    while True:
+        try:
+            updates = await api.async_get_updates(timeout=120)
+        except CameDomoticServerTimeoutError:
+            continue
+
+        for update in updates.get_typed_updates():
+            if isinstance(update, EnergyMeterUpdate):
+                print(
+                    f"Meter '{update.name}' (ID: {update.device_id}): "
+                    f"{update.instant_power} {update.unit}, "
+                    f"counter={update.last_24h_avg} {update.energy_unit}"
+                )
+
+        await asyncio.sleep(1)
+
+Example output:
+
+.. code-block:: text
+
+    Meter 'Line 1 + Line 2' (ID: 3): 636 W, counter=7788947 Wh
+    Meter 'Consumed Energy' (ID: 4): 636 W, counter=5813290 Wh
+
+.. note::
+    The exact power-change threshold that triggers a push is not documented;
+    in captured traffic a change of roughly 40 W was enough. The
+    ``last_24h_avg`` / ``last_month_avg`` counters carried by the update
+    have the same cumulative-counter semantics described in the
+    `Energy meters`_ section above.
 
 
 Advanced topics

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -509,6 +509,22 @@ def timer_data():
 
 
 @pytest.fixture
+def energy_meter_data():
+    """Mock data for an energy meter (real traffic, swver 3.0.1)."""
+    return {
+        "name": "Consumed Energy",
+        "id": 4,
+        "meter_type": 1,
+        "produced": 0,
+        "instant_power": 595,
+        "unit": "W",
+        "energy_unit": "Wh",
+        "last_24h_avg": 5813270,
+        "last_month_avg": 5813270,
+    }
+
+
+@pytest.fixture
 def timer_data_minimal():
     """Mock data for a timer without stop/active fields (v3.0.1 format)."""
     return {

--- a/tests/aiocamedomotic/mocked_responses.py
+++ b/tests/aiocamedomotic/mocked_responses.py
@@ -694,3 +694,25 @@ GENERIC_REPLY = {
     "cmd_name": "generic_reply",
     "sl_data_ack_reason": 0,
 }
+
+# Push update received after the measured power changed (real traffic,
+# swver 3.0.1): one meter_instant_power_ind per meter, full meter snapshot.
+METER_INSTANT_POWER_IND_STATUS_UPDATE_RESP = {
+    "cmd_name": "status_update_resp",
+    "cseq": 42,
+    "sl_data_ack_reason": 0,
+    "result": [
+        {
+            "name": "S1 + S2 + S3",
+            "id": 3,
+            "meter_type": 1,
+            "produced": 0,
+            "instant_power": 636,
+            "unit": "W",
+            "energy_unit": "Wh",
+            "last_24h_avg": 7788947,
+            "last_month_avg": 7788947,
+            "cmd_name": "meter_instant_power_ind",
+        }
+    ],
+}

--- a/tests/aiocamedomotic/test_energy_meter.py
+++ b/tests/aiocamedomotic/test_energy_meter.py
@@ -1,0 +1,133 @@
+# Copyright 2024 - GitHub user: fredericks1982
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+
+from unittest.mock import patch
+
+import pytest
+
+from aiocamedomotic import Auth, CameDomoticAPI
+from aiocamedomotic.models import EnergyMeter, EnergyMeterType
+from tests.aiocamedomotic.mocked_responses import METERS_LIST_RESP
+
+
+class TestEnergyMeter:
+    def test_properties(self, energy_meter_data):
+        meter = EnergyMeter(energy_meter_data)
+        assert meter.id == 4
+        assert meter.name == "Consumed Energy"
+        assert meter.meter_type == EnergyMeterType.POWER
+        assert meter.instant_power == 595
+        assert meter.unit == "W"
+        assert meter.energy_unit == "Wh"
+        assert meter.produced == 0
+        assert meter.last_24h_avg == 5813270
+        assert meter.last_month_avg == 5813270
+
+    def test_defaults_for_optional_fields(self):
+        meter = EnergyMeter({"name": "Minimal Meter", "id": 1})
+        assert meter.instant_power == 0
+        assert meter.unit == "W"
+        assert meter.energy_unit == "Wh"
+        assert meter.produced == 0
+        assert meter.last_24h_avg == 0
+        assert meter.last_month_avg == 0
+
+    def test_meter_type_unknown_value(self, energy_meter_data):
+        energy_meter_data["meter_type"] = 99
+        meter = EnergyMeter(energy_meter_data)
+        assert meter.meter_type == EnergyMeterType.UNKNOWN
+
+    def test_meter_type_missing(self):
+        meter = EnergyMeter({"name": "Meter", "id": 1})
+        assert meter.meter_type == EnergyMeterType.UNKNOWN
+
+    def test_missing_name(self):
+        with pytest.raises(ValueError, match="Data is missing required keys: name"):
+            EnergyMeter({"id": 4})
+
+    def test_missing_id(self):
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            EnergyMeter({"name": "Meter"})
+
+    def test_invalid_id_type(self):
+        with pytest.raises(ValueError):
+            EnergyMeter({"name": "Meter", "id": "not-an-int"})
+
+
+class TestAPIEnergyMeters:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_energy_meters(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = METERS_LIST_RESP
+
+        meters = await api.async_get_energy_meters()
+
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "meters_list_req"},
+            response_command="meters_list_resp",
+        )
+        assert len(meters) == 2
+        assert all(isinstance(m, EnergyMeter) for m in meters)
+        assert meters[0].id == 1
+        assert meters[0].name == "Meter 1"
+        assert meters[0].instant_power == 144
+        assert meters[1].id == 2
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_energy_meters_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "meters_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        meters = await api.async_get_energy_meters()
+        assert meters == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_energy_meters_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "meters_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        meters = await api.async_get_energy_meters()
+        assert meters == []
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_energy_meters_null_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": None,
+            "cmd_name": "meters_list_resp",
+            "cseq": 1,
+            "sl_data_ack_reason": 0,
+        }
+
+        meters = await api.async_get_energy_meters()
+        assert meters == []

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -42,6 +42,8 @@ from aiocamedomotic.models import (
     DigitalInputStatus,
     DigitalInputType,
     DigitalInputUpdate,
+    EnergyMeterType,
+    EnergyMeterUpdate,
     Floor,
     Light,
     LightStatus,
@@ -73,7 +75,10 @@ from aiocamedomotic.models import (
     get_update_device_type,
     parse_update,
 )
-from tests.aiocamedomotic.mocked_responses import STATUS_UPDATE_RESP
+from tests.aiocamedomotic.mocked_responses import (
+    METER_INSTANT_POWER_IND_STATUS_UPDATE_RESP,
+    STATUS_UPDATE_RESP,
+)
 
 
 class TestDeviceType:
@@ -3015,3 +3020,64 @@ class TestTimerUpdate:
         assert update.days == 0
         assert update.bars == 0
         assert update.timetable == []
+
+
+class TestEnergyMeterUpdate:
+    def test_parse_meter_instant_power_ind(self):
+        """Real traffic: push received after the measured power changed."""
+        raw = METER_INSTANT_POWER_IND_STATUS_UPDATE_RESP["result"][0]
+        update = parse_update(raw)
+        assert isinstance(update, EnergyMeterUpdate)
+        assert update.id == 3
+        assert update.name == "S1 + S2 + S3"
+        assert update.meter_type == EnergyMeterType.POWER
+        assert update.instant_power == 636
+        assert update.unit == "W"
+        assert update.energy_unit == "Wh"
+        assert update.produced == 0
+        assert update.last_24h_avg == 7788947
+        assert update.last_month_avg == 7788947
+
+    def test_device_id_is_raw_id(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3}
+        update = parse_update(raw)
+        assert isinstance(update, EnergyMeterUpdate)
+        assert update.device_id == 3
+
+    def test_device_type(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3}
+        assert get_update_device_type(raw) == DeviceType.ENERGY_SENSOR
+
+    def test_update_indicator(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3}
+        update = parse_update(raw)
+        assert update.update_indicator == UpdateIndicator.ENERGY_METER
+
+    def test_meter_type_unknown_value(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3, "meter_type": 99}
+        update = parse_update(raw)
+        assert isinstance(update, EnergyMeterUpdate)
+        assert update.meter_type == EnergyMeterType.UNKNOWN
+
+    def test_meter_type_missing(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3}
+        update = parse_update(raw)
+        assert isinstance(update, EnergyMeterUpdate)
+        assert update.meter_type == EnergyMeterType.UNKNOWN
+
+    def test_defaults_when_fields_missing(self):
+        raw = {"cmd_name": "meter_instant_power_ind", "id": 3}
+        update = parse_update(raw)
+        assert isinstance(update, EnergyMeterUpdate)
+        assert update.instant_power == 0
+        assert update.unit == "W"
+        assert update.energy_unit == "Wh"
+        assert update.produced == 0
+        assert update.last_24h_avg == 0
+        assert update.last_month_avg == 0
+
+    def test_get_typed_by_device_type(self):
+        updates = UpdateList(METER_INSTANT_POWER_IND_STATUS_UPDATE_RESP["result"])
+        typed = updates.get_typed_by_device_type(DeviceType.ENERGY_SENSOR)
+        assert len(typed) == 1
+        assert isinstance(typed[0], EnergyMeterUpdate)


### PR DESCRIPTION
## Summary

Adds read-only support for the CAME **energy meters** (`energy` feature):

- New model `EnergyMeter` with `EnergyMeterType` enum (`POWER`, `UNKNOWN` fallback logged with a warning on unrecognized values).
- New API method `CameDomoticAPI.async_get_energy_meters()`.
- New typed update `EnergyMeterUpdate` for `meter_instant_power_ind` push indications, registered in the update parsing machinery.
- Documentation: new "Energy meters" subsection and "Energy meter updates" monitoring subsection in the usage examples; all public properties/methods covered by examples.

## Protocol reference (from real captured traffic, ETI/Domo swver 3.0.1, board 3)

- `meters_list_req` → `meters_list_resp`: returns an `array` of meters, each with `name`, `id`, `meter_type` (1 = power meter, only value observed), `produced` (0 observed on consumption meters), `instant_power`, `unit` ("W"), `energy_unit` ("Wh"), `last_24h_avg`, `last_month_avg`. The command is plant-level: no `topologic_scope` is sent.
- Energy meters have **no `act_id`, floor, or room** — `id` is the identifier and the matching key for push updates.
- `meter_instant_power_ind` is pushed inside `status_update_resp.result[]` when the measured power changes. The payload is a full meter snapshot with refreshed values.
- `last_24h_avg` / `last_month_avg` are exposed as raw pass-through fields, expressed in `energy_unit`, with no assumptions made about their semantics.
- No unit conversion is applied: power/energy values pass through as reported by the server.

## Tests

- New `tests/aiocamedomotic/test_energy_meter.py`: model properties, defaults for optional fields, `meter_type` UNKNOWN fallback (unknown value and missing key), `ValueError` on missing `name`/`id` and non-int `id`, API happy path with exact request payload assertion, empty/missing/null `array` handling.
- `TestEnergyMeterUpdate` in `test_models.py`: parsing of the real captured push payload, `device_id` → raw `id`, device type/indicator mapping, enum fallbacks, defaults, `get_typed_by_device_type` filtering.
- New reference push payload appended verbatim to `mocked_responses.py`; existing entries untouched.
- Full suite: 612 passed, coverage 100%.

## Checks

- `ruff format` / `ruff check`: clean
- `pylint aiocamedomotic tests`: 9.74/10 (improved vs. baseline)
- `mypy aiocamedomotic`: no issues
- `pytest --cov=aiocamedomotic`: 612 passed, 100% coverage
- `sphinx -b html`: build succeeded, no warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only energy meter support with new energy meter models and typed update handling for live instantaneous power.
  * You can now fetch energy meters via the API and access identity, meter type, instant power, units, produced energy, and rolling averages.

* **Documentation**
  * Updated usage examples to treat energy meters as a first-class feature, including fetching meters and handling real-time updates.

* **Tests**
  * Added unit tests for energy meter model parsing, defaults and unknown types, empty/missing responses, and update parsing for instant power indications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
