### PR TITLE
docs: restructure llms.txt as curated index and de-noise LLM docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,8 +77,8 @@ Once you are a bit more familiar with the library, you may want to explore the f
 resources too:
 
 - `API reference <https://aiocamedomotic.readthedocs.io/latest/api_reference.html>`_
-- `LLM-friendly docs <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms.txt>`_
-  (also available: `full version <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms-full.txt>`_)
+- `LLM-friendly docs <https://aiocamedomotic.readthedocs.io/latest/llms.txt>`_
+  (also available: `full version <https://aiocamedomotic.readthedocs.io/latest/llms-full.txt>`_)
 - `What's new (releases) <https://github.com/camedomotic-unofficial/aiocamedomotic/releases>`_
 - `Development roadmap <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap>`_
 - `Security Policy <https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy>`_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,12 @@ exclude_patterns = exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
 
+# Serve the LLM documentation files (generated in the repo root by
+# scripts/build_llms_docs.py) at the docs site root, so that the
+# conventional https://aiocamedomotic.readthedocs.io/latest/llms.txt
+# lookup works.
+html_extra_path = ["../../llms.txt", "../../llms-full.txt"]
+
 
 # -- Options for Markdown output -----------------------------------------------
 markdown_anchor_sections = True

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,9 +2,7 @@
 
 > Async Python library for interacting with CAME Domotic home automation systems. Provides automatic session management and device control.
 
-## Welcome!
-
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-D22128.svg)](https://opensource.org/licenses/Apache-2.0)[![Python 3.12 | 3.13 | 3.14](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-417fb0.svg)](https://www.python.org)[![SonarCloud - Security Rating](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=security_rating)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=vulnerabilities)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Bugs](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=bugs)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![Documentation status](https://readthedocs.org/projects/aiocamedomotic/badge/?version=latest)](https://aiocamedomotic.readthedocs.io/en/latest/?badge=latest)
+## Overview
 
 The **CAME Domotic Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
 provides a streamlined Python interface for interacting with CAME Domotic plants, much
@@ -18,7 +16,7 @@ Although primarily developed for use with
 under the [Apache license 2.0](http://www.apache.org/licenses/LICENSE-2.0) for anyone
 interested in experimenting with a CAME Domotic plant.
 
-##### IMPORTANT
+**IMPORTANT:**
 This library is independently developed and is not affiliated with, endorsed by,
 or supported by [CAME](https://www.came.com/). It may not be compatible with all
 CAME Domotic systems. While this library is stable and publicly released, it comes
@@ -33,38 +31,6 @@ with no guarantees. Use at your own risk.
 - **First of its kind**: Unique in providing integration with CAME Domotic systems.
 - **Open source**: Freely available under the Apache 2.0 license, inviting
   contributions and adaptations.
-
-### Quick Start
-
-Have a look at the following guides to learn how to install and use the library:
-
-- [Getting started](https://aiocamedomotic.readthedocs.io/latest/getting_started.html)
-- [Usage examples](https://aiocamedomotic.readthedocs.io/latest/usage_examples.html)
-
-Once you are a bit more familiar with the library, you may want to explore the following
-resources too:
-
-- [API reference](https://aiocamedomotic.readthedocs.io/latest/api_reference.html)
-- [LLM-friendly docs](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms.txt)
-  (also available: [full version](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms-full.txt))
-- [What’s new (releases)](https://github.com/camedomotic-unofficial/aiocamedomotic/releases)
-- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap)
-- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy)
-- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md#contributing-to-our-project)
-
-### Acknowledgments
-
-Special thanks to Andrea Michielan for his foundational work with the
-[eti_domo](https://github.com/andrea-michielan/eti_domo) library, which greatly
-facilitated the initial development of this library. We also found great inspiration in
-the Home Assistant document
-[Building a Python library for an API](https://developers.home-assistant.io/docs/api_lib_index).
-
-## License
-
-This project is licensed under the Apache License 2.0. For more details, see the
-[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/LICENSE)
-on GitHub.
 
 ## Getting started
 
@@ -244,7 +210,7 @@ CAME Domotic server: connecting, discovering what the server offers, fetching
 and controlling devices, and monitoring real-time changes. For a minimal
 “hello world” example, see [Getting started](#getting-started).
 
-##### NOTE
+**NOTE:**
 The examples below assume the library is installed (`pip install
 aiocamedomotic`). Unless otherwise noted, all code runs inside an
 `async with` block:
@@ -300,7 +266,7 @@ async def main():
 asyncio.run(main())
 ```
 
-##### NOTE
+**NOTE:**
 The session is **not** authenticated at creation time. The library
 authenticates lazily on the first real API call, like `async_get_server_info()`.
 If the credentials are invalid, a `CameDomoticAuthError` will be raised at that
@@ -550,7 +516,7 @@ if rgb_strip:
     await rgb_strip.async_set_status(LightStatus.ON, brightness=75, rgb=[0, 128, 255])
 ```
 
-##### NOTE
+**NOTE:**
 The `brightness` parameter is silently ignored for non-dimmable
 (STEP_STEP) lights. The `rgb` parameter is silently ignored for
 non-RGB lights. Dimmer hardware may quantize the requested brightness
@@ -659,7 +625,7 @@ await zone.async_set_fan_speed(ThermoZoneFanSpeed.SLOW)
 await api.async_set_thermo_season(ThermoZoneSeason.WINTER)
 ```
 
-##### WARNING
+**WARNING:**
 **Setting the season to** `PLANT_OFF` **forces all zones to** `OFF`.
 
 When the season is set to `PLANT_OFF`, the CAME server automatically
@@ -672,7 +638,7 @@ If your application needs to restore zone operation after re-enabling a
 season, you must track each zone’s previous mode yourself and re-apply it
 after changing the season.
 
-##### NOTE
+**NOTE:**
 Temperature values are returned as floats in degrees Celsius.
 
 The `fan_speed` parameter in `async_set_config` is optional; when
@@ -743,7 +709,7 @@ digit `1`-`5`. The official app edits profiles per hour, so the four
 quarters within an hour normally share the same level; the typed API speaks
 in hours only.
 
-##### NOTE
+**NOTE:**
 Thermo profiles are currently **read-only**: the command the official
 app uses to write them has not been mapped yet, so the library cannot
 send an edited thermo profile back to the server. The editing methods
@@ -835,7 +801,7 @@ button = next((di for di in digital_inputs if di.act_id == 1), None)
 sensor = next((di for di in digital_inputs if di.name == "Front door button"), None)
 ```
 
-##### NOTE
+**NOTE:**
 Some digital inputs do not report a `status` until their first state
 change. In that case, `status` returns `DigitalInputStatus.UNKNOWN`.
 
@@ -845,7 +811,7 @@ Analog inputs are read-only standalone sensors exposed via the `analogin` featur
 They provide a numeric reading and a unit of measurement and cannot be
 controlled remotely.
 
-##### NOTE
+**NOTE:**
 These sensors are independent of the thermoregulation system’s
 [`AnalogSensor`](#aiocamedomotic.models.AnalogSensor). The same physical sensor
 may appear in both endpoints.
@@ -1029,7 +995,7 @@ Slot 0: 10:00:00 → 18:30:00
 Slot 2: 22:00:00 → N/A
 ```
 
-##### NOTE
+**NOTE:**
 The `stop` and `active` fields may not be
 present in the server response. The corresponding properties return
 `None` in that case. Your code should handle both cases.
@@ -1088,7 +1054,7 @@ for slot in timer.timetable:
 await timer.async_set_timetable([None, None, None, None])
 ```
 
-##### IMPORTANT
+**IMPORTANT:**
 `async_set_timetable()` always sends **all 4 slots** to the server.
 To keep existing slots unchanged, read the current timetable first and
 merge your changes:
@@ -1239,7 +1205,7 @@ value: **the lower the priority value, the earlier the load is detached**.
 Keep this direction in mind throughout this section — your most expendable
 appliance should have the *lowest* priority value.
 
-##### NOTE
+**NOTE:**
 The number and names of controllers and loads are **entirely
 plant-specific**: another plant may have any number of loads (including
 zero) with arbitrary user-defined names. Never hard-code load names or
@@ -1357,7 +1323,7 @@ await ctrl.async_set_detach_order([
 ])
 ```
 
-##### NOTE
+**NOTE:**
 `async_set_detach_order()` writes **only the relays whose priority
 actually changes** (the official app does the same), so a no-op reorder
 sends no set commands. It raises `ValueError` if the sequence is not
@@ -1463,7 +1429,7 @@ ctrl = (await api.async_get_loadsctrl_meters())[0]
 print(ctrl.profile == edited)  # True
 ```
 
-##### NOTE
+**NOTE:**
 `profile_data` accepts a `LoadsCtrlProfile` object only (typically
 obtained from `ctrl.profile` and edited), not raw digit strings — to
 send a raw server-captured value, parse it first with
@@ -1565,7 +1531,7 @@ Example output:
 [THERMOSTAT] Living Room (ID: 1)
 ```
 
-##### NOTE
+**NOTE:**
 The `asyncio.sleep(1)` acts as a safety throttle in case the server
 returns immediately (e.g. errors or rapid update bursts). If you need to
 run the polling loop alongside other logic, wrap it in
@@ -1597,7 +1563,7 @@ disconnections:
 updates = await api.async_get_updates(timeout=120)
 ```
 
-##### NOTE
+**NOTE:**
 If no `timeout` is passed to `async_get_updates()`, it falls back to
 the instance-level `command_timeout` (default: 30s). For most real-time
 monitoring use cases, a timeout of **60–120 seconds** is recommended.
@@ -1691,7 +1657,7 @@ if updates.has_plant_update:
     digital_inputs = await api.async_get_digital_inputs()
 ```
 
-##### NOTE
+**NOTE:**
 Plant updates are relatively rare. They typically occur when an installer
 modifies the system configuration. Failing to handle them may result in
 stale device data or missing newly added devices.
@@ -1757,7 +1723,7 @@ Each update is a **complete snapshot** of the timer’s state — not a delta.
 You can safely overwrite the cached timer data with the update payload
 without needing to merge changes.
 
-##### NOTE
+**NOTE:**
 The `timer_info_ind` indication name was confirmed from real server
 traffic (firmware 3.0.1). A legacy variant `timer_update_ind` is also
 handled for firmware compatibility.
@@ -1809,7 +1775,7 @@ a **complete snapshot** of the affected entity, parsed into
 [`LoadsCtrlMeterUpdate`](#aiocamedomotic.models.LoadsCtrlMeterUpdate); for both,
 `device_id` is the loadsctrl `id` (not the relay’s `act_id`).
 
-##### NOTE
+**NOTE:**
 **Your own writes are echoed back to you.** These pushes are sent to
 *all* clients — including the one that issued the set command. A
 consumer polling `async_get_updates()` must therefore expect to
@@ -1920,7 +1886,7 @@ if guest:
     await guest.async_change_password("old_pwd", "new_pwd")
 ```
 
-##### NOTE
+**NOTE:**
 Changing the password does not invalidate existing active sessions for
 that user — they remain valid until they expire; the new password is
 required at the next login. If the changed user is the currently
@@ -1971,7 +1937,7 @@ else:
     print("No valid session — it will be renewed automatically on the next call.")
 ```
 
-##### NOTE
+**NOTE:**
 You rarely need to call this. The library handles reauthentication
 automatically whenever the session expires.
 
@@ -2002,7 +1968,7 @@ async def async_discover_came_server(host: str, mac_address: str) -> bool:
     return await async_is_came_endpoint(host)
 ```
 
-##### NOTE
+**NOTE:**
 `CAME_MAC_PREFIXES` contains prefixes in **colon-separated uppercase hex**
 format (e.g. `"00:1C:B2"`). Make sure the MAC address you pass uses the
 same format (`"00:1C:B2:AA:BB:CC"`) before comparing. Other common
@@ -2052,14 +2018,14 @@ The following fields are redacted automatically:
 - Host IP in the URL → last octet masked (e.g. `192.168.1.***`)
 - Usernames inside `sl_users_list` items → partially masked
 
-##### NOTE
+**NOTE:**
 The traffic logger level is independent from the main library logger.
 Setting `aiocamedomotic` to `WARNING` and
 `aiocamedomotic.traffic` to `DEBUG` is a valid configuration —
 you will see only the HTTP traffic, without the library’s internal
 debug messages.
 
-##### SEE ALSO
+**SEE ALSO:**
 For full API details, see the [API Reference](#api-reference).
 
 ## API Reference
@@ -2068,7 +2034,7 @@ For full API details, see the [API Reference](#api-reference).
 
 This module exposes the CAME Domotic API to the end-users.
 
-#### *class* aiocamedomotic.came_domotic_api.CameDomoticAPI(auth: [Auth](#aiocamedomotic.auth.Auth), \*, command_timeout: int = 30)
+#### *class* aiocamedomotic.came_domotic_api.CameDomoticAPI(auth: [Auth](#aiocamedomotic.auth.Auth), , command_timeout: int = 30)
 
 Main class, exposes all the public methods of the CAME Domotic API.
 
@@ -2091,7 +2057,7 @@ Add a new user to the CAME Domotic server.
   * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
   * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
 
-##### *async classmethod* async_create(host: str, username: str, password: str, \*, websession: ClientSession | None = None, close_websession_on_disposal: bool = False, command_timeout: int = 30) → [CameDomoticAPI](#aiocamedomotic.came_domotic_api.CameDomoticAPI)
+##### *async classmethod* async_create(host: str, username: str, password: str, , websession: ClientSession | None = None, close_websession_on_disposal: bool = False, command_timeout: int = 30) → [CameDomoticAPI](#aiocamedomotic.came_domotic_api.CameDomoticAPI)
 
 Create a CameDomoticAPI object.
 
@@ -2101,7 +2067,7 @@ Create a CameDomoticAPI object.
   * **password** (*str*) – The password to use for the API.
   * **websession** (*aiohttp.ClientSession* *,* *optional*) – The aiohttp session to use for
     the API. If not provided, a new aiohttp.ClientSession will be created.
-  * **close_websession_on_disposal** (*bool* *,* *default False*) – 
+  * **close_websession_on_disposal** (*bool* *,* *default False*) –
 
     Controls whether the
     aiohttp session is closed when this object is disposed.
@@ -2128,7 +2094,7 @@ Create a CameDomoticAPI object.
   [**CameDomoticServerNotFoundError**](#aiocamedomotic.errors.CameDomoticServerNotFoundError) – if the host doesn’t respond to an HTTP
       request or doesn’t expose the CAME Domotic API endpoint.
 
-##### NOTE
+**NOTE:**
 The session is not logged in until the first request is made.
 
 ##### *async* async_dispose() → None
@@ -2492,7 +2458,7 @@ Set the global thermoregulation season for all zones.
 This is a plant-level command that changes the season for the
 entire thermoregulation system.
 
-##### WARNING
+**WARNING:**
 Setting `season` to `PLANT_OFF` causes the CAME server to
 automatically switch **all** thermoregulation zones to
 `ThermoZoneMode.OFF`. Reverting the season back to `WINTER`
@@ -2577,7 +2543,7 @@ separate from the thermoregulation zones.
   * **sensor_type** – The type of sensor (temperature, humidity, or pressure).
     Defaults to `AnalogSensorType.UNKNOWN` if not specified.
 
-##### NOTE
+**NOTE:**
 The `value` property returns the real sensor reading in the
 unit reported by `unit` (e.g., degrees C, %, hPa).
 
@@ -2628,7 +2594,7 @@ Cameras are read-only devices that provide streaming video and still-image
 URIs for IP cameras connected to the CAME Domotic system. They cannot be
 controlled remotely — this is purely a viewing/monitoring feature.
 
-##### WARNING
+**WARNING:**
 The `uri` and `uri_still` fields point directly to camera HTTP
 endpoints on the local network. These URIs may contain embedded
 authentication credentials (e.g. `http://user:pass@camera/stream`).
@@ -3135,7 +3101,7 @@ view shown by the official app.
   * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
   * [**CameDomoticServerError**](#aiocamedomotic.errors.CameDomoticServerError) – If the server returns an error.
 
-##### *async* async_set_config(\*, max_power: int | None = None, hysteresis: int | None = None, profile_data: [LoadsCtrlProfile](#aiocamedomotic.models.LoadsCtrlProfile) | None = None) → None
+##### *async* async_set_config(, max_power: int | None = None, hysteresis: int | None = None, profile_data: [LoadsCtrlProfile](#aiocamedomotic.models.LoadsCtrlProfile) | None = None) → None
 
 Update the controller configuration.
 
@@ -3964,11 +3930,11 @@ ID of the thermoregulation zone.
 
 Antifreeze temperature in degrees Celsius, or None if not set.
 
-##### *async* async_set_config(mode: [ThermoZoneMode](#aiocamedomotic.models.ThermoZoneMode), set_point: float, \*, fan_speed: [ThermoZoneFanSpeed](#aiocamedomotic.models.ThermoZoneFanSpeed) | None = None) → None
+##### *async* async_set_config(mode: [ThermoZoneMode](#aiocamedomotic.models.ThermoZoneMode), set_point: float, , fan_speed: [ThermoZoneFanSpeed](#aiocamedomotic.models.ThermoZoneFanSpeed) | None = None) → None
 
 Configure the thermoregulation zone.
 
-##### NOTE
+**NOTE:**
 The season cannot be changed via this method.
 Use `CameDomoticAPI.async_set_thermo_season()` to change the
 season at the plant level.
@@ -4006,7 +3972,7 @@ Set the operating mode, keeping the current target temperature.
 
 Set the target temperature, keeping the current operating mode.
 
-##### WARNING
+**WARNING:**
 This method only has an effect when the zone is in
 `ThermoZoneMode.MANUAL` mode. When the zone is in any other mode
 (e.g. `AUTO`, `JOLLY`), the server accepts the request without error but
@@ -4528,7 +4494,7 @@ Change the password of this user on the CAME Domotic server.
   * **current_password** (*str*) – The user’s current password.
   * **new_password** (*str*) – The desired new password.
 
-##### NOTE
+**NOTE:**
 Changing the password does not invalidate existing active sessions
 for that user — they remain valid until they expire. The new
 password will be required at the next login.
@@ -4564,7 +4530,7 @@ Set the user as the current user in the CAME Domotic API session.
 * **Raises:**
   [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – If the authentication fails.
 
-##### NOTE
+**NOTE:**
 This method logs out the current user and logs in with the new user.
 If login with the new credentials fails, a
 `CameDomoticAuthError` is raised and the previous credentials
@@ -4686,7 +4652,7 @@ modified.
   **ValueError** – If `source` or any target is not a row of this
       profile type.
 
-##### with_level(level: int, \*, days: [ProfileDay](#aiocamedomotic.models.ProfileDay) | int | Iterable[[ProfileDay](#aiocamedomotic.models.ProfileDay) | int] | None = None, start: time | int = 0, end: time | int | None = None) → Self
+##### with_level(level: int, , days: [ProfileDay](#aiocamedomotic.models.ProfileDay) | int | Iterable[[ProfileDay](#aiocamedomotic.models.ProfileDay) | int] | None = None, start: time | int = 0, end: time | int | None = None) → Self
 
 Return a copy with `[start, end)` on `days` set to `level`.
 
@@ -4952,7 +4918,7 @@ See also the exception hierarchy mapping for Home Assistant integrations:
 
 This module manages the HTTP interaction with the CAME Domotic API.
 
-##### NOTE
+**NOTE:**
 As a consumer of the CAME Domotic library, **it’s quite unlikely that you
 will need to use this class directly**: you should use the `CameDomoticAPI` and the
 CameEntity classes instead.
@@ -4961,7 +4927,7 @@ In case of special needs, consider requesting the implementation of the desired
 feature in the CAME Domotic library, or forking the library and implement
 the feature yourself.
 
-#### *class* aiocamedomotic.auth.Auth(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = False)
+#### *class* aiocamedomotic.auth.Auth(websession: ClientSession, host: str, username: str, password: str, , close_websession_on_disposal: bool = False)
 
 Class to make authenticated requests to the CAME Domotic API server.
 
@@ -4971,12 +4937,12 @@ Security features:
   using Fernet symmetric encryption with a runtime-generated key. Credentials
   are explicitly cleared on disposal and as a safety net on garbage collection.
 
-##### NOTE
+**NOTE:**
 This class is not meant to be used directly, but through the `CameDomoticAPI`
 class. To create an instance of this class, use the factory method
 `async_create`.
 
-##### *async classmethod* async_create(websession: ClientSession, host: str, username: str, password: str, \*, close_websession_on_disposal: bool = False, command_timeout: int = 30) → [Auth](#aiocamedomotic.auth.Auth)
+##### *async classmethod* async_create(websession: ClientSession, host: str, username: str, password: str, , close_websession_on_disposal: bool = False, command_timeout: int = 30) → [Auth](#aiocamedomotic.auth.Auth)
 
 Create an Auth instance.
 
@@ -4997,7 +4963,7 @@ Create an Auth instance.
 * **Return type:**
   [Auth](#aiocamedomotic.auth.Auth)
 
-##### NOTE
+**NOTE:**
 The session is not logged in until the first request is made.
 
 ##### *async* async_dispose() → None
@@ -5052,7 +5018,7 @@ Check the response status and raise an error if necessary.
   * [**CameDomoticAuthError**](#aiocamedomotic.errors.CameDomoticAuthError) – if there is an authentication error with
         the remote CAME Domotic server.
 
-##### *async* async_send_command(command: dict[str, Any], \*, response_command: str | None = None, timeout: int | None = None, skip_ack_check: bool = False, command_type: str = 'sl_data_req', additional_payload: dict[str, Any] | None = None, \_caller_holds_lock: bool = False) → dict[str, Any]
+##### *async* async_send_command(command: dict[str, Any], , response_command: str | None = None, timeout: int | None = None, skip_ack_check: bool = False, command_type: str = 'sl_data_req', additional_payload: dict[str, Any] | None = None, \_caller_holds_lock: bool = False) → dict[str, Any]
 
 Send a command to the CAME Domotic server.
 
@@ -5110,7 +5076,7 @@ Return the decrypted username for the current session, or None.
 * **Return type:**
   str | None
 
-##### NOTE
+**NOTE:**
 Usernames are not secret — they appear in plaintext in all API
 payloads. This property is intended for internal comparisons
 (e.g. preventing deletion of the current user). Avoid logging

--- a/llms.txt
+++ b/llms.txt
@@ -2,90 +2,28 @@
 
 > Async Python library for interacting with CAME Domotic home automation systems. Provides automatic session management and device control.
 
-## Welcome!
+Key facts:
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-D22128.svg)](https://opensource.org/licenses/Apache-2.0)[![Python 3.12 | 3.13 | 3.14](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-417fb0.svg)](https://www.python.org)[![SonarCloud - Security Rating](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=security_rating)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=vulnerabilities)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![SonarCloud - Bugs](https://sonarcloud.io/api/project_badges/measure?project=camedomotic-unofficial_aiocamedomotic&metric=bugs)](https://sonarcloud.io/project/overview?id=camedomotic-unofficial_aiocamedomotic)[![Documentation status](https://readthedocs.org/projects/aiocamedomotic/badge/?version=latest)](https://aiocamedomotic.readthedocs.io/en/latest/?badge=latest)
+- Install with `pip install aiocamedomotic`. Requires Python 3.12, 3.13, or 3.14.
+- Built on asyncio and aiohttp; every public method is async and prefixed
+  with `async_`.
+- Entry point: `CameDomoticAPI.async_create(host, username, password)`, used
+  as an async context manager.
+- Authentication is lazy: login happens on the first server call, not at
+  client creation. Sessions are kept alive and renewed automatically.
+- Supported device types: lights (on/off, dimmable, RGB), openings (covers),
+  scenarios, thermoregulation zones, analog sensors, digital inputs, analog
+  inputs, relays, timers, energy meters, loads control, and map pages.
+  Server users can be managed too.
+- Real-time device updates are available via long polling
+  (`api.async_get_updates()`) with typed update classes.
+- All exceptions inherit from `CameDomoticError`:
+  `CameDomoticServerNotFoundError` (host unreachable), `CameDomoticAuthError`
+  (bad credentials), `CameDomoticServerError` (other server errors).
+- Unofficial library, not affiliated with or endorsed by CAME.
+  Apache 2.0 license.
 
-The **CAME Domotic Library** ([aiocamedomotic](https://github.com/camedomotic-unofficial/aiocamedomotic))
-provides a streamlined Python interface for interacting with CAME Domotic plants, much
-like the official
-[CAME Domotic app](https://www.came.com/global/itex/installers/solutions/domotica-e-termoregolazione/prodotti-compatibili-domotica/app-domotic-30).
-This library is designed to simplify the management of domotic devices by abstracting
-the complexities of the CAME Domotic API.
-
-Although primarily developed for use with
-[Home Assistant](https://www.home-assistant.io/), the library is freely available
-under the [Apache license 2.0](http://www.apache.org/licenses/LICENSE-2.0) for anyone
-interested in experimenting with a CAME Domotic plant.
-
-##### IMPORTANT
-This library is independently developed and is not affiliated with, endorsed by,
-or supported by [CAME](https://www.came.com/). It may not be compatible with all
-CAME Domotic systems. While this library is stable and publicly released, it comes
-with no guarantees. Use at your own risk.
-
-### Key Features
-
-- **Simplicity**: Easy interaction with domotic entities.
-- **Automatic session management**: No need for manual login or session handling.
-- **Real-time updates**: Built-in long-polling support with typed update classes
-  for monitoring device state changes as they happen.
-- **First of its kind**: Unique in providing integration with CAME Domotic systems.
-- **Open source**: Freely available under the Apache 2.0 license, inviting
-  contributions and adaptations.
-
-### Quick Start
-
-Have a look at the following guides to learn how to install and use the library:
-
-- [Getting started](https://aiocamedomotic.readthedocs.io/latest/getting_started.html)
-- [Usage examples](https://aiocamedomotic.readthedocs.io/latest/usage_examples.html)
-
-Once you are a bit more familiar with the library, you may want to explore the following
-resources too:
-
-- [API reference](https://aiocamedomotic.readthedocs.io/latest/api_reference.html)
-- [LLM-friendly docs](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms.txt)
-  (also available: [full version](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/llms-full.txt))
-- [What’s new (releases)](https://github.com/camedomotic-unofficial/aiocamedomotic/releases)
-- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md#development-roadmap)
-- [Security Policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md#security-policy)
-- [Contributing to Our Project](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md#contributing-to-our-project)
-
-### Acknowledgments
-
-Special thanks to Andrea Michielan for his foundational work with the
-[eti_domo](https://github.com/andrea-michielan/eti_domo) library, which greatly
-facilitated the initial development of this library. We also found great inspiration in
-the Home Assistant document
-[Building a Python library for an API](https://developers.home-assistant.io/docs/api_lib_index).
-
-## License
-
-This project is licensed under the Apache License 2.0. For more details, see the
-[LICENSE file](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/LICENSE)
-on GitHub.
-
-## Getting started
-
-This guide will walk you through the steps to quickly start using the CAME Domotic
-library in your projects. Before you begin, ensure you have:
-
-- Python 3.12, 3.13 or 3.14 installed on your system.
-- Access to a CAME Domotic server.
-
-### Installation
-
-Use [pip](https://pip.pypa.io/en/stable/) to install the latest version of the CAME
-Domotic library and its dependencies:
-
-```bash
-pip install aiocamedomotic
-```
-
-### Basic usage examples
-
-Here’s a simple example to demonstrate how to use the library to turn on or off a light:
+## Quickstart
 
 ```python
 import asyncio
@@ -97,146 +35,32 @@ async def main():
     async with await CameDomoticAPI.async_create(
         "192.168.x.x", "username", "password"
     ) as api:
-
-        # Get the server info
-        server_info = await api.async_get_server_info()
-        print(f"Keycode: {server_info.keycode}")
-
-        # Get the list of all the lights configured on the CAME Domotic server
         lights = await api.async_get_lights()
+        lamp = next((l for l in lights if l.name == "Kitchen lamp"), None)
+        if lamp:
+            await lamp.async_set_status(LightStatus.ON)
 
-        # Get a specific light by ID
-        bedroom_dimmable_lamp = next((l for l in lights if l.act_id == 33), None)
-
-        # Get a specific light by name
-        kitchen_lamp = next(
-            (l for l in lights if l.name == "My beautiful lamp"), None
-        )
-
-        # Ensure the light is found (dimmable)
-        if bedroom_dimmable_lamp:
-            # Turn the light on, setting the brightness to 50%
-            await bedroom_dimmable_lamp.async_set_status(LightStatus.ON, brightness=50)
-
-            # Turn the light off
-            await bedroom_dimmable_lamp.async_set_status(LightStatus.OFF)
-
-            # Turn the light on, leaving the brightness unchanged
-            await bedroom_dimmable_lamp.async_set_status(LightStatus.ON)
-
-        # Ensure the light is found
-        if kitchen_lamp:
-            # Turn the light on
-            await kitchen_lamp.async_set_status(LightStatus.ON)
-
-            # Turn the light off
-            await kitchen_lamp.async_set_status(LightStatus.OFF)
-
-# Run the main function
 asyncio.run(main())
 ```
 
-Let’s go step by step:
+## Docs
 
-1. **Creating a Server Instance**:
+- [Full documentation (llms-full.txt)](https://aiocamedomotic.readthedocs.io/latest/llms-full.txt): the
+  complete documentation in a single Markdown file (~44k
+  tokens) — getting started, usage examples for every device type, and the
+  full API reference
+- [Getting started](https://aiocamedomotic.readthedocs.io/latest/getting_started.html): installation and
+  a step-by-step first example
+- [Usage examples](https://aiocamedomotic.readthedocs.io/latest/usage_examples.html): task-oriented
+  examples for every supported device type and feature
+- [API reference](https://aiocamedomotic.readthedocs.io/latest/api_reference.html): reference for all
+  public classes and methods
 
-   First, import the `CameDomoticAPI` classes from the library and create a
-   `CameDomoticAPI` instance using the async factory method
-   `CameDomoticAPI.async_create`.
-   ```python
-   import asyncio
+## Optional
 
-   from aiocamedomotic import CameDomoticAPI
-   from aiocamedomotic.models import LightStatus
-
-   async def main():
-       async with await CameDomoticAPI.async_create(
-           "192.168.x.x", "username", "password"
-       ) as api:
-           ...
-   ```
-
-   This command will raise a `CameDomoticServerNotFoundError` exception if the server
-   is not found (typically, bad IP/hostname or other network issue). Notice that the
-   `CameDomoticAPI` class is an asynchronous context manager, so it must be used with
-   the `async with` statement.
-
-   #### NOTE
-   The session is *NOT* authenticated at this point: the library will
-   authenticate only when the first actual call to the server is made. In case the
-   provided credentials are not valid, a `CameDomoticAuthError` exception will be
-   raised at that time.
-2. **Getting the server info**:
-
-   You can retrieve the server info (keycode, serial number, etc.) by using the
-   awaitable method `api.async_get_server_info()`.
-   ```python
-   # Get the server info
-   server_info = await api.async_get_server_info()
-   print(f"Keycode: {server_info.keycode}")
-   ```
-
-   Since this is the first actual call to the server, the library will now authenticate:
-   if the provided credentials are not valid, a `CameDomoticAuthError` exception will
-   be raised.
-3. **Fetching the list of available lights**:
-
-   You can retrieve a list of all the lights configured on the CAME Domotic server
-   by using the awaitable method `api.async_get_lights()`.
-   ```python
-   # Get the list of all the lights configured on the CAME Domotic server
-   lights = await api.async_get_lights()
-   ```
-4. **Selecting a specific light**:
-
-   You can select a specific light, for example, by ID (`act_id` attribute) or display
-   name (`name` attribute):
-   ```python
-   # Get a specific light by ID
-   bedroom_dimmable_lamp = next((l for l in lights if l.act_id == 33), None)
-
-   # Get a specific light by name
-   kitchen_lamp = next(
-       (l for l in lights if l.name == "My beautiful lamp"), None
-   )
-   ```
-5. **Changing the status of a light**
-
-   Lights are controlled by the method `async_set_status`. You can turn a light on or
-   off by passing respectively the status `LightStatus.ON` or  `LightStatus.OFF` as
-   an argument. You can also set the brightness level of a dimmable light by passing the
-   optional `brightness` argument (range: 0-100).
-   ```python
-   # Ensure the light is found (dimmable)
-   if bedroom_dimmable_lamp:
-       # Turn the light on, setting the brightness to 50%
-       await bedroom_dimmable_lamp.async_set_status(LightStatus.ON, brightness=50)
-
-       # Turn the light off
-       await bedroom_dimmable_lamp.async_set_status(LightStatus.OFF)
-
-       # Turn the light on, leaving the brightness unchanged
-       await bedroom_dimmable_lamp.async_set_status(LightStatus.ON)
-
-   # Ensure the light is found
-   if kitchen_lamp:
-       # Turn the light on
-       await kitchen_lamp.async_set_status(LightStatus.ON)
-
-       # Turn the light off
-       await kitchen_lamp.async_set_status(LightStatus.OFF)
-   ```
-
-Congratulations! You’ve successfully used the CAME Domotic library to
-interact with your CAME Domotic server.
-
-### Exploring further
-
-- For more detailed examples see [Usage examples](#usage-examples).
-- To check the technical specifications see the [API Reference](#api-reference).
-
-Thank you for choosing the CAME Domotic library. Happy automating!
-
----
-
-For complete usage examples and full API reference, see [llms-full.txt](llms-full.txt).
+- [Source repository](https://github.com/camedomotic-unofficial/aiocamedomotic): GitHub repository, issues, and releases
+- [Development roadmap](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/ROADMAP.md): planned features
+- [Security policy](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/SECURITY.md): how to report
+  vulnerabilities
+- [Contributing guide](https://github.com/camedomotic-unofficial/aiocamedomotic/blob/main/CONTRIBUTING.md): how to
+  contribute to the project

--- a/scripts/build_llms_docs.py
+++ b/scripts/build_llms_docs.py
@@ -5,7 +5,12 @@ This script uses sphinx-markdown-builder to render the project's Sphinx
 documentation (including autodoc-resolved API reference) into Markdown,
 then assembles two LLM-optimized documentation files:
 
-  - llms.txt      : Summary (overview + getting started)
+  - llms.txt      : Curated index per the llms.txt spec (https://llmstxt.org):
+                   key facts, a minimal quickstart, and links to the full
+                   documentation. Authored in this script, not extracted
+                   from the Sphinx output — keep its content (especially the
+                   quickstart snippet) in sync with the docs when the public
+                   API changes.
   - llms-full.txt : Full reference (overview + getting started + usage
                    examples + complete API reference)
 
@@ -78,6 +83,34 @@ def read_section(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def strip_badges(content: str) -> str:
+    """Remove badge images (linked or bare), e.g. [![alt](img)](url)."""
+    content = re.sub(r"\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)", "", content)
+    content = re.sub(r"!\[[^\]]*\]\([^)]*badge[^)]*\)", "", content)
+    return content
+
+
+def convert_admonition_headings(content: str) -> str:
+    """Turn admonition headings (e.g. '#### NOTE') into bold inline labels.
+
+    sphinx-markdown-builder renders admonitions as headings, which pollute
+    the document outline; '**NOTE:**' keeps the emphasis without the noise.
+    Lines inside fenced code blocks are left untouched.
+    """
+    keywords = "NOTE|IMPORTANT|WARNING|TIP|HINT|CAUTION|ATTENTION|DANGER|ERROR|SEE ALSO"
+    pattern = re.compile(rf"^#{{2,6}}\s+({keywords})\s*$")
+    lines = content.split("\n")
+    result = []
+    in_code_block = False
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_code_block = not in_code_block
+        if not in_code_block:
+            line = pattern.sub(lambda m: f"**{m.group(1)}:**", line)
+        result.append(line)
+    return "\n".join(result)
+
+
 def clean_markdown(content: str) -> str:
     """Clean up sphinx-markdown-builder output artifacts."""
     # Remove empty anchor references like []() or [](...)
@@ -97,6 +130,12 @@ def clean_markdown(content: str) -> str:
         content,
         flags=re.MULTILINE,
     )
+    # Turn admonition headings into bold labels (after the autodoc NOTE
+    # removal above, which matches on the heading form)
+    content = convert_admonition_headings(content)
+    # Strip trailing whitespace (matches the repo's pre-commit policy, so
+    # generated files don't churn against locally committed ones)
+    content = re.sub(r"[ \t]+\n", "\n", content)
     # Normalize multiple consecutive blank lines to two
     content = re.sub(r"\n{3,}", "\n\n", content)
     return content.strip()
@@ -145,9 +184,18 @@ def fix_internal_links(content: str) -> str:
 
 
 def extract_overview(index_content: str) -> str:
-    """Extract the overview content from index.md, removing toctree/nav/contents."""
-    # Cut off everything from the "Contents" section onward (toctree + nav links)
-    content = re.split(r'<a id="contents"></a>', index_content, maxsplit=1)[0]
+    """Extract the overview content from index.md, keeping only what informs
+    an LLM: the intro and the key features.
+
+    Everything from "Quick Start" onward (doc navigation links,
+    acknowledgments, license section, toctree) is dropped: navigation is
+    pointless inside a single self-contained file, and the intro already
+    states the license.
+    """
+    content = re.split(r'<a id="quick-start"></a>', index_content, maxsplit=1)[0]
+    # Rename the marketing-style "Welcome!" heading to a descriptive one
+    content = re.sub(r"^# Welcome!\s*$", "# Overview", content, flags=re.MULTILINE)
+    content = strip_badges(content)
     # Remove anchor tags like <a id="welcome"></a>
     content = re.sub(r'<a id="[^"]*"></a>\s*', "", content)
     return content
@@ -162,25 +210,83 @@ def build_header() -> str:
     )
 
 
-def assemble_llms_md(overview: str, getting_started: str) -> str:
-    """Assemble the summary llms.txt file."""
-    parts = [
-        build_header(),
-        "",
-        overview,
-        "",
-        getting_started,
-        "",
-        "---",
-        "",
-        "For complete usage examples and full API reference, see "
-        "[llms-full.txt](llms-full.txt).",
-        "",
-    ]
-    content = "\n".join(parts)
-    content = fix_internal_links(content)
-    content = clean_markdown(content)
-    return content + "\n"
+DOCS_BASE_URL = "https://aiocamedomotic.readthedocs.io/latest"
+REPO_URL = "https://github.com/camedomotic-unofficial/aiocamedomotic"
+
+QUICKSTART_EXAMPLE = """```python
+import asyncio
+
+from aiocamedomotic import CameDomoticAPI
+from aiocamedomotic.models import LightStatus
+
+async def main():
+    async with await CameDomoticAPI.async_create(
+        "192.168.x.x", "username", "password"
+    ) as api:
+        lights = await api.async_get_lights()
+        lamp = next((l for l in lights if l.name == "Kitchen lamp"), None)
+        if lamp:
+            await lamp.async_set_status(LightStatus.ON)
+
+asyncio.run(main())
+```"""
+
+
+def assemble_llms_md(full_content: str) -> str:
+    """Assemble the llms.txt index file (see https://llmstxt.org).
+
+    Content is curated here rather than extracted from the Sphinx output;
+    ``full_content`` is only used to report the size of llms-full.txt.
+    """
+    full_tokens_approx = round(len(full_content) / 4 / 1000)
+    return f"""{build_header()}
+Key facts:
+
+- Install with `pip install aiocamedomotic`. Requires Python 3.12, 3.13, or 3.14.
+- Built on asyncio and aiohttp; every public method is async and prefixed
+  with `async_`.
+- Entry point: `CameDomoticAPI.async_create(host, username, password)`, used
+  as an async context manager.
+- Authentication is lazy: login happens on the first server call, not at
+  client creation. Sessions are kept alive and renewed automatically.
+- Supported device types: lights (on/off, dimmable, RGB), openings (covers),
+  scenarios, thermoregulation zones, analog sensors, digital inputs, analog
+  inputs, relays, timers, energy meters, loads control, and map pages.
+  Server users can be managed too.
+- Real-time device updates are available via long polling
+  (`api.async_get_updates()`) with typed update classes.
+- All exceptions inherit from `CameDomoticError`:
+  `CameDomoticServerNotFoundError` (host unreachable), `CameDomoticAuthError`
+  (bad credentials), `CameDomoticServerError` (other server errors).
+- Unofficial library, not affiliated with or endorsed by CAME.
+  Apache 2.0 license.
+
+## Quickstart
+
+{QUICKSTART_EXAMPLE}
+
+## Docs
+
+- [Full documentation (llms-full.txt)]({DOCS_BASE_URL}/llms-full.txt): the
+  complete documentation in a single Markdown file (~{full_tokens_approx}k
+  tokens) — getting started, usage examples for every device type, and the
+  full API reference
+- [Getting started]({DOCS_BASE_URL}/getting_started.html): installation and
+  a step-by-step first example
+- [Usage examples]({DOCS_BASE_URL}/usage_examples.html): task-oriented
+  examples for every supported device type and feature
+- [API reference]({DOCS_BASE_URL}/api_reference.html): reference for all
+  public classes and methods
+
+## Optional
+
+- [Source repository]({REPO_URL}): GitHub repository, issues, and releases
+- [Development roadmap]({REPO_URL}/blob/main/ROADMAP.md): planned features
+- [Security policy]({REPO_URL}/blob/main/SECURITY.md): how to report
+  vulnerabilities
+- [Contributing guide]({REPO_URL}/blob/main/CONTRIBUTING.md): how to
+  contribute to the project
+"""
 
 
 def assemble_llms_full_md(
@@ -259,17 +365,17 @@ def main():
     # Assemble output files
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    llms_path = args.output_dir / "llms.txt"
-    llms_content = assemble_llms_md(overview, getting_started)
-    llms_path.write_text(llms_content, encoding="utf-8")
-    print(f"Written: {llms_path} ({len(llms_content)} bytes)")
-
     llms_full_path = args.output_dir / "llms-full.txt"
     llms_full_content = assemble_llms_full_md(
         overview, getting_started, usage_examples, api_reference
     )
     llms_full_path.write_text(llms_full_content, encoding="utf-8")
     print(f"Written: {llms_full_path} ({len(llms_full_content)} bytes)")
+
+    llms_path = args.output_dir / "llms.txt"
+    llms_content = assemble_llms_md(llms_full_content)
+    llms_path.write_text(llms_content, encoding="utf-8")
+    print(f"Written: {llms_path} ({len(llms_content)} bytes)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Rework `llms.txt` into an [llmstxt.org](https://llmstxt.org)-style index: key facts, a minimal quickstart, and links to `llms-full.txt` and the docs pages (10.4 KB → 2.9 KB, ~750 tokens)
- De-noise the generated LLM docs: strip badges, acknowledgments, and the license section; convert admonition headings (`#### NOTE`/`IMPORTANT`/`WARNING`) into bold inline labels so they no longer pollute the document outline
- Strip trailing whitespace in generated output so the files match the repo pre-commit policy and don't churn against committed copies
- Serve `llms.txt` and `llms-full.txt` at the Read the Docs site root via `html_extra_path`, enabling the conventional `…readthedocs.io/latest/llms.txt` lookup
- Point the README LLM-docs links to the Read the Docs URLs (they will resolve after this merges and RTD rebuilds)

The generation pipeline (`build-llms-docs.yml` → auto-PR) is unchanged; only `scripts/build_llms_docs.py` output is affected.

## Test plan

- `ruff format --check`, `ruff check`, `pylint` clean on the script
- Full `sphinx-build` (markdown + html) succeeds; verified both llms files are copied to the built HTML site root
- Generator re-run is idempotent (no diff on second run)