### PR TITLE
docs: update LLM documentation files

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -287,7 +287,8 @@ from aiocamedomotic.models import (
     ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
     Timer, TimerTimeSlot, TimerUpdate,
     DeviceUpdate, LightUpdate, OpeningUpdate, RelayUpdate,
-    ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate, PlantUpdate,
+    ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate,
+    EnergyMeterUpdate, PlantUpdate,
 )
 from aiocamedomotic.errors import (
     CameDomoticError,
@@ -479,6 +480,9 @@ if ServerFeature.ANALOGIN in server_info.features:
 
 if ServerFeature.TIMERS in server_info.features:
     timers = await api.async_get_timers()
+
+if ServerFeature.ENERGY in server_info.features:
+    meters = await api.async_get_energy_meters()
 ```
 
 #### Floors and rooms
@@ -1113,6 +1117,56 @@ async def main():
 asyncio.run(main())
 ```
 
+#### Energy meters
+
+Energy meters are read-only sensors exposed via the `energy` feature. They
+report the instantaneous power measured on a line (e.g. the whole-home
+consumption) together with energy values. Unlike lights or
+openings, energy meters are **plant-level entities keyed by** `id`: they
+have no `act_id` and no floor/room placement. The number of meters and
+their names are entirely plant-specific — always discover them via the API.
+
+**Fetching and inspecting energy meters:**
+
+```python
+meters = await api.async_get_energy_meters()
+
+for meter in meters:
+    print(f"ID: {meter.id}, Name: {meter.name}, "
+          f"Power: {meter.instant_power} {meter.unit}")
+```
+
+Example output:
+
+```text
+ID: 4, Name: Consumed Energy, Power: 595 W
+ID: 3, Name: Line 1 + Line 2, Power: 595 W
+```
+
+**Finding a specific energy meter:**
+
+```python
+# By ID
+main_meter = next((m for m in meters if m.id == 4), None)
+
+# By name
+consumption = next((m for m in meters if m.name == "Consumed Energy"), None)
+```
+
+**Reading the energy values:**
+
+Each meter also exposes the raw `last_24h_avg` and `last_month_avg`
+fields, expressed in `energy_unit` (typically `Wh`):
+
+```python
+if main_meter:
+    print(f"last_24h_avg: {main_meter.last_24h_avg} {main_meter.energy_unit}")
+    print(f"last_month_avg: {main_meter.last_month_avg} {main_meter.energy_unit}")
+```
+
+Real-time power readings are delivered as push updates — see
+[Energy meter updates](#energy-meter-updates) in the monitoring section below.
+
 ### Monitoring real-time updates
 
 The CAME Domotic server supports **long polling** for real-time status updates.
@@ -1240,6 +1294,9 @@ for update in updates.get_typed_updates():
             f"days={update.days}, slots={len(update.timetable)}"
         )
 
+    elif isinstance(update, EnergyMeterUpdate):
+        print(f"Meter '{update.name}': {update.instant_power} {update.unit}")
+
     elif isinstance(update, PlantUpdate):
         print("Plant configuration changed, re-fetching devices...")
 ```
@@ -1334,6 +1391,43 @@ without needing to merge changes.
 The `timer_info_ind` indication name was confirmed from real server
 traffic (firmware 3.0.1). A legacy variant `timer_update_ind` is also
 handled for firmware compatibility.
+
+#### Energy meter updates
+
+When the power measured by an energy meter changes, the server pushes a
+`meter_instant_power_ind` indication — one per meter, each containing a
+**complete snapshot** of the meter state (the same fields as the meter list
+response), with the energy values refreshed in the same push. The library
+parses it into an [`EnergyMeterUpdate`](#aiocamedomotic.models.EnergyMeterUpdate)
+object whose `device_id` is the meter’s `id`.
+
+This is the recommended way to track power consumption in real time,
+instead of repeatedly calling `async_get_energy_meters()`:
+
+```python
+while True:
+    try:
+        updates = await api.async_get_updates(timeout=120)
+    except CameDomoticServerTimeoutError:
+        continue
+
+    for update in updates.get_typed_updates():
+        if isinstance(update, EnergyMeterUpdate):
+            print(
+                f"Meter '{update.name}' (ID: {update.device_id}): "
+                f"{update.instant_power} {update.unit}, "
+                f"last_24h_avg={update.last_24h_avg} {update.energy_unit}"
+            )
+
+    await asyncio.sleep(1)
+```
+
+Example output:
+
+```text
+Meter 'Line 1 + Line 2' (ID: 3): 636 W, last_24h_avg=7788947 Wh
+Meter 'Consumed Energy' (ID: 4): 636 W, last_24h_avg=5813290 Wh
+```
 
 ### Advanced topics
 
@@ -1571,6 +1665,25 @@ contact sensors). They report their state but cannot be controlled.
   List of digital inputs.
 * **Return type:**
   list[[DigitalInput](#aiocamedomotic.models.DigitalInput)]
+* **Raises:**
+  * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
+  * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
+
+##### *async* async_get_energy_meters() → list[[EnergyMeter](#aiocamedomotic.models.EnergyMeter)]
+
+Get the list of all energy meters defined on the server.
+
+Energy meters are read-only, plant-level entities exposed via the
+`energy` feature. They report the instantaneous power measured on
+a line and energy values, and have no floor/room
+placement.
+
+* **Returns:**
+  List of energy meters. Returns an empty list
+  if none are defined or the server response lacks the `array`
+  key.
+* **Return type:**
+  list[[EnergyMeter](#aiocamedomotic.models.EnergyMeter)]
 * **Raises:**
   * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
   * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
@@ -2155,6 +2268,132 @@ Digital input status value.
 ##### *property* utc_time *: int*
 
 UTC timestamp of the digital input event.
+
+#### *class* aiocamedomotic.models.EnergyMeter(raw_data: dict[str, Any])
+
+Read-only energy meter from the `meters_list_resp` endpoint.
+
+Represents an energy meter exposed via the `energy` feature. Energy
+meters are plant-level entities keyed by [`id`](#aiocamedomotic.models.EnergyMeter.id) (they have no
+`act_id`, floor, or room). They report the current power reading and
+energy values, and cannot be controlled.
+
+* **Parameters:**
+  **raw_data** – Dictionary containing the meter data from the API.
+* **Raises:**
+  **ValueError** – If `name` or `id` keys are missing from the input
+      data, or if `id` is not an integer.
+
+##### *property* energy_unit *: str*
+
+Unit of measurement (`'Wh'` observed) for the
+[`last_24h_avg`](#aiocamedomotic.models.EnergyMeter.last_24h_avg) and [`last_month_avg`](#aiocamedomotic.models.EnergyMeter.last_month_avg) values.
+
+##### *property* id *: int*
+
+Unique meter identifier.
+
+This is also the matching key for `meter_instant_power_ind`
+push updates (energy meters have no `act_id`).
+
+##### *property* instant_power *: int*
+
+Current power reading, in the unit reported by [`unit`](#aiocamedomotic.models.EnergyMeter.unit).
+
+The value is passed through exactly as reported by the server
+(no unit conversion is applied).
+
+##### *property* last_24h_avg *: int*
+
+Raw `last_24h_avg` field from the server, in [`energy_unit`](#aiocamedomotic.models.EnergyMeter.energy_unit).
+
+The value is passed through exactly as reported by the server.
+
+##### *property* last_month_avg *: int*
+
+Raw `last_month_avg` field from the server, in [`energy_unit`](#aiocamedomotic.models.EnergyMeter.energy_unit).
+
+The value is passed through exactly as reported by the server.
+
+##### *property* meter_type *: [EnergyMeterType](#aiocamedomotic.models.EnergyMeterType)*
+
+Type of the meter (POWER is the only value observed so far).
+
+##### *property* name *: str*
+
+Display name of the meter.
+
+##### *property* produced *: int*
+
+Raw `produced` field from the server.
+
+`0` observed on consumption meters; semantics for production
+meters are unverified.
+
+##### *property* unit *: str*
+
+Unit of measurement for [`instant_power`](#aiocamedomotic.models.EnergyMeter.instant_power) (`'W'` observed).
+
+#### *class* aiocamedomotic.models.EnergyMeterType(\*values)
+
+Type of an energy meter, as reported in the `meter_type` field.
+
+Allowed values are:
+: - POWER (1): Power meter (the only value observed on real servers).
+  - UNKNOWN (-1): Returned when the server reports an unrecognised
+    `meter_type` value.
+
+#### *class* aiocamedomotic.models.EnergyMeterUpdate(raw_data: dict[str, Any])
+
+Typed update for an energy meter (`meter_instant_power_ind`).
+
+Pushed by the server when the power measured by a meter changes. The
+payload is a complete snapshot of the meter state (same shape as a
+`meters_list_resp` item), including refreshed energy values.
+
+##### *property* device_id *: int | None*
+
+For energy meters the primary ID is `id`.
+
+##### *property* energy_unit *: str*
+
+Unit of measurement (`'Wh'` observed) for the
+[`last_24h_avg`](#aiocamedomotic.models.EnergyMeterUpdate.last_24h_avg) and [`last_month_avg`](#aiocamedomotic.models.EnergyMeterUpdate.last_month_avg) values.
+
+##### *property* id *: int*
+
+Meter identifier (energy meters have no `act_id`).
+
+##### *property* instant_power *: int*
+
+Current power reading, in the unit reported by [`unit`](#aiocamedomotic.models.EnergyMeterUpdate.unit).
+
+The value is passed through exactly as reported by the server
+(no unit conversion is applied).
+
+##### *property* last_24h_avg *: int*
+
+Raw `last_24h_avg` field, in [`energy_unit`](#aiocamedomotic.models.EnergyMeterUpdate.energy_unit).
+
+The value is passed through exactly as reported by the server.
+
+##### *property* last_month_avg *: int*
+
+Raw `last_month_avg` field, in [`energy_unit`](#aiocamedomotic.models.EnergyMeterUpdate.energy_unit).
+
+The value is passed through exactly as reported by the server.
+
+##### *property* meter_type *: [EnergyMeterType](#aiocamedomotic.models.EnergyMeterType)*
+
+Type of the meter (POWER is the only value observed so far).
+
+##### *property* produced *: int*
+
+Raw `produced` field (`0` observed on consumption meters).
+
+##### *property* unit *: str*
+
+Unit of measurement for [`instant_power`](#aiocamedomotic.models.EnergyMeterUpdate.instant_power) (`'W'` observed).
 
 #### *class* aiocamedomotic.models.Floor(raw_data: dict[str, Any])
 


### PR DESCRIPTION
Automated update of `llms.txt` and `llms-full.txt` triggered by changes
to source code or documentation.

These files are auto-generated by `scripts/build_llms_docs.py` from the
Sphinx documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete energy meter usage guidance to the quick start, monitoring, API, and entity model docs.
  * Documented how to list and look up energy meters, read power and energy values, and handle live updates.
  * Included examples showing energy meter-specific update handling and the new API call for retrieving meters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->