### PR TITLE
chore: bump docs dependencies to latest and align with poetry group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     labels:
       - "chore"
 
+  # Docs build dependencies (requirements.in + pip-compiled requirements.txt),
+  # used by Read the Docs and the LLM docs generation workflow
+  - package-ecosystem: "pip"
+    directory: "/docs/source"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "chore"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,3 +63,30 @@ html_extra_path = ["../../llms.txt", "../../llms-full.txt"]
 # -- Options for Markdown output -----------------------------------------------
 markdown_anchor_sections = True
 markdown_anchor_signatures = True
+
+
+def setup(app):
+    """Register handlers for node types sphinx-markdown-builder can't render.
+
+    Without these, the builder logs "unknown node type" and silently drops
+    the node and all its content: the keyword-only ``*`` marker in autodoc
+    signatures (wrapped in an abbreviation node since Sphinx 8.2) and the
+    body of ``danger``/``tip`` admonitions would disappear from llms*.txt.
+    The handlers are no-ops so the builder descends into the children and
+    renders their text; admonitions additionally get a bold label, matching
+    how the LLM docs render the natively supported admonition types.
+    """
+    from docutils import nodes
+
+    def _noop(self, node):
+        pass
+
+    def _labelled(label):
+        def visit(self, node):
+            node.insert(0, nodes.paragraph("", "", nodes.strong(text=f"{label}:")))
+
+        return visit
+
+    app.add_node(nodes.abbreviation, override=True, markdown=(_noop, _noop))
+    app.add_node(nodes.danger, override=True, markdown=(_labelled("DANGER"), _noop))
+    app.add_node(nodes.tip, override=True, markdown=(_labelled("TIP"), _noop))

--- a/docs/source/requirements.in
+++ b/docs/source/requirements.in
@@ -1,4 +1,4 @@
-sphinx==7.3.7
-sphinx_rtd_theme==2.0.0
-readthedocs-sphinx-search==0.3.2
-sphinx-markdown-builder==0.6.9
+sphinx>=9.1
+sphinx_rtd_theme>=3.1
+readthedocs-sphinx-search>=0.3.2
+sphinx-markdown-builder>=0.6.10

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -4,47 +4,49 @@
 #
 #    pip-compile --output-file=docs/source/requirements.txt docs/source/requirements.in
 #
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+babel==2.18.0
     # via sphinx
-certifi==2025.1.31
+certifi==2026.6.17
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.9
     # via requests
-docutils==0.20.1
+docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-markdown-builder
     #   sphinx-rtd-theme
-idna==3.15
+idna==3.18
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
-packaging==24.2
+packaging==26.2
     # via sphinx
 pygments==2.20.0
     # via sphinx
 readthedocs-sphinx-search==0.3.2
-    # via -r requirements.in
-requests==2.33.0
+    # via -r docs/source/requirements.in
+requests==2.34.2
     # via sphinx
-snowballstemmer==2.2.0
+roman-numerals==4.1.0
     # via sphinx
-sphinx==7.3.7
+snowballstemmer==3.1.1
+    # via sphinx
+sphinx==9.1.0
     # via
-    #   -r requirements.in
+    #   -r docs/source/requirements.in
     #   sphinx-markdown-builder
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-markdown-builder==0.6.9
-    # via -r requirements.in
-sphinx-rtd-theme==2.0.0
-    # via -r requirements.in
+sphinx-markdown-builder==0.6.10
+    # via -r docs/source/requirements.in
+sphinx-rtd-theme==3.1.0
+    # via -r docs/source/requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,6 +22,11 @@ or supported by [CAME](https://www.came.com/). It may not be compatible with all
 CAME Domotic systems. While this library is stable and publicly released, it comes
 with no guarantees. Use at your own risk.
 
+**DANGER:**
+
+This library is not intended for use in critical systems, such as security or
+life-support systems. Always use official and supported tools for such applications.
+
 ### Key Features
 
 - **Simplicity**: Easy interaction with domotic entities.
@@ -2024,6 +2029,21 @@ Setting `aiocamedomotic` to `WARNING` and
 `aiocamedomotic.traffic` to `DEBUG` is a valid configuration —
 you will see only the HTTP traffic, without the library’s internal
 debug messages.
+
+**TIP:**
+
+To write the traffic log to a **file** for later analysis, add a
+dedicated `FileHandler`. Use `propagate = False` if you want the
+traffic to go *only* to the file and not to the console:
+
+```python
+import logging
+
+traffic_logger = logging.getLogger("aiocamedomotic.traffic")
+traffic_logger.setLevel(logging.DEBUG)
+traffic_logger.addHandler(logging.FileHandler("came_traffic.log"))
+traffic_logger.propagate = False  # file only, no console output
+```
 
 **SEE ALSO:**
 For full API details, see the [API Reference](#api-reference).

--- a/poetry.lock
+++ b/poetry.lock
@@ -2461,4 +2461,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c8188acab77c47c5fe9a24a078acdfa906394848fedde1924fd0c3f6110e9eab"
+content-hash = "753467243c780f0b163dd9724269c68c3c33b2ab0bd5e705c072d94c82975814"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ mypy = '>=1.19.1,<3.0.0'
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-sphinx = ">=7.2.6,<10.0.0"
-sphinx_rtd_theme = ">=2,<4"
+sphinx = ">=9.1,<10.0.0"
+sphinx_rtd_theme = ">=3.1,<4"
 readthedocs-sphinx-search = "^0.3.2"
 jinja2 = "^3.1.6"
-sphinx-markdown-builder = "^0.6.9"
+sphinx-markdown-builder = "^0.6.10"
 pygments = ">=2.20.0,<3.0.0"
 
 


### PR DESCRIPTION
## Summary

- **Bump the pinned docs build dependencies to latest**: Sphinx 7.3.7 → 9.1.0, sphinx-markdown-builder 0.6.9 → 0.6.10, sphinx-rtd-theme 2.0.0 → 3.1.0. `requirements.in` now holds lower bounds; pip-compile pins the resolved set in `requirements.txt`.
- **Align the poetry `docs` group** constraints with the pins, so local builds, CI, and Read the Docs all resolve the same Sphinx (previously local resolved 9.1.0 while CI/RTD were pinned to 7.3.7, producing different generated output — see #392).
- **Fix rendering regressions/losses in the markdown builder** via node handlers in `conf.py`:
  - Sphinx ≥8.2 wraps the keyword-only `*` signature marker in an `abbreviation` node that sphinx-markdown-builder drops ("unknown node type"), corrupting autodoc signatures — now rendered correctly (verified on 8.2.3, 9.0, 9.1).
  - `danger` and `tip` admonitions were silently dropped from the LLM docs on **all** Sphinx versions — their content is now rendered with bold `**DANGER:**`/`**TIP:**` labels, consistent with the other admonitions.
- **Regenerate `llms-full.txt`**: the only diff is the recovered content (critical-systems disclaimer, traffic-logging tip). Generated with the exact pinned environment, so the auto-update workflow should find no further diff.
- **Add a Dependabot entry for `/docs/source`** (pip, monthly) so these pins stay current automatically.

## Test plan

- Markdown build with pinned env: zero "unknown node type" warnings, keyword-only `*` markers present in signatures
- HTML build with Sphinx 9.1.0 + sphinx-rtd-theme 3.1.0 succeeds; `llms*.txt` copied to site root via `html_extra_path`
- `poetry lock` + `poetry install --with docs` clean; local env matches CI pins exactly
- pre-commit (ruff, mypy, bandit, yaml checks) passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent warning against using the library in critical systems.
  * Added guidance and an example for writing anonymized traffic logs to a file.
  * Improved generated documentation output so admonitions and abbreviations are preserved correctly.

* **Chores**
  * Updated documentation tooling and related package versions.
  * Added monthly automated checks for documentation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->