### PR TITLE
docs: fix SECURITY.md inconsistencies and drop redundant HTTP warning

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,9 +35,8 @@ supported with security updates.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.0.x   | ✅         |
-| 1.0.x   | ❌         |
-| 0.x.    | ❌         |
+| 1.x.x   | ✅         |
+| < 1.0   | ❌         |
 
 ## Reporting a vulnerability
 
@@ -57,7 +56,7 @@ within our project, we kindly ask you to follow these steps:
 
 Our project undergoes continuous integration and deployment (CI/CD), incorporating various security and code quality tools to ensure the safety and reliability of our codebase. Here are some of the measures and tools we use:
 
-- **Static code analysis**: We use `mypy`, `pylint`, `flake8`, and `black` to enforce coding standards and identify potential issues.
+- **Static code analysis**: We use `mypy`, `pylint`, and `ruff` to enforce coding standards and identify potential issues.
 - **Security scanning**: `bandit` and `gitguardian` scan our code for security vulnerabilities and secrets, respectively.
 - **Dependencies security**: `Dependabot` scans our dependencies for known vulnerabilities and automatically creates pull requests to update them.
 - **Automated testing**: `pytest` ensures that our code behaves as expected and that new changes do not introduce regressions.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,13 +7,6 @@ library in your projects. Before you begin, ensure you have:
 - Python 3.12, 3.13 or 3.14 installed on your system.
 - Access to a CAME Domotic server.
 
-.. warning::
-    CAME ETI/Domo servers expose their API over plain HTTP only, so all traffic —
-    including your credentials at login — travels unencrypted on the local network.
-    This is a limitation of the CAME hardware, not of this library. Keep the server
-    on a trusted network, never expose its HTTP port to the internet, and prefer a
-    VPN for remote access.
-
 Installation
 ------------
 


### PR DESCRIPTION
## Summary
- Fix a duplicated/malformed row in SECURITY.md's supported-versions table (repo has no 0.x releases; tags start at v1.4.x, current version is 1.13.0)
- Correct SECURITY.md's listed static-analysis tools to match the actual toolchain (ruff instead of flake8/black)
- Remove the plain-HTTP security warning from docs/source/getting_started.rst, since the network security model is already documented in SECURITY.md (and previously in the README, removed in #381)

## Test plan
- N/A (docs-only change)