### PR TITLE
docs: restructure SECURITY.md to lead with vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,31 +3,6 @@ SPDX-License-Identifier: Apache-2.0 -->
 
 # Security policy
 
-## Network security model
-
-CAME ETI/Domo servers expose their API over **plain HTTP only**. All traffic exchanged
-by this library with the server — including the username and password sent at login —
-travels **unencrypted** on the local network. This is a limitation of the CAME hardware
-and its proprietary protocol, **not of this library**: the official CAME clients
-communicate the same way, and the server offers no TLS/HTTPS endpoint.
-
-The resulting threat model is: anyone able to observe traffic on the network segment
-where the CAME server lives can capture the credentials and control the plant. We
-therefore recommend to:
-
-- Keep the CAME server on a **trusted local network** (ideally a dedicated VLAN or an
-  isolated IoT network segment).
-- **Never expose** the CAME server's HTTP port directly to the internet (no port
-  forwarding). For remote access, use a **VPN** into the home network.
-- Use a **dedicated CAME user** with a password not reused for any other service.
-
-What the library does on its side:
-
-- Credentials are **never persisted to disk** and are kept **encrypted in memory**
-  (runtime-generated key), cleared on disposal.
-- Passwords, client IDs, and other sensitive values are **automatically redacted**
-  from debug and traffic logs, so logs can be shared safely for troubleshooting.
-
 ## Supported versions
 
 This section to tell users about which versions of this project are currently being
@@ -60,6 +35,16 @@ Our project undergoes continuous integration and deployment (CI/CD), incorporati
 - **Security scanning**: `bandit` and `gitguardian` scan our code for security vulnerabilities and secrets, respectively.
 - **Dependencies security**: `Dependabot` scans our dependencies for known vulnerabilities and automatically creates pull requests to update them.
 - **Automated testing**: `pytest` ensures that our code behaves as expected and that new changes do not introduce regressions.
+
+## Network security model
+
+This library talks to CAME ETI/Domo servers over **plain HTTP only**, since that's the
+only protocol the hardware supports — traffic, including login credentials, is
+therefore unencrypted on the local network. On its side, the library never persists
+credentials to disk, keeps them encrypted in memory, and redacts sensitive values from
+logs. When deploying, keep the CAME server on a trusted/isolated network segment, avoid
+exposing its HTTP port to the internet (use a VPN for remote access instead), and use a
+dedicated CAME account.
 
 ## External audit
 


### PR DESCRIPTION
## Summary
- Reorder SECURITY.md so the standard vulnerability-disclosure content (supported versions, reporting process, security measures) comes first, since that's the conventional purpose/audience of a SECURITY.md
- Move the CAME network/plain-HTTP caveat to a later section and condense it into one paragraph, reframed to start from the library's perspective ("This library talks to CAME ETI/Domo servers over plain HTTP...") rather than opening the file talking about the CAME hardware

## Test plan
- N/A (docs-only change)