### PR TITLE
fix: add missing openssh-client to dev container image

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -59,6 +59,9 @@ git reset --hard HEAD~1       # drop the test commit
 - **"key not found" / "failed to sign" on commit**: the key is missing on the
   host side of the mount, or the container was built before the key existed.
   Re-run step 1, then rebuild the container.
+- **"error: cannot run ssh-keygen: No such file or directory" on commit**: the
+  `openssh-client` package is missing from the container image. It's listed
+  in `Dockerfile.dev`; rebuild the container to pick it up.
 - **"No signature" from `git log --show-signature` (with an error about
   `gpg.ssh.allowedSignersFile`)**: the commit is usually signed just fine —
   git only lacks the allowed-signers file needed to *verify* it. Complete

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,7 @@ RUN apk update && \
     apk add --no-cache \
         bash \
         git \
+        openssh-client \
         gcc \
         musl-dev \
         linux-headers \


### PR DESCRIPTION
## Summary
- Add `openssh-client` to `Dockerfile.dev` so `ssh-keygen` is available for SSH commit signing
- Document the resulting failure mode ("cannot run ssh-keygen") in `.devcontainer/README.md`'s troubleshooting section

## Test plan
- [x] Verified `ssh-keygen`-dependent signing failed without this package on a fresh rebuild
- [ ] Rebuild dev container and confirm signing test passes end-to-end