### PR TITLE
fix: support awning, venetian blind, and gate opening types

### DIFF
--- a/aiocamedomotic/models/opening.py
+++ b/aiocamedomotic/models/opening.py
@@ -49,17 +49,16 @@ class OpeningType(Enum):
 
     Allowed values are:
         - SHUTTER (0)
+        - AWNING (1)
+        - VENETIAN_BLIND (2)
+        - GATE (3)
     """
 
     SHUTTER = 0
+    AWNING = 1
+    VENETIAN_BLIND = 2
+    GATE = 3
     UNKNOWN = -1
-
-
-## Other types as guessed by AI chatbot, not tested yet.
-## If uncommented, update the docstring above and the unit test too.
-#    AWNING = 1
-#    VENETIAN_BLIND = 2
-#    GATE = 3
 
 
 @dataclass

--- a/tests/aiocamedomotic/conftest.py
+++ b/tests/aiocamedomotic/conftest.py
@@ -215,10 +215,10 @@ def opening_data_awning_opening():
         "open_act_id": 20,
         "close_act_id": 21,
         "floor_ind": 1,
-        "name": "Patio Shutter",
+        "name": "Patio Awning",
         "room_ind": 3,
         "status": 1,  # Corresponds to OpeningStatus.OPENING
-        "type": 0,  # OpeningType.SHUTTER
+        "type": 1,  # Corresponds to OpeningType.AWNING
         "partial": [],
     }
 

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -1707,6 +1707,9 @@ class TestOpening:
 
     def test_type_enum(self):
         assert OpeningType.SHUTTER.value == 0
+        assert OpeningType.AWNING.value == 1
+        assert OpeningType.VENETIAN_BLIND.value == 2
+        assert OpeningType.GATE.value == 3
         assert OpeningType.UNKNOWN.value == -1
 
     def test_unknown_type(self, auth_instance):
@@ -1767,7 +1770,7 @@ class TestOpening:
         assert opening.close_act_id == opening_data_awning_opening["close_act_id"]
         assert opening.name == opening_data_awning_opening["name"]
         assert opening.status == OpeningStatus.OPENING
-        assert opening.type == OpeningType.SHUTTER
+        assert opening.type == OpeningType.AWNING
         assert opening.floor_ind == opening_data_awning_opening["floor_ind"]
         assert opening.room_ind == opening_data_awning_opening["room_ind"]
         assert len(opening.partial_positions) == 0


### PR DESCRIPTION
## Summary

The CAME API reports motorised retractable awnings (OH/MA modules) with `type: 1`, which `OpeningType` did not recognise: every read of `Opening.type` logged an *"Unknown opening type '1' encountered…"* warning, flooding the logs of downstream consumers such as Home Assistant (see the HA community thread linked in the issue).

- Add `AWNING = 1`, `VENETIAN_BLIND = 2`, and `GATE = 3` to `OpeningType`. `AWNING` is confirmed on real hardware by the issue reporter; the other two values were previously tracked in the code as commented-out guesses and are now promoted.
- Update the `opening_data_awning_opening` fixture, which was labelled "awning" but actually described a shutter (`type: 0`), to use `type: 1`.
- Extend the enum unit test to cover the new values.

No documentation changes needed: the usage examples only reference `OpeningStatus`, and the API reference picks up the updated docstring via `automodule`.

Fixes #399

## Test plan

- `pytest` (764 passed, 28 skipped)
- `ruff format --check`, `ruff check`, `mypy`, `pylint` all clean
- Runtime smoke check: `Opening` instances with `type` 0–3 resolve to the expected `OpeningType` member with no warnings logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying awnings, Venetian blinds, and gates as distinct opening types alongside shutters.
  - Updated opening classifications with explicit type values while retaining support for unknown types.

- **Bug Fixes**
  - Corrected awning opening data so it is recognized as an awning rather than a shutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->