### PR TITLE
feat: add typed weekly profile models (loadsctrl + thermo value types)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,9 @@ insights. We look forward to growing this library together with our users and co
   Switch between seasons (WINTER, SUMMER, PLANT_OFF) plant-wide via `thermo_season_req`.
   Expose fan speed, dehumidifier state (enabled/setpoint), and auxiliary temperature
   sensors (t1, t2, t3) on `ThermoZone` and `ThermoZoneUpdate`. Top-level analog sensor
-  readings (temperature, humidity, pressure) are also exposed.
+  readings (temperature, humidity, pressure) are also exposed. Each zone's weekly
+  setpoint schedule (8 rows: Monday–Sunday plus the JOLLY profile, quarter-hour wire
+  resolution) is exposed **read-only** as a typed, immutable `ThermoProfile` object.
 - **Timers management**: List timers with their timetables via `timers_list_req`;
   enable/disable timers, toggle individual days, and set timetables via
   `timers_enable_req`, `timers_enable_day_req`, and `timers_set_req`.
@@ -37,7 +39,10 @@ insights. We look forward to growing this library together with our users and co
   loads, change their detach priorities (including bulk reordering), and configure the
   controller's power threshold and hysteresis (`loadsctrl_relay_set_req`,
   `loadsctrl_meter_set_req`); real-time state via `loadsctrl_meter_ind` and
-  `loadsctrl_relay_ind`.
+  `loadsctrl_relay_ind`. The controller's weekly threshold profile (`profile_data`:
+  7 days × 24 hourly levels, each level 1–5 selecting the active threshold as a
+  fraction of `max_power`) can be read, edited, and written back through the typed,
+  immutable `LoadsCtrlProfile` API (verified against a real plant).
 - **Generic relays**: List and control simple on/off relay actuators via
   `relays_list_req` and `relay_activation_req` (documented API, not yet verified against
   a real server).
@@ -78,19 +83,13 @@ under [Future considerations](#future-considerations).
   (`energy_stat_req`, with instant/day/week/month scopes) for monitoring and dashboard
   integration.
 
-### Version 1.14 — Load control threshold profiles
+### Version 1.14 — Thermostat profile writing
 
-- **Weekly hourly profiles**: Parse and edit the load controller's weekly threshold
-  profile (`profile_data`: 7 days × 24 hourly levels, each level 1–5 selecting the
-  active threshold as a fraction of `max_power`) through a validated, immutable
-  profile API, once the exact level-to-threshold mapping is confirmed on a real plant.
-
-### Version 1.15 — Thermostat hourly profiles
-
-- **Weekly schedules**: Parse and edit the thermostat zones' hourly schedule profiles
-  via `thermo_zone_config_req` (`profile_id` / `profile_data` fields), enabling
-  AUTO-mode weekly programming from the library, once the profile wire format is
-  verified against a real plant.
+- **Weekly schedule editing**: Write the thermostat zones' weekly setpoint profiles
+  back to the server, enabling AUTO-mode weekly programming from the library. Reading
+  and editing are already supported through the typed `ThermoProfile` API; writing is
+  blocked on capturing the profile set command from the official app, which has not
+  been observed in real traffic yet.
 
 ## Future considerations
 

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -332,6 +332,7 @@ class CameDomoticAPI:
         payload = {
             "cmd_name": _CommandName.THERMO_LIST.value,
             "topologic_scope": _TopologicScope.PLANT.value,
+            "extended_infos": 2,
         }
 
         json_response = await self.auth.async_send_command(

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -36,6 +36,14 @@ from .loads_ctrl import (  # noqa: F401
 )
 from .map_page import MapPage  # noqa: F401
 from .opening import Opening, OpeningStatus, OpeningType  # noqa: F401
+from .profiles import (  # noqa: F401
+    WEEKDAYS,
+    LoadsCtrlProfile,
+    ProfileDay,
+    ProfileSpan,
+    ThermoProfile,
+    WeeklyProfile,
+)
 from .relay import Relay, RelayStatus  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
 from .thermo_zone import (  # noqa: F401
@@ -90,6 +98,7 @@ __all__ = [
     "LightUpdate",
     "LoadsCtrlMeter",
     "LoadsCtrlMeterUpdate",
+    "LoadsCtrlProfile",
     "LoadsCtrlRelay",
     "LoadsCtrlRelayStatus",
     "LoadsCtrlRelayUpdate",
@@ -100,6 +109,8 @@ __all__ = [
     "OpeningUpdate",
     "PlantTopology",
     "PlantUpdate",
+    "ProfileDay",
+    "ProfileSpan",
     "Relay",
     "RelayStatus",
     "RelayUpdate",
@@ -110,6 +121,7 @@ __all__ = [
     "ServerFeature",
     "ServerInfo",
     "TerminalGroup",
+    "ThermoProfile",
     "ThermoZone",
     "ThermoZoneFanSpeed",
     "ThermoZoneMode",
@@ -124,6 +136,8 @@ __all__ = [
     "UpdateIndicator",
     "UpdateList",
     "User",
+    "WEEKDAYS",
+    "WeeklyProfile",
     "get_update_device_type",
     "parse_update",
 ]

--- a/aiocamedomotic/models/loads_ctrl.py
+++ b/aiocamedomotic/models/loads_ctrl.py
@@ -46,6 +46,7 @@ from ..utils import (
     EntityValidator,
 )
 from .base import CameEntity
+from .profiles import LoadsCtrlProfile
 
 
 class LoadsCtrlRelayStatus(Enum):
@@ -332,13 +333,27 @@ class LoadsCtrlMeter(CameEntity):
         Seven strings — one per weekday, Monday first — of 24 characters
         each (one per hour of day). Each character is a digit ``1``-``5``
         selecting the power threshold active in that hour as a fraction of
-        :attr:`max_power`. The library exposes the raw value only; profile
-        editing is not yet a library feature.
+        :attr:`max_power`. For a typed view use :attr:`profile`.
 
         Returns a copy: mutating the returned list does not affect
         ``raw_data``.
         """
         return list(self.raw_data.get("profile_data", []))
+
+    @property
+    def profile(self) -> LoadsCtrlProfile:
+        """Weekly hourly threshold profile (typed view).
+
+        Parsed fresh from ``raw_data`` on every access (never cached), so
+        it always reflects the latest known server state. Edit it with the
+        :class:`LoadsCtrlProfile` methods and write it back via
+        :meth:`async_set_config`.
+
+        Raises:
+            ValueError: If ``raw_data`` lacks a well-formed
+                ``profile_data`` value.
+        """
+        return LoadsCtrlProfile.from_wire(self.raw_data.get("profile_data", []))
 
     async def async_get_relays(self) -> list[LoadsCtrlRelay]:
         """Get the loads managed by this controller.
@@ -378,7 +393,7 @@ class LoadsCtrlMeter(CameEntity):
         *,
         max_power: int | None = None,
         hysteresis: int | None = None,
-        profile_data: list[str] | None = None,
+        profile_data: LoadsCtrlProfile | None = None,
     ) -> None:
         """Update the controller configuration.
 
@@ -392,17 +407,15 @@ class LoadsCtrlMeter(CameEntity):
             hysteresis: New hysteresis in Watts (non-negative integer; ``0``
                 disables the hysteresis band), or ``None`` to keep the
                 current value.
-            profile_data: New weekly hourly threshold profile in raw wire
-                format — exactly 7 strings of exactly 24 characters, each
-                character a digit ``1``-``5`` — or ``None`` to keep the
-                current value. This parameter exists mainly for the
-                mandatory wire round-trip: an ergonomic profile-editing API
-                is not yet available.
+            profile_data: New weekly hourly threshold profile as a
+                :class:`LoadsCtrlProfile` (typically obtained from
+                :attr:`profile` and edited), or ``None`` to keep the
+                current value.
 
         Raises:
             ValueError: If ``max_power`` is not a positive integer, if
                 ``hysteresis`` is not a non-negative integer, or if
-                ``profile_data`` does not match the required shape.
+                ``profile_data`` is not a ``LoadsCtrlProfile``.
             CameDomoticAuthError: If the authentication fails.
             CameDomoticServerError: If the server returns an error.
         """
@@ -420,15 +433,18 @@ class LoadsCtrlMeter(CameEntity):
             raise ValueError(
                 f"hysteresis must be a non-negative int, got {hysteresis!r}"
             )
-        if profile_data is not None:
-            self._validate_profile_data(profile_data)
+        if profile_data is not None and not isinstance(profile_data, LoadsCtrlProfile):
+            raise ValueError(
+                "profile_data must be a LoadsCtrlProfile, "
+                f"got {type(profile_data).__name__}"
+            )
 
         # The wire command requires the full triple: source untouched
         # values from raw_data.
         new_max_power = max_power if max_power is not None else self.max_power
         new_hysteresis = hysteresis if hysteresis is not None else self.hysteresis
         new_profile = (
-            list(profile_data) if profile_data is not None else self.profile_data
+            profile_data.to_wire() if profile_data is not None else self.profile_data
         )
 
         LOGGER.debug(
@@ -553,26 +569,3 @@ class LoadsCtrlMeter(CameEntity):
             self.id,
             changed,
         )
-
-    @staticmethod
-    def _validate_profile_data(profile_data: list[str]) -> None:
-        """Validate the raw weekly profile shape (7 x 24 digits in 1-5).
-
-        A malformed profile would be written to the controller, so the
-        shape is checked strictly before sending.
-        """
-        if not isinstance(profile_data, list) or len(profile_data) != 7:
-            raise ValueError(
-                "profile_data must be a list of exactly 7 strings "
-                "(one per weekday, Monday first)"
-            )
-        for index, day in enumerate(profile_data):
-            if not isinstance(day, str) or len(day) != 24:
-                raise ValueError(
-                    f"profile_data[{index}] must be a string of exactly 24 "
-                    "characters (one per hour of day)"
-                )
-            if any(char not in "12345" for char in day):
-                raise ValueError(
-                    f"profile_data[{index}] must contain only digits in the range 1-5"
-                )

--- a/aiocamedomotic/models/profiles.py
+++ b/aiocamedomotic/models/profiles.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CAME Domotic weekly schedule profiles ("profile_data").
+
+CAME transmits weekly schedules as arrays of digit strings — one string per
+day, one character per time slot, each character a digit ``1``-``5``
+selecting one of the five levels shown in the official app. Two features use
+this pattern (both confirmed by captured traffic, ETI/Domo swver 3.0.1):
+
+- **loadsctrl** (:class:`LoadsCtrlProfile`): 7 strings of 24 characters
+  (Monday..Sunday, one slot per hour).
+- **thermo** (:class:`ThermoProfile`): 8 strings of 96 characters
+  (Monday..Sunday plus the **JOLLY** profile as the 8th row, one slot per
+  quarter hour).
+
+Although the thermo wire format has 15-minute slots, the official app edits
+profiles **per hour** for both features, always writing four identical
+quarters per hour. This library follows the same contract: the public API
+speaks in hours only (edit spans are whole hours), while the wire resolution
+is preserved internally so that ``from_wire(x).to_wire() == x`` holds
+byte-for-byte for any server-provided value.
+
+Profiles are immutable value objects: editing methods return a new instance
+and never modify the original, so the only way changes reach the server is
+an explicit set command carrying ``to_wire()``. Captured traffic shows that
+profile reads and writes always carry the **full week**; a profile object
+cannot represent less than the full grid, so partial sends are impossible
+by construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, time
+from enum import IntEnum
+from typing import Any, ClassVar, Self
+
+from ..utils import LOGGER
+
+
+class ProfileDay(IntEnum):
+    """A row of a weekly profile grid.
+
+    ``MONDAY``..``SUNDAY`` are ``0``..``6``, matching both the wire row
+    order (Monday first) and :meth:`datetime.date.weekday`, so
+    ``ProfileDay(some_date.weekday())`` is always correct.
+
+    ``JOLLY`` (``7``) is the special thermo profile used while a thermo zone
+    is in JOLLY mode; it is the 8th wire row of thermo profiles and is not a
+    valid day for loadsctrl profiles.
+    """
+
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+    JOLLY = 7
+
+
+WEEKDAYS: tuple[ProfileDay, ...] = (
+    ProfileDay.MONDAY,
+    ProfileDay.TUESDAY,
+    ProfileDay.WEDNESDAY,
+    ProfileDay.THURSDAY,
+    ProfileDay.FRIDAY,
+    ProfileDay.SATURDAY,
+    ProfileDay.SUNDAY,
+)
+"""The seven real weekdays (Monday..Sunday), excluding :attr:`ProfileDay.JOLLY`.
+
+Convenience for editing methods on thermo profiles, where an omitted
+``days`` argument targets every row including JOLLY.
+"""
+
+
+@dataclass(frozen=True)
+class ProfileSpan:
+    """A run of consecutive slots sharing the same level (read-only view).
+
+    Produced by :meth:`WeeklyProfile.spans`. The range is half-open:
+    ``start`` is inclusive, ``end`` is exclusive; an ``end`` of ``time(0)``
+    means "through midnight" (end of day).
+    """
+
+    start: time
+    end: time
+    level: int
+
+
+class WeeklyProfile:
+    """Immutable weekly schedule grid (abstract base).
+
+    Concrete subclasses (:class:`LoadsCtrlProfile`, :class:`ThermoProfile`)
+    define the grid shape via :attr:`DAYS` and :attr:`WIRE_SLOTS_PER_DAY`;
+    all parsing, reading, and editing logic lives here.
+
+    Instances are immutable value objects: editing methods
+    (:meth:`with_level`, :meth:`with_day_copied`) return a **new** instance,
+    and equality/hashing are by value (two profiles of the same class with
+    the same grid are equal). Construct instances via :meth:`from_wire` or
+    :meth:`constant`.
+
+    The public API speaks in **hours** (the official app edits per hour);
+    the internal grid keeps the wire resolution, so serializing an unedited
+    profile reproduces the server bytes exactly.
+    """
+
+    # ClassVar annotations are class attributes, not instance slots, but
+    # pylint's declare-non-slot check flags them in slotted classes.
+    DAYS: ClassVar[tuple[ProfileDay, ...]]  # pylint: disable=declare-non-slot
+    """The rows of the grid, in wire order."""
+
+    WIRE_SLOTS_PER_DAY: ClassVar[int]  # pylint: disable=declare-non-slot
+    """Number of wire slots per day row (a multiple of 24)."""
+
+    LEVELS: ClassVar[frozenset[int]] = frozenset({1, 2, 3, 4, 5})
+    """Allowed level values (the five levels shown in the official app)."""
+
+    __slots__ = ("_rows",)
+
+    _rows: tuple[tuple[int, ...], ...]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        days = getattr(cls, "DAYS", None)
+        slots = getattr(cls, "WIRE_SLOTS_PER_DAY", None)
+        if not days:
+            raise TypeError(f"{cls.__name__} must define a non-empty DAYS tuple")
+        if not isinstance(slots, int) or slots <= 0 or slots % 24 != 0:
+            raise TypeError(
+                f"{cls.__name__}.WIRE_SLOTS_PER_DAY must be a positive multiple "
+                f"of 24, got {slots!r}"
+            )
+
+    def __init__(self, rows: Sequence[Sequence[int]]) -> None:
+        """Create a profile from a grid of levels (one row per day).
+
+        Args:
+            rows: Exactly ``len(DAYS)`` rows of exactly
+                ``WIRE_SLOTS_PER_DAY`` integers, each in :attr:`LEVELS`.
+
+        Raises:
+            TypeError: If called on the abstract ``WeeklyProfile`` class.
+            ValueError: If the grid shape or any level value is invalid.
+        """
+        cls = type(self)
+        if cls is WeeklyProfile:
+            raise TypeError(
+                "WeeklyProfile is an abstract base: instantiate "
+                "LoadsCtrlProfile or ThermoProfile instead"
+            )
+        if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence):
+            raise ValueError(
+                f"rows must be a sequence of exactly {len(cls.DAYS)} day rows"
+            )
+        if len(rows) != len(cls.DAYS):
+            raise ValueError(
+                f"rows must contain exactly {len(cls.DAYS)} day rows, got {len(rows)}"
+            )
+        frozen_rows: list[tuple[int, ...]] = []
+        for index, row in enumerate(rows):
+            if isinstance(row, (str, bytes)) or not isinstance(row, Sequence):
+                raise ValueError(
+                    f"rows[{index}] must be a sequence of exactly "
+                    f"{cls.WIRE_SLOTS_PER_DAY} integer levels"
+                )
+            frozen_row = tuple(row)
+            if len(frozen_row) != cls.WIRE_SLOTS_PER_DAY:
+                raise ValueError(
+                    f"rows[{index}] must contain exactly "
+                    f"{cls.WIRE_SLOTS_PER_DAY} levels, got {len(frozen_row)}"
+                )
+            for value in frozen_row:
+                if (
+                    not isinstance(value, int)
+                    or isinstance(value, bool)
+                    or value not in cls.LEVELS
+                ):
+                    raise ValueError(
+                        f"rows[{index}] contains invalid level {value!r}: "
+                        f"allowed levels are {sorted(cls.LEVELS)}"
+                    )
+            frozen_rows.append(frozen_row)
+        self._rows = tuple(frozen_rows)
+
+    # region Wire boundary
+
+    @classmethod
+    def from_wire(cls, data: Sequence[str]) -> Self:
+        """Parse a profile from its raw wire format.
+
+        The wire format is a list of digit strings, one per row of
+        :attr:`DAYS` in order, each of exactly :attr:`WIRE_SLOTS_PER_DAY`
+        characters, each character a digit in :attr:`LEVELS`.
+
+        Guarantee: ``cls.from_wire(x).to_wire() == x`` byte-for-byte —
+        nothing is normalized or reinterpreted.
+
+        On profile types with sub-hour wire slots, a row whose hours are not
+        uniform (different levels within the same hour) is unexpected — the
+        official app edits per hour — so a warning is logged, but the data
+        is accepted and preserved exactly.
+
+        Args:
+            data: The raw profile rows, e.g. from a server response.
+
+        Raises:
+            TypeError: If called on the abstract ``WeeklyProfile`` class.
+            ValueError: If the shape or any character is invalid.
+        """
+        if cls is WeeklyProfile:
+            raise TypeError(
+                "WeeklyProfile is an abstract base: use "
+                "LoadsCtrlProfile.from_wire() or ThermoProfile.from_wire()"
+            )
+        if isinstance(data, (str, bytes)) or not isinstance(data, Sequence):
+            raise ValueError(
+                f"profile data must be a list of exactly {len(cls.DAYS)} "
+                "strings (one per day, Monday first)"
+            )
+        if len(data) != len(cls.DAYS):
+            raise ValueError(
+                f"profile data must contain exactly {len(cls.DAYS)} strings "
+                f"(one per day, Monday first), got {len(data)}"
+            )
+        allowed_chars = {str(level) for level in cls.LEVELS}
+        rows: list[tuple[int, ...]] = []
+        for index, day_str in enumerate(data):
+            if not isinstance(day_str, str) or len(day_str) != cls.WIRE_SLOTS_PER_DAY:
+                raise ValueError(
+                    f"profile data[{index}] must be a string of exactly "
+                    f"{cls.WIRE_SLOTS_PER_DAY} characters"
+                )
+            if any(char not in allowed_chars for char in day_str):
+                raise ValueError(
+                    f"profile data[{index}] must contain only digits in "
+                    f"{sorted(cls.LEVELS)}"
+                )
+            rows.append(tuple(int(char) for char in day_str))
+        profile = cls(rows)
+        slots_per_hour = cls._slots_per_hour()
+        if slots_per_hour > 1 and any(
+            len(set(row[hour * slots_per_hour : (hour + 1) * slots_per_hour])) > 1
+            for row in rows
+            for hour in range(24)
+        ):
+            LOGGER.warning(
+                "%s data contains different levels within the same hour; "
+                "this is unexpected (the official app edits profiles per "
+                "hour). The data is preserved as-is, but hour-based edits "
+                "overwrite whole hours. Please report this to the library "
+                "developers.",
+                cls.__name__,
+            )
+        return profile
+
+    def to_wire(self) -> list[str]:
+        """Serialize to the raw wire format (a fresh list of digit strings).
+
+        For a profile obtained via :meth:`from_wire` and not edited since,
+        this returns exactly the original input.
+        """
+        return ["".join(str(value) for value in row) for row in self._rows]
+
+    # endregion
+
+    # region Constructors
+
+    @classmethod
+    def constant(cls, level: int) -> Self:
+        """Create a profile with every slot of every row set to ``level``.
+
+        Raises:
+            TypeError: If called on the abstract ``WeeklyProfile`` class.
+            ValueError: If ``level`` is not in :attr:`LEVELS`.
+        """
+        if cls is WeeklyProfile:
+            raise TypeError(
+                "WeeklyProfile is an abstract base: use "
+                "LoadsCtrlProfile.constant() or ThermoProfile.constant()"
+            )
+        cls._validate_level(level)
+        return cls([[level] * cls.WIRE_SLOTS_PER_DAY for _ in cls.DAYS])
+
+    # endregion
+
+    # region Reading
+
+    def level_at(self, day: ProfileDay | int, at: time | datetime | int) -> int:
+        """Return the level active on ``day`` at the given moment.
+
+        Args:
+            day: The profile row to read (a :class:`ProfileDay` or its
+                integer value).
+            at: The moment of day: an ``int`` hour (0-23), a
+                :class:`datetime.time`, or a :class:`datetime.datetime`
+                (its time of day is used; the date is **not** used to pick
+                ``day``). Any time is accepted — it resolves to the
+                containing wire slot, so no hour alignment is required for
+                reads.
+
+        Raises:
+            ValueError: If ``day`` is not a row of this profile type or
+                ``at`` is not a valid moment of day.
+        """
+        row = self._rows[type(self).DAYS.index(self._validate_day(day))]
+        if isinstance(at, datetime):
+            at = at.time()
+        slots_per_hour = self._slots_per_hour()
+        if isinstance(at, int) and not isinstance(at, bool):
+            if not 0 <= at <= 23:
+                raise ValueError(f"at must be an hour in the range 0-23, got {at}")
+            return row[at * slots_per_hour]
+        if isinstance(at, time):
+            return row[at.hour * slots_per_hour + at.minute * slots_per_hour // 60]
+        raise ValueError(
+            f"at must be an int hour, a time, or a datetime, got {type(at).__name__}"
+        )
+
+    def spans(self, day: ProfileDay | int) -> list[ProfileSpan]:
+        """Return ``day``'s schedule as runs of consecutive equal levels.
+
+        Each :class:`ProfileSpan` is a half-open ``[start, end)`` range; the
+        last span's ``end`` is ``time(0)``, meaning "through midnight". For
+        app-written data the boundaries fall on whole hours.
+
+        Raises:
+            ValueError: If ``day`` is not a row of this profile type.
+        """
+        row = self._rows[type(self).DAYS.index(self._validate_day(day))]
+        result: list[ProfileSpan] = []
+        run_start = 0
+        for slot in range(1, len(row) + 1):
+            if slot == len(row) or row[slot] != row[run_start]:
+                result.append(
+                    ProfileSpan(
+                        start=self._slot_time(run_start),
+                        end=self._slot_time(slot),
+                        level=row[run_start],
+                    )
+                )
+                run_start = slot
+        return result
+
+    # endregion
+
+    # region Editing
+
+    def with_level(
+        self,
+        level: int,
+        *,
+        days: ProfileDay | int | Iterable[ProfileDay | int] | None = None,
+        start: time | int = 0,
+        end: time | int | None = None,
+    ) -> Self:
+        """Return a copy with ``[start, end)`` on ``days`` set to ``level``.
+
+        The original profile is not modified. The full week is always kept
+        (and later sent to the server) — this method only chooses which
+        cells of the copy get the new level.
+
+        Args:
+            level: The level to set (must be in :attr:`LEVELS`).
+            days: The rows to change: a single :class:`ProfileDay` (or its
+                integer value), an iterable of them, or ``None`` (the
+                default) for **every** row of this profile type — on thermo
+                profiles that includes :attr:`ProfileDay.JOLLY`; pass
+                :data:`WEEKDAYS` to target Monday..Sunday only.
+            start: Start hour, inclusive: an ``int`` (0-23) or a whole-hour
+                :class:`datetime.time`. Defaults to ``0`` (midnight).
+            end: End hour, exclusive: an ``int`` (1-24), a whole-hour
+                :class:`datetime.time` (``time(0)`` means end of day), or
+                ``None`` (the default) for end of day. Edits are hour-based,
+                so ``start``/``end`` must be whole hours (no rounding is
+                applied) and spans cannot cross midnight — split such an
+                edit into two calls.
+
+        Raises:
+            ValueError: If ``level``, ``days``, ``start``, or ``end`` are
+                invalid, or if ``start >= end``.
+        """
+        self._validate_level(level)
+        day_list = self._normalize_days(days)
+        start_hour = self._normalize_hour(start, name="start")
+        if end is None or (isinstance(end, time) and end == time(0)):
+            end_hour = 24
+        else:
+            end_hour = self._normalize_hour(end, name="end", maximum=24)
+        if start_hour >= end_hour:
+            raise ValueError(
+                f"start must be before end, got start={start_hour} and end={end_hour}"
+            )
+
+        slots_per_hour = self._slots_per_hour()
+        rows = [list(row) for row in self._rows]
+        for day in day_list:
+            row = rows[type(self).DAYS.index(day)]
+            for slot in range(start_hour * slots_per_hour, end_hour * slots_per_hour):
+                row[slot] = level
+        return type(self)(rows)
+
+    def with_day_copied(
+        self,
+        source: ProfileDay | int,
+        to: ProfileDay | int | Iterable[ProfileDay | int],
+    ) -> Self:
+        """Return a copy with ``source``'s whole row copied over ``to``.
+
+        The "copy this day to other days" operation. Rows are copied at wire
+        resolution, so the copy is lossless. The original profile is not
+        modified.
+
+        Args:
+            source: The row to copy from.
+            to: The row(s) to copy onto: a single :class:`ProfileDay` (or
+                its integer value) or an iterable of them.
+
+        Raises:
+            ValueError: If ``source`` or any target is not a row of this
+                profile type.
+        """
+        cls = type(self)
+        source_row = self._rows[cls.DAYS.index(self._validate_day(source))]
+        rows = list(self._rows)
+        for day in self._normalize_days(to):
+            rows[cls.DAYS.index(day)] = source_row
+        return cls(rows)
+
+    # endregion
+
+    # region Dunders
+
+    def __eq__(self, other: object) -> bool:
+        if type(other) is not type(self):
+            return NotImplemented
+        return self._rows == other._rows
+
+    def __hash__(self) -> int:
+        return hash((type(self), self._rows))
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}.from_wire({self.to_wire()!r})"
+
+    # endregion
+
+    # region Internal helpers
+
+    @classmethod
+    def _slots_per_hour(cls) -> int:
+        return cls.WIRE_SLOTS_PER_DAY // 24
+
+    @classmethod
+    def _validate_level(cls, level: int) -> None:
+        if not isinstance(level, int) or isinstance(level, bool):
+            raise ValueError(f"level must be an int, got {type(level).__name__}")
+        if level not in cls.LEVELS:
+            raise ValueError(f"level must be one of {sorted(cls.LEVELS)}, got {level}")
+
+    @classmethod
+    def _validate_day(cls, day: ProfileDay | int) -> ProfileDay:
+        if isinstance(day, bool) or not isinstance(day, int):
+            raise ValueError(
+                f"day must be a ProfileDay or an int, got {type(day).__name__}"
+            )
+        try:
+            profile_day = ProfileDay(day)
+        except ValueError as err:
+            raise ValueError(f"{day} is not a valid ProfileDay value") from err
+        if profile_day not in cls.DAYS:
+            raise ValueError(
+                f"{profile_day.name} is not a valid day for {cls.__name__}"
+            )
+        return profile_day
+
+    @classmethod
+    def _normalize_days(
+        cls, days: ProfileDay | int | Iterable[ProfileDay | int] | None
+    ) -> list[ProfileDay]:
+        if days is None:
+            return list(cls.DAYS)
+        if isinstance(days, int) and not isinstance(days, bool):
+            return [cls._validate_day(days)]
+        if isinstance(days, Iterable) and not isinstance(days, (str, bytes)):
+            return [cls._validate_day(day) for day in days]
+        raise ValueError(
+            "days must be a ProfileDay, an int, an iterable of them, or "
+            f"None, got {type(days).__name__}"
+        )
+
+    @classmethod
+    def _normalize_hour(cls, value: time | int, *, name: str, maximum: int = 23) -> int:
+        if isinstance(value, time):
+            if value.minute or value.second or value.microsecond:
+                raise ValueError(
+                    f"{name} must be a whole hour (edits are hour-based), got {value!r}"
+                )
+            hour = value.hour
+        elif isinstance(value, int) and not isinstance(value, bool):
+            hour = value
+        else:
+            raise ValueError(
+                f"{name} must be an int hour or a datetime.time, "
+                f"got {type(value).__name__}"
+            )
+        if not 0 <= hour <= maximum:
+            raise ValueError(f"{name} must be in the range 0-{maximum}, got {hour}")
+        return hour
+
+    def _slot_time(self, slot: int) -> time:
+        """Convert a wire slot index to its start time (end-of-day → time(0))."""
+        if slot == self.WIRE_SLOTS_PER_DAY:
+            return time(0)
+        minutes = slot * 24 * 60 // self.WIRE_SLOTS_PER_DAY
+        return time(hour=minutes // 60, minute=minutes % 60)
+
+    # endregion
+
+
+class LoadsCtrlProfile(WeeklyProfile):
+    """Weekly hourly threshold profile of a loads controller.
+
+    7 rows (Monday..Sunday) of 24 hourly slots; each level ``1``-``5``
+    selects the power threshold active in that hour as a fraction of the
+    controller's ``max_power`` (the five levels shown in the official app).
+
+    Used by :attr:`LoadsCtrlMeter.profile` and accepted by
+    :meth:`LoadsCtrlMeter.async_set_config`.
+    """
+
+    DAYS = WEEKDAYS
+    WIRE_SLOTS_PER_DAY = 24
+
+
+class ThermoProfile(WeeklyProfile):
+    """Weekly setpoint-level profile of a thermo zone.
+
+    8 rows — Monday..Sunday plus :attr:`ProfileDay.JOLLY` as the 8th row —
+    of 96 quarter-hour wire slots; each level ``1``-``5`` selects one of the
+    five setpoint levels shown in the official app. The app edits thermo
+    profiles per hour, so this class exposes hours only (see
+    :class:`WeeklyProfile`).
+
+    Currently a read/edit value type only: the thermo profile set command
+    has never been observed in captured traffic, so writing a profile back
+    to a zone is not yet supported by the library.
+    """
+
+    DAYS = WEEKDAYS + (ProfileDay.JOLLY,)
+    WIRE_SLOTS_PER_DAY = 96

--- a/aiocamedomotic/models/profiles.py
+++ b/aiocamedomotic/models/profiles.py
@@ -534,6 +534,8 @@ class LoadsCtrlProfile(WeeklyProfile):
     :meth:`LoadsCtrlMeter.async_set_config`.
     """
 
+    __slots__ = ()
+
     DAYS = WEEKDAYS
     WIRE_SLOTS_PER_DAY = 24
 
@@ -551,6 +553,8 @@ class ThermoProfile(WeeklyProfile):
     has never been observed in captured traffic, so writing a profile back
     to a zone is not yet supported by the library.
     """
+
+    __slots__ = ()
 
     DAYS = WEEKDAYS + (ProfileDay.JOLLY,)
     WIRE_SLOTS_PER_DAY = 96

--- a/aiocamedomotic/models/thermo_zone.py
+++ b/aiocamedomotic/models/thermo_zone.py
@@ -25,6 +25,7 @@ from ..utils import (
     EntityValidator,
 )
 from .base import CameEntity
+from .profiles import ThermoProfile
 
 
 class ThermoZoneStatus(Enum):
@@ -278,6 +279,38 @@ class ThermoZone(CameEntity):
         if raw is None:
             return None
         return raw / 10.0
+
+    @property
+    def profile_data(self) -> list[str]:
+        """Weekly setpoint-level profile (raw wire format, copied).
+
+        Eight strings — Monday..Sunday plus the JOLLY profile as the 8th
+        row — of 96 characters each (one per quarter hour of day). Each
+        character is a digit ``1``-``5`` selecting one of the five setpoint
+        levels shown in the official app. For a typed view use
+        :attr:`profile`.
+
+        Read-only: the thermo profile set command has never been observed
+        in captured traffic, so writing a profile back to the zone is not
+        yet supported by the library.
+
+        Returns a copy: mutating the returned list does not affect
+        ``raw_data``. Returns an empty list if the zone data carries no
+        profile (push updates do not include it).
+        """
+        return list(self.raw_data.get("profile_data", []))
+
+    @property
+    def profile(self) -> ThermoProfile:
+        """Weekly setpoint-level profile (typed view).
+
+        Parsed fresh from ``raw_data`` on every access (never cached).
+
+        Raises:
+            ValueError: If ``raw_data`` lacks a well-formed
+                ``profile_data`` value.
+        """
+        return ThermoProfile.from_wire(self.raw_data.get("profile_data", []))
 
     async def async_set_config(
         self,

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -21,14 +21,15 @@ and controlling devices, and monitoring real-time changes. For a minimal
         from aiocamedomotic import CameDomoticAPI
         from aiocamedomotic.models import (
             AnalogSensorType, DeviceType, DigitalInputStatus, LightStatus,
-            LightType, OpeningStatus, RelayStatus, ScenarioStatus,
-            ServerFeature, ThermoZoneFanSpeed,
+            LightType, LoadsCtrlProfile, OpeningStatus, ProfileDay,
+            RelayStatus, ScenarioStatus,
+            ServerFeature, ThermoProfile, ThermoZoneFanSpeed,
             ThermoZoneMode, ThermoZoneSeason, ThermoZoneStatus,
             Timer, TimerTimeSlot, TimerUpdate,
             DeviceUpdate, LightUpdate, OpeningUpdate, RelayUpdate,
             ThermoZoneUpdate, ScenarioUpdate, DigitalInputUpdate,
             EnergyMeterUpdate, LoadsCtrlMeterUpdate, LoadsCtrlRelayUpdate,
-            PlantUpdate,
+            PlantUpdate, WEEKDAYS,
         )
         from aiocamedomotic.errors import (
             CameDomoticError,
@@ -459,6 +460,84 @@ Example output:
     provided, the ``extended_infos`` flag is set automatically.
 
     Season can only be changed at the plant level via ``async_set_thermo_season()``.
+
+Weekly setpoint profile
+"""""""""""""""""""""""
+
+Each thermo zone carries a weekly schedule that selects, hour by hour, which
+of the **five setpoint levels** shown in the official CAME app is active.
+The ``profile`` property exposes it as a typed
+:class:`~aiocamedomotic.models.ThermoProfile` object with **8 rows**:
+Monday through Sunday, plus the special **JOLLY** profile (the schedule used
+while the zone is in ``ThermoZoneMode.JOLLY``) as the 8th row.
+
+Rows are addressed with :class:`~aiocamedomotic.models.ProfileDay`, whose
+``MONDAY``..``SUNDAY`` values (0-6) match ``datetime.date.weekday()``, so
+``ProfileDay(some_date.weekday())`` always picks the right row.
+
+**Reading the profile:**
+
+.. code-block:: python
+
+    from datetime import datetime, time
+    from aiocamedomotic.models import ProfileDay
+
+    zones = await api.async_get_thermo_zones()
+    zone = next((z for z in zones if z.name == "Office"), None)
+    profile = zone.profile
+
+    # Level active on a given day at a given moment
+    print(profile.level_at(ProfileDay.MONDAY, 8))            # int hour (0-23)
+    print(profile.level_at(ProfileDay.MONDAY, time(6, 30)))  # any time of day
+
+    # Level active right now
+    now = datetime.now()
+    print(profile.level_at(ProfileDay(now.weekday()), now))
+
+    # The JOLLY row is addressed like a day
+    print(profile.level_at(ProfileDay.JOLLY, 12))
+
+**Viewing a day as time spans:**
+
+``spans()`` returns a day's schedule as runs of consecutive equal levels —
+handy for displaying the schedule the way the official app draws it:
+
+.. code-block:: python
+
+    for span in profile.spans(ProfileDay.MONDAY):
+        print(f"{span.start} - {span.end}: level {span.level}")
+
+Example output:
+
+.. code-block:: text
+
+    00:00:00 - 08:00:00: level 1
+    08:00:00 - 09:00:00: level 4
+    09:00:00 - 15:00:00: level 3
+    15:00:00 - 00:00:00: level 1
+
+Each span is a half-open ``[start, end)`` range; the last span's ``end`` of
+``00:00`` means "through midnight".
+
+The ``profile_data`` property exposes the same schedule in raw wire format:
+8 strings of 96 characters (one per quarter hour of day), each character a
+digit ``1``-``5``. The official app edits profiles per hour, so the four
+quarters within an hour normally share the same level; the typed API speaks
+in hours only.
+
+.. note::
+    Thermo profiles are currently **read-only**: the command the official
+    app uses to write them has not been mapped yet, so the library cannot
+    send an edited thermo profile back to the server. The editing methods
+    described in :ref:`loadsctrl-weekly-profile` work on ``ThermoProfile``
+    objects too (with one extra option: pass
+    ``days=aiocamedomotic.models.WEEKDAYS`` to target Monday..Sunday while
+    leaving the JOLLY row untouched, since ``days=None`` targets all 8
+    rows), but the result can only be used locally.
+
+    Zone objects returned by ``async_get_thermo_zones()`` always carry the
+    profile; ``ThermoZoneUpdate`` push updates do **not** include it, so
+    read profiles from the zone list, not from updates.
 
 Analog sensors
 ^^^^^^^^^^^^^^
@@ -1095,14 +1174,100 @@ the wire command requires the full configuration on every write:
     await ctrl.async_set_config(max_power=4500)
     await ctrl.async_set_config(max_power=5000, hysteresis=300)
 
-.. note::
-    The ``profile_data`` parameter (the weekly hourly threshold profile) is
-    accepted only for the mandatory raw round-trip and is strictly
-    validated (7 strings of 24 digits in ``1``-``5``); profile *editing* is
-    not yet a library feature.
-
 Configuration writes and load changes are echoed back as push updates —
 see :ref:`loadsctrl-updates` in the monitoring section below.
+
+.. _loadsctrl-weekly-profile:
+
+Weekly threshold profile
+""""""""""""""""""""""""
+
+Besides the fixed ``max_power`` value, each controller carries a weekly
+schedule that selects, hour by hour, which of the **five threshold levels**
+shown in the official CAME app is active (each level is a fraction of
+``max_power``). The ``profile`` property exposes it as a typed
+:class:`~aiocamedomotic.models.LoadsCtrlProfile` object with 7 rows
+(Monday through Sunday) of 24 hourly slots, each set to a level ``1``-``5``.
+
+**Reading the profile:**
+
+.. code-block:: python
+
+    from aiocamedomotic.models import ProfileDay
+
+    profile = ctrl.profile
+
+    # Level active on Monday at 08:00
+    print(profile.level_at(ProfileDay.MONDAY, 8))
+
+    # A day's schedule as runs of consecutive equal levels
+    for span in profile.spans(ProfileDay.MONDAY):
+        print(f"{span.start} - {span.end}: level {span.level}")
+
+Example output:
+
+.. code-block:: text
+
+    4
+    00:00:00 - 00:00:00: level 4
+
+Here the whole day runs at level 4, so there is a single span covering the
+full day: spans are half-open ``[start, end)`` ranges, and an ``end`` of
+``00:00`` means "through midnight". (The ``profile_data`` property exposes
+the same schedule in raw wire format: 7 strings of 24 hourly digits.)
+
+**Editing the profile:**
+
+Profiles are **immutable value objects**: every editing method returns a
+*new* profile and leaves the original untouched, so nothing reaches the
+server until you explicitly write the result back with
+``async_set_config()``. Edits are hour-based (``start`` inclusive, ``end``
+exclusive), matching how the official app edits profiles:
+
+.. code-block:: python
+
+    from aiocamedomotic.models import LoadsCtrlProfile, ProfileDay
+
+    # Level 2 on Monday from 08:00 to 12:00
+    edited = profile.with_level(2, days=ProfileDay.MONDAY, start=8, end=12)
+
+    # Level 1 every day from 22:00 through midnight
+    # (days omitted → all days; end omitted → end of day)
+    edited = edited.with_level(1, start=22)
+
+    # Copy Monday's whole schedule onto the weekend
+    edited = edited.with_day_copied(
+        ProfileDay.MONDAY, to=[ProfileDay.SATURDAY, ProfileDay.SUNDAY]
+    )
+
+    # Or start from scratch: every hour of every day at level 5
+    flat = LoadsCtrlProfile.constant(5)
+
+Spans that cross midnight must be split into two calls (e.g. 22:00-06:00 is
+``with_level(1, start=22)`` on one day plus ``with_level(1, end=6)`` on the
+next).
+
+**Writing the profile back:**
+
+Pass the edited profile to ``async_set_config()`` — alone or together with
+``max_power``/``hysteresis``. As with the other configuration values, the
+accepted state is echoed back as a ``loadsctrl_meter_ind`` push update:
+
+.. code-block:: python
+
+    await ctrl.async_set_config(profile_data=edited)
+
+    # Re-fetch to confirm the server state
+    ctrl = (await api.async_get_loadsctrl_meters())[0]
+    print(ctrl.profile == edited)  # True
+
+.. note::
+    ``profile_data`` accepts a ``LoadsCtrlProfile`` object only (typically
+    obtained from ``ctrl.profile`` and edited), not raw digit strings — to
+    send a raw server-captured value, parse it first with
+    ``LoadsCtrlProfile.from_wire(raw_list)``. Profiles compare by value, so
+    two profiles with the same grid are equal regardless of how they were
+    built.
 
 
 Monitoring real-time updates

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -551,6 +551,17 @@ def loadsctrl_relay_data():
 
 
 @pytest.fixture
+def thermo_profile_wire_data():
+    """Mock thermo profile rows (8 x 96, modeled on real traffic, swver 3.0.1).
+
+    Hour-aligned runs, as written by the official app: 8h at level 1,
+    1h at level 4, 7h at level 3, 8h at level 1. The 8th row is the
+    JOLLY profile.
+    """
+    return ["1" * 32 + "4" * 4 + "3" * 28 + "1" * 32] * 8
+
+
+@pytest.fixture
 def timer_data_minimal():
     """Mock data for a timer without stop/active fields (v3.0.1 format)."""
     return {

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -1242,6 +1242,26 @@ class TestAPIThermoZones:
         assert zones[1].name == "Room 2"
 
     @patch.object(Auth, "async_send_command")
+    async def test_async_get_thermo_zones_request_payload(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = THERMO_LIST_RESP
+
+        await api.async_get_thermo_zones()
+
+        # extended_infos=2 is required for the server to include the
+        # profile_data and antifreeze fields (real server behavior).
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "thermo_list_req",
+                "topologic_scope": "plant",
+                "extended_infos": 2,
+            },
+            response_command="thermo_list_resp",
+        )
+
+    @patch.object(Auth, "async_send_command")
     async def test_async_get_thermo_zones_empty_array(
         self, mock_send_command, auth_instance
     ):

--- a/tests/aiocamedomotic/test_loads_ctrl.py
+++ b/tests/aiocamedomotic/test_loads_ctrl.py
@@ -14,8 +14,10 @@ from aiocamedomotic import Auth, CameDomoticAPI
 from aiocamedomotic.errors import CameDomoticServerError
 from aiocamedomotic.models import (
     LoadsCtrlMeter,
+    LoadsCtrlProfile,
     LoadsCtrlRelay,
     LoadsCtrlRelayStatus,
+    ProfileDay,
 )
 from tests.aiocamedomotic.mocked_responses import (
     LOADSCTRL_METER_LIST_RESP,
@@ -274,7 +276,7 @@ class TestLoadsCtrlMeter:
         auth_instance,
     ):
         meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
-        new_profile = ["5" * 24] * 7
+        new_profile = LoadsCtrlProfile.constant(5)
 
         await meter.async_set_config(
             max_power=4800, hysteresis=1000, profile_data=new_profile
@@ -287,12 +289,12 @@ class TestLoadsCtrlMeter:
                 "id": 196612,
                 "max_power": 4800,
                 "hysteresis": 1000,
-                "profile_data": new_profile,
+                "profile_data": ["5" * 24] * 7,
             }
         )
         assert meter.max_power == 4800
         assert meter.hysteresis == 1000
-        assert meter.profile_data == new_profile
+        assert meter.profile_data == ["5" * 24] * 7
 
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
     @patch.object(Auth, "async_get_valid_client_id", new_callable=AsyncMock)
@@ -387,40 +389,62 @@ class TestLoadsCtrlMeter:
         assert meter.hysteresis == 0
 
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
-    async def test_async_set_config_profile_wrong_count(
+    async def test_async_set_config_profile_raw_list_rejected(
         self, mock_send_command, loadsctrl_meter_data, auth_instance
     ):
         meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
+        with pytest.raises(ValueError, match="must be a LoadsCtrlProfile"):
+            await meter.async_set_config(profile_data=["5" * 24] * 7)
+        mock_send_command.assert_not_called()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    @patch.object(Auth, "async_get_valid_client_id", new_callable=AsyncMock)
+    async def test_async_set_config_edited_profile(
+        self,
+        mock_get_client_id,
+        mock_send_command,
+        loadsctrl_meter_data,
+        auth_instance,
+    ):
+        meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
+        new_profile = meter.profile.with_level(
+            2, days=ProfileDay.SUNDAY, start=8, end=18
+        )
+
+        await meter.async_set_config(profile_data=new_profile)
+
+        expected_wire = ["4" * 24] * 6 + ["4" * 8 + "2" * 10 + "4" * 6]
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "loadsctrl_meter_set_req",
+                "id": 196612,
+                "max_power": 5000,
+                "hysteresis": 400,
+                "profile_data": expected_wire,
+            }
+        )
+        assert meter.profile_data == expected_wire
+
+    def test_profile_typed_view(self, loadsctrl_meter_data, auth_instance):
+        meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
+        assert isinstance(meter.profile, LoadsCtrlProfile)
+        assert meter.profile.to_wire() == ["4" * 24] * 7
+
+    def test_profile_fresh_parse_per_access(self, loadsctrl_meter_data, auth_instance):
+        meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
+        meter.raw_data["profile_data"] = ["5" * 24] * 7
+        assert meter.profile.to_wire() == ["5" * 24] * 7
+
+    def test_profile_missing_raw_data(self, auth_instance):
+        meter = LoadsCtrlMeter({"name": "Controller", "id": 1}, auth_instance)
         with pytest.raises(ValueError, match="exactly 7 strings"):
-            await meter.async_set_config(profile_data=["5" * 24] * 6)
-        mock_send_command.assert_not_called()
+            _ = meter.profile
 
-    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
-    async def test_async_set_config_profile_wrong_length(
-        self, mock_send_command, loadsctrl_meter_data, auth_instance
-    ):
+    def test_profile_malformed_raw_data(self, loadsctrl_meter_data, auth_instance):
+        loadsctrl_meter_data["profile_data"] = ["9" * 24] * 7
         meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
-        with pytest.raises(ValueError, match="exactly 24"):
-            await meter.async_set_config(profile_data=["5" * 23] + ["5" * 24] * 6)
-        mock_send_command.assert_not_called()
-
-    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
-    async def test_async_set_config_profile_char_out_of_range(
-        self, mock_send_command, loadsctrl_meter_data, auth_instance
-    ):
-        meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
-        with pytest.raises(ValueError, match="digits in the\\s+range 1-5"):
-            await meter.async_set_config(profile_data=["6" * 24] + ["5" * 24] * 6)
-        mock_send_command.assert_not_called()
-
-    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
-    async def test_async_set_config_profile_non_string_entry(
-        self, mock_send_command, loadsctrl_meter_data, auth_instance
-    ):
-        meter = LoadsCtrlMeter(loadsctrl_meter_data, auth_instance)
-        with pytest.raises(ValueError, match="must be a string"):
-            await meter.async_set_config(profile_data=[44444] + ["5" * 24] * 6)
-        mock_send_command.assert_not_called()
+        with pytest.raises(ValueError, match="only digits"):
+            _ = meter.profile
 
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
     @patch.object(Auth, "async_get_valid_client_id", new_callable=AsyncMock)

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -55,6 +55,7 @@ from aiocamedomotic.models import (
     ScenarioUpdate,
     ServerInfo,
     TerminalGroup,
+    ThermoProfile,
     ThermoZone,
     ThermoZoneFanSpeed,
     ThermoZoneMode,
@@ -2563,6 +2564,60 @@ class TestThermoZone:
         assert call_payload["extended_infos"] == 1
         assert call_payload["mode"] == 2  # preserves current AUTO mode
         assert call_payload["set_point"] == 348  # preserves current setpoint
+
+
+class TestThermoZoneProfile:
+    def test_profile_data_raw(
+        self, thermo_zone_data_winter_auto, thermo_profile_wire_data, auth_instance
+    ):
+        zone_data = {
+            **thermo_zone_data_winter_auto,
+            "profile_data": thermo_profile_wire_data,
+        }
+        zone = ThermoZone(zone_data, auth_instance)
+        assert zone.profile_data == thermo_profile_wire_data
+
+    def test_profile_data_returns_copy(
+        self, thermo_zone_data_winter_auto, thermo_profile_wire_data, auth_instance
+    ):
+        zone_data = {
+            **thermo_zone_data_winter_auto,
+            "profile_data": thermo_profile_wire_data,
+        }
+        zone = ThermoZone(zone_data, auth_instance)
+        rows = zone.profile_data
+        rows[0] = "tampered"
+        assert zone.raw_data["profile_data"][0] == thermo_profile_wire_data[0]
+
+    def test_profile_data_missing(self, thermo_zone_data_winter_auto, auth_instance):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        assert zone.profile_data == []
+
+    def test_profile_typed_view(
+        self, thermo_zone_data_winter_auto, thermo_profile_wire_data, auth_instance
+    ):
+        zone_data = {
+            **thermo_zone_data_winter_auto,
+            "profile_data": thermo_profile_wire_data,
+        }
+        zone = ThermoZone(zone_data, auth_instance)
+        assert isinstance(zone.profile, ThermoProfile)
+        assert zone.profile.to_wire() == thermo_profile_wire_data
+
+    def test_profile_missing_raw_data(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone = ThermoZone(thermo_zone_data_winter_auto, auth_instance)
+        with pytest.raises(ValueError, match="exactly 8 strings"):
+            _ = zone.profile
+
+    def test_profile_malformed_raw_data(
+        self, thermo_zone_data_winter_auto, auth_instance
+    ):
+        zone_data = {**thermo_zone_data_winter_auto, "profile_data": ["9" * 96] * 8}
+        zone = ThermoZone(zone_data, auth_instance)
+        with pytest.raises(ValueError, match="only digits"):
+            _ = zone.profile
 
 
 class TestThermoZoneFanSpeed:

--- a/tests/aiocamedomotic/test_profiles.py
+++ b/tests/aiocamedomotic/test_profiles.py
@@ -1,0 +1,426 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+
+import logging
+from datetime import date, datetime, time
+
+import pytest
+
+from aiocamedomotic.models import (
+    WEEKDAYS,
+    LoadsCtrlProfile,
+    ProfileDay,
+    ProfileSpan,
+    ThermoProfile,
+    WeeklyProfile,
+)
+
+# Wire values captured from a real server (swver 3.0.1)
+LOADSCTRL_WIRE = ["4" * 24] * 7
+THERMO_MIXED_ROW = "1" * 32 + "4" * 4 + "3" * 28 + "1" * 32
+
+
+class TestProfileDay:
+    def test_weekday_values_match_date_weekday(self):
+        # 2026-07-06 is a Monday
+        for offset, day in enumerate(WEEKDAYS):
+            assert ProfileDay(date(2026, 7, 6 + offset).weekday()) == day
+
+    def test_jolly_is_row_eight(self):
+        assert ProfileDay.JOLLY == 7
+
+    def test_weekdays_excludes_jolly(self):
+        assert len(WEEKDAYS) == 7
+        assert ProfileDay.JOLLY not in WEEKDAYS
+
+
+class TestLoadsCtrlProfileFromWire:
+    def test_happy_path(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        assert profile.level_at(ProfileDay.MONDAY, 0) == 4
+
+    def test_wrong_row_count(self):
+        with pytest.raises(ValueError, match="exactly 7 strings"):
+            LoadsCtrlProfile.from_wire(["4" * 24] * 6)
+
+    def test_non_string_row(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            LoadsCtrlProfile.from_wire([44444] + ["4" * 24] * 6)
+
+    def test_wrong_row_length(self):
+        with pytest.raises(ValueError, match="exactly 24 characters"):
+            LoadsCtrlProfile.from_wire(["4" * 23] + ["4" * 24] * 6)
+
+    def test_digit_zero_rejected(self):
+        with pytest.raises(ValueError, match="only digits"):
+            LoadsCtrlProfile.from_wire(["0" * 24] + ["4" * 24] * 6)
+
+    def test_digit_six_rejected(self):
+        with pytest.raises(ValueError, match="only digits"):
+            LoadsCtrlProfile.from_wire(["6" * 24] + ["4" * 24] * 6)
+
+    def test_letter_rejected(self):
+        with pytest.raises(ValueError, match="only digits"):
+            LoadsCtrlProfile.from_wire(["a" * 24] + ["4" * 24] * 6)
+
+    def test_non_sequence_rejected(self):
+        with pytest.raises(ValueError, match="exactly 7 strings"):
+            LoadsCtrlProfile.from_wire("4" * 24)
+
+
+class TestThermoProfileFromWire:
+    def test_happy_path(self, thermo_profile_wire_data):
+        profile = ThermoProfile.from_wire(thermo_profile_wire_data)
+        assert profile.level_at(ProfileDay.JOLLY, 8) == 4
+
+    def test_wrong_row_count(self, thermo_profile_wire_data):
+        with pytest.raises(ValueError, match="exactly 8 strings"):
+            ThermoProfile.from_wire(thermo_profile_wire_data[:7])
+
+    def test_non_hour_uniform_accepted_with_warning(self, caplog):
+        # Hour 0 is "1112": not app-writable, but must be preserved
+        anomalous = ["1112" + "1" * 92] + ["1" * 96] * 7
+        with caplog.at_level(logging.WARNING):
+            profile = ThermoProfile.from_wire(anomalous)
+        assert "within the same hour" in caplog.text
+        assert profile.to_wire() == anomalous
+
+    def test_hour_uniform_no_warning(self, thermo_profile_wire_data, caplog):
+        with caplog.at_level(logging.WARNING):
+            ThermoProfile.from_wire(thermo_profile_wire_data)
+        assert caplog.text == ""
+
+
+class TestToWireRoundTrip:
+    def test_loadsctrl_round_trip(self):
+        assert LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE).to_wire() == LOADSCTRL_WIRE
+
+    def test_thermo_round_trip(self, thermo_profile_wire_data):
+        profile = ThermoProfile.from_wire(thermo_profile_wire_data)
+        assert profile.to_wire() == thermo_profile_wire_data
+
+    def test_thermo_mixed_levels_round_trip(self):
+        wire = [THERMO_MIXED_ROW] * 8
+        assert ThermoProfile.from_wire(wire).to_wire() == wire
+
+    def test_to_wire_returns_fresh_list(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        wire = profile.to_wire()
+        wire[0] = "tampered"
+        assert profile.to_wire() == LOADSCTRL_WIRE
+
+
+class TestConstant:
+    def test_all_slots_set(self):
+        profile = LoadsCtrlProfile.constant(3)
+        assert profile.to_wire() == ["3" * 24] * 7
+
+    def test_thermo_includes_jolly(self):
+        profile = ThermoProfile.constant(2)
+        assert profile.to_wire() == ["2" * 96] * 8
+
+    def test_invalid_level(self):
+        with pytest.raises(ValueError, match="level must be one of"):
+            LoadsCtrlProfile.constant(6)
+
+    def test_non_int_level(self):
+        with pytest.raises(ValueError, match="level must be an int"):
+            LoadsCtrlProfile.constant("3")
+
+
+class TestLevelAt:
+    def test_int_hour(self):
+        profile = ThermoProfile.from_wire([THERMO_MIXED_ROW] * 8)
+        assert profile.level_at(ProfileDay.MONDAY, 7) == 1
+        assert profile.level_at(ProfileDay.MONDAY, 8) == 4
+        assert profile.level_at(ProfileDay.MONDAY, 9) == 3
+
+    def test_time_object(self):
+        profile = ThermoProfile.from_wire([THERMO_MIXED_ROW] * 8)
+        assert profile.level_at(ProfileDay.MONDAY, time(8, 59)) == 4
+
+    def test_datetime_uses_time_of_day(self):
+        profile = ThermoProfile.from_wire([THERMO_MIXED_ROW] * 8)
+        # The datetime's date is NOT used to pick the day
+        moment = datetime(2026, 7, 10, 8, 15)
+        assert profile.level_at(ProfileDay.SUNDAY, moment) == 4
+
+    def test_mid_hour_time_on_loadsctrl(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        assert profile.level_at(ProfileDay.FRIDAY, time(14, 37)) == 4
+
+    def test_quarter_resolution_on_anomalous_data(self):
+        anomalous = ["1112" + "1" * 92] + ["1" * 96] * 7
+        profile = ThermoProfile.from_wire(anomalous)
+        assert profile.level_at(ProfileDay.MONDAY, time(0, 40)) == 1
+        assert profile.level_at(ProfileDay.MONDAY, time(0, 45)) == 2
+
+    def test_invalid_day(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        with pytest.raises(ValueError, match="JOLLY is not a valid day"):
+            profile.level_at(ProfileDay.JOLLY, 0)
+
+    def test_hour_out_of_range(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        with pytest.raises(ValueError, match="range 0-23"):
+            profile.level_at(ProfileDay.MONDAY, 24)
+
+    def test_invalid_at_type(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        with pytest.raises(ValueError, match="at must be"):
+            profile.level_at(ProfileDay.MONDAY, "08:00")
+
+
+class TestSpans:
+    def test_multi_run_day(self):
+        profile = ThermoProfile.from_wire([THERMO_MIXED_ROW] * 8)
+        assert profile.spans(ProfileDay.MONDAY) == [
+            ProfileSpan(start=time(0), end=time(8), level=1),
+            ProfileSpan(start=time(8), end=time(9), level=4),
+            ProfileSpan(start=time(9), end=time(16), level=3),
+            ProfileSpan(start=time(16), end=time(0), level=1),
+        ]
+
+    def test_constant_day_single_span(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        assert profile.spans(ProfileDay.SUNDAY) == [
+            ProfileSpan(start=time(0), end=time(0), level=4),
+        ]
+
+    def test_anomalous_data_reports_quarter_boundary(self):
+        anomalous = ["1112" + "1" * 92] + ["1" * 96] * 7
+        profile = ThermoProfile.from_wire(anomalous)
+        assert profile.spans(ProfileDay.MONDAY) == [
+            ProfileSpan(start=time(0), end=time(0, 45), level=1),
+            ProfileSpan(start=time(0, 45), end=time(1), level=2),
+            ProfileSpan(start=time(1), end=time(0), level=1),
+        ]
+
+    def test_invalid_day(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        with pytest.raises(ValueError, match="JOLLY is not a valid day"):
+            profile.spans(ProfileDay.JOLLY)
+
+
+class TestWithLevel:
+    def test_single_day_and_range(self):
+        profile = LoadsCtrlProfile.constant(4)
+        edited = profile.with_level(2, days=ProfileDay.SUNDAY, start=8, end=18)
+        expected = ["4" * 24] * 6 + ["4" * 8 + "2" * 10 + "4" * 6]
+        assert edited.to_wire() == expected
+
+    def test_original_unchanged(self):
+        profile = LoadsCtrlProfile.constant(4)
+        edited = profile.with_level(2, days=ProfileDay.SUNDAY)
+        assert profile.to_wire() == ["4" * 24] * 7
+        assert edited is not profile
+
+    def test_days_none_targets_all_rows_including_jolly(self):
+        profile = ThermoProfile.constant(1)
+        edited = profile.with_level(5, start=8, end=9)
+        assert edited.level_at(ProfileDay.JOLLY, 8) == 5
+        assert edited.level_at(ProfileDay.MONDAY, 8) == 5
+
+    def test_weekdays_excludes_jolly(self):
+        profile = ThermoProfile.constant(1)
+        edited = profile.with_level(5, days=WEEKDAYS, start=8, end=9)
+        assert edited.level_at(ProfileDay.JOLLY, 8) == 1
+        assert edited.level_at(ProfileDay.SUNDAY, 8) == 5
+
+    def test_int_and_time_hours_equivalent(self):
+        profile = LoadsCtrlProfile.constant(4)
+        by_int = profile.with_level(2, start=8, end=18)
+        by_time = profile.with_level(2, start=time(8), end=time(18))
+        assert by_int == by_time
+
+    def test_end_time_midnight_means_end_of_day(self):
+        profile = LoadsCtrlProfile.constant(4)
+        by_time = profile.with_level(2, start=time(18), end=time(0))
+        by_none = profile.with_level(2, start=18)
+        assert by_time == by_none
+
+    def test_non_whole_hour_start_rejected_loadsctrl(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="whole hour"):
+            profile.with_level(2, start=time(8, 30))
+
+    def test_non_whole_hour_start_rejected_thermo(self):
+        # Rejected on thermo too, despite its 15-min wire slots
+        profile = ThermoProfile.constant(1)
+        with pytest.raises(ValueError, match="whole hour"):
+            profile.with_level(2, start=time(8, 30))
+
+    def test_start_not_before_end(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="start must be before end"):
+            profile.with_level(2, start=18, end=8)
+
+    def test_level_out_of_range(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="level must be one of"):
+            profile.with_level(0)
+
+    def test_jolly_rejected_on_loadsctrl(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(
+            ValueError, match="JOLLY is not a valid day for LoadsCtrlProfile"
+        ):
+            profile.with_level(2, days=ProfileDay.JOLLY)
+
+    def test_thermo_hour_writes_four_quarters(self):
+        profile = ThermoProfile.constant(1)
+        edited = profile.with_level(5, days=ProfileDay.MONDAY, start=8, end=9)
+        assert edited.to_wire()[0] == "1" * 32 + "5555" + "1" * 60
+
+    def test_untouched_anomalous_quarters_preserved(self):
+        anomalous = ["1112" + "1" * 92] + ["1" * 96] * 7
+        profile = ThermoProfile.from_wire(anomalous)
+        edited = profile.with_level(5, days=ProfileDay.MONDAY, start=8, end=9)
+        assert edited.to_wire()[0] == "1112" + "1" * 28 + "5555" + "1" * 60
+
+    def test_int_day_accepted(self):
+        profile = LoadsCtrlProfile.constant(4)
+        edited = profile.with_level(2, days=0, start=8, end=9)
+        assert edited.level_at(ProfileDay.MONDAY, 8) == 2
+
+    def test_invalid_days_type(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="days must be"):
+            profile.with_level(2, days="monday")
+
+    def test_non_int_day_in_iterable(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="day must be a ProfileDay or an int"):
+            profile.with_level(2, days=["monday"])
+
+    def test_out_of_range_int_day(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="not a valid ProfileDay value"):
+            profile.with_level(2, days=9)
+
+    def test_invalid_start_type(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="start must be an int hour"):
+            profile.with_level(2, start="08:00")
+
+    def test_start_hour_out_of_range(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="start must be in the range 0-23"):
+            profile.with_level(2, start=24)
+
+
+class TestWithDayCopied:
+    def test_single_target(self):
+        profile = LoadsCtrlProfile.constant(4).with_level(
+            2, days=ProfileDay.MONDAY, start=8, end=18
+        )
+        edited = profile.with_day_copied(ProfileDay.MONDAY, to=ProfileDay.TUESDAY)
+        assert edited.to_wire()[1] == edited.to_wire()[0]
+        assert edited.to_wire()[2] == "4" * 24
+
+    def test_multiple_targets(self):
+        profile = LoadsCtrlProfile.constant(4).with_level(
+            2, days=ProfileDay.MONDAY, start=8, end=18
+        )
+        edited = profile.with_day_copied(
+            ProfileDay.MONDAY, to=[ProfileDay.SATURDAY, ProfileDay.SUNDAY]
+        )
+        monday_row = edited.to_wire()[0]
+        assert edited.to_wire()[5] == monday_row
+        assert edited.to_wire()[6] == monday_row
+
+    def test_jolly_as_target_on_thermo(self, thermo_profile_wire_data):
+        profile = ThermoProfile.from_wire(thermo_profile_wire_data).with_level(
+            5, days=ProfileDay.MONDAY
+        )
+        edited = profile.with_day_copied(ProfileDay.MONDAY, to=ProfileDay.JOLLY)
+        assert edited.to_wire()[7] == "5" * 96
+
+    def test_jolly_rejected_on_loadsctrl(self):
+        profile = LoadsCtrlProfile.constant(4)
+        with pytest.raises(ValueError, match="JOLLY is not a valid day"):
+            profile.with_day_copied(ProfileDay.JOLLY, to=ProfileDay.MONDAY)
+
+
+class TestEqualityAndRepr:
+    def test_value_equality(self):
+        assert LoadsCtrlProfile.constant(4) == LoadsCtrlProfile.from_wire(
+            LOADSCTRL_WIRE
+        )
+
+    def test_value_inequality(self):
+        assert LoadsCtrlProfile.constant(4) != LoadsCtrlProfile.constant(5)
+
+    def test_hashable(self):
+        assert len({LoadsCtrlProfile.constant(4), LoadsCtrlProfile.constant(4)}) == 1
+
+    def test_cross_class_inequality(self):
+        assert LoadsCtrlProfile.constant(4) != ThermoProfile.constant(4)
+
+    def test_not_equal_to_wire_list(self):
+        assert LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE) != LOADSCTRL_WIRE
+
+    def test_repr(self):
+        profile = LoadsCtrlProfile.from_wire(LOADSCTRL_WIRE)
+        assert repr(profile) == f"LoadsCtrlProfile.from_wire({LOADSCTRL_WIRE!r})"
+
+
+class TestAbstractBase:
+    def test_direct_instantiation_rejected(self):
+        with pytest.raises(TypeError, match="abstract base"):
+            WeeklyProfile([[4] * 24] * 7)
+
+    def test_from_wire_on_base_rejected(self):
+        with pytest.raises(TypeError, match="abstract base"):
+            WeeklyProfile.from_wire(LOADSCTRL_WIRE)
+
+    def test_constant_on_base_rejected(self):
+        with pytest.raises(TypeError, match="abstract base"):
+            WeeklyProfile.constant(4)
+
+    def test_subclass_without_days_rejected(self):
+        with pytest.raises(TypeError, match="non-empty DAYS"):
+
+            class BadProfile(WeeklyProfile):  # pylint: disable=unused-variable
+                WIRE_SLOTS_PER_DAY = 24
+
+    def test_subclass_with_bad_slot_count_rejected(self):
+        with pytest.raises(TypeError, match="positive multiple"):
+
+            class BadProfile(WeeklyProfile):  # pylint: disable=unused-variable
+                DAYS = WEEKDAYS
+                WIRE_SLOTS_PER_DAY = 25
+
+
+class TestConstructorValidation:
+    def test_rows_from_ints(self):
+        profile = LoadsCtrlProfile([[4] * 24] * 7)
+        assert profile.to_wire() == LOADSCTRL_WIRE
+
+    def test_wrong_row_count(self):
+        with pytest.raises(ValueError, match="exactly 7 day rows"):
+            LoadsCtrlProfile([[4] * 24] * 6)
+
+    def test_wrong_row_length(self):
+        with pytest.raises(ValueError, match="exactly\\s+24 levels"):
+            LoadsCtrlProfile([[4] * 23] + [[4] * 24] * 6)
+
+    def test_invalid_level_value(self):
+        with pytest.raises(ValueError, match="invalid level 6"):
+            LoadsCtrlProfile([[6] * 24] + [[4] * 24] * 6)
+
+    def test_bool_level_rejected(self):
+        with pytest.raises(ValueError, match="invalid level True"):
+            LoadsCtrlProfile([[True] * 24] + [[4] * 24] * 6)
+
+    def test_string_row_rejected(self):
+        with pytest.raises(ValueError, match="integer levels"):
+            LoadsCtrlProfile(["4" * 24] + [[4] * 24] * 6)
+
+    def test_non_sequence_rows_rejected(self):
+        with pytest.raises(ValueError, match="sequence of exactly 7 day rows"):
+            LoadsCtrlProfile(42)


### PR DESCRIPTION
## Summary

CAME transmits weekly schedules (`profile_data`) as arrays of digit strings — a stringly-typed grid where editing "Wednesday 8–18 to level 4" means counting characters. This PR introduces typed, immutable profile value objects with an hour-based editing API, and wires them into the loadsctrl and thermo models.

### New module `aiocamedomotic/models/profiles.py`

- **`ProfileDay(IntEnum)`** — `MONDAY..SUNDAY = 0..6` (matches both the wire row order and `date.weekday()`), plus `JOLLY = 7` (the 8th wire row of thermo profiles, used in JOLLY zone mode). Module constant `WEEKDAYS` for Monday–Sunday.
- **`WeeklyProfile`** — immutable, hashable value object holding the full-week grid at wire resolution. Public API speaks in **hours only** (the official app edits per hour, verified in captured traffic):
  - `from_wire()` / `to_wire()` — strict validation; guaranteed byte-for-byte round-trip (`from_wire(x).to_wire() == x`); non-hour-uniform data is accepted with a warning and preserved verbatim.
  - `level_at(day, at)` / `spans(day)` — read the schedule (any time resolves to its containing wire slot; spans are half-open `[start, end)` runs).
  - `with_level(level, days=, start=, end=)` / `with_day_copied(source, to=)` / `constant(level)` — editing returns a **new** instance; whole-hour boundaries enforced, no silent rounding.
- **`LoadsCtrlProfile`** (7×24) and **`ThermoProfile`** (8×96 incl. JOLLY) — subclasses differing only in shape; levels 1–5 shared.

### Model integration

- `LoadsCtrlMeter.profile` — typed view, parsed fresh from `raw_data` on each access.
- `LoadsCtrlMeter.async_set_config` now accepts **only** `LoadsCtrlProfile` for `profile_data` (raw `list[str]` dropped — no release is in use yet); `_validate_profile_data` removed (validity by construction).
- `ThermoZone.profile_data` / `ThermoZone.profile` — read-only access to zone schedules (the thermo profile set command has never been captured, so no write support yet).

### Testing

- New `tests/aiocamedomotic/test_profiles.py` (100% coverage of the new module), including round-trip identity on captured wire shapes and preservation of anomalous sub-hour data.
- Updated loads_ctrl set-config tests to the typed input; new `ThermoZone` profile tests.
- Verified end-to-end against a local mimic of the CAME `/domo/` endpoint replaying verbatim captured responses: typed read/edit/write flow produces the exact full-triple wire payload observed in real traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed weekly profiles for load controllers and thermostats.
  * Added profile tools for viewing levels, identifying time spans, copying days, and making immutable schedule edits.
  * Load controller profiles can now be read and submitted through structured profile objects.
  * Thermostat zones now expose weekly profile data with validation and wire-format conversion.
  * Added support for weekday and special-day profile access.

* **Bug Fixes**
  * Improved validation and error reporting for missing or malformed profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->