### PR TITLE
feat: activate scenarios and control relays by name

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,11 @@ insights. We look forward to growing this library together with our users and co
 - **Lights management**: List and control lights (on/off, dimmer brightness, RGB color).
 - **Openings management**: List and control shutters/blinds (open, close, stop, slat
   tilting).
-- **Scenarios management**: List available scenarios and trigger their activation.
+- **Scenarios management**: List available scenarios and trigger their activation, either
+  by scenario object or directly by name (`scenario_activation_by_name_req`) without
+  fetching the list first. Creating and deleting scenarios remains under
+  [Future considerations](#future-considerations), pending a real capture of the
+  registration flow.
 - **Thermoregulation (full control)**: List thermoregulation zones with their current
   state; set target temperature, operating mode (OFF, MANUAL, AUTO, JOLLY), and fan speed
   (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via `thermo_zone_config_req`.
@@ -44,8 +48,8 @@ insights. We look forward to growing this library together with our users and co
   fraction of `max_power`) can be read, edited, and written back through the typed,
   immutable `LoadsCtrlProfile` API (verified against a real plant).
 - **Generic relays**: List and control simple on/off relay actuators via
-  `relays_list_req` and `relay_activation_req` (documented API, not yet verified against
-  a real server).
+  `relays_list_req` and `relay_activation_req`, either by relay object or directly by
+  name (documented API, not yet verified against a real server).
 - **Digital inputs (read-only)**: List binary sensors (door contacts, motion sensors, etc.)
   via `digitalin_list_req`. Each digital input exposes its current state and attributes.
   Real-time updates are supported via `DigitalInputUpdate`.
@@ -90,7 +94,10 @@ The following features are known from reverse-engineered sources (API_reference.
 API_MANUAL.md) but have not been verified with real traffic captures. They may be
 considered for future development once real-world testing is possible:
 
-- **Scenario management**: Create and delete scenarios (beyond the current list/activate).
+- **Scenario management**: Create and delete scenarios (beyond the current
+  list/activate/activate-by-name).
+- **Energy statistics**: Historical energy statistics per meter (`energy_stat_req`) and
+  plant-wide measurement history reset (`energy_reset_store_req`) — deferred until real traffic captures are available.
 - **Audio system**: Sound zone and source management (entirely unverified).
 - **Security system**: Area/scenario management and alarm control (entirely unverified).
 - **Infrastructure improvements**: Automated keep-alive scheduling, per-actuator scope

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -41,6 +41,7 @@ from .models import (
     Opening,
     PlantTopology,
     Relay,
+    RelayStatus,
     Room,
     Scenario,
     ServerInfo,
@@ -768,6 +769,76 @@ class CameDomoticAPI:
         scenarios_list = json_response.get("array", []) or []
         LOGGER.info("Retrieved %d scenario(s)", len(scenarios_list))
         return [Scenario(scenario_data, self.auth) for scenario_data in scenarios_list]
+
+    async def async_activate_scenario_by_name(self, name: str) -> None:
+        """Activate a scenario by its name, without fetching the scenario list.
+
+        This is the plant-level counterpart to
+        :meth:`~aiocamedomotic.models.Scenario.async_activate`: the server
+        resolves the scenario by ``name`` itself, so there is no need to first
+        download the scenarios via :meth:`async_get_scenarios` just to trigger
+        one — which is precisely the value of this command.
+
+        The match is performed **server-side on the exact name**. Case
+        sensitivity has not been verified, so pass the exact name as returned
+        by :meth:`async_get_scenarios` (the ``name`` property of each
+        :class:`~aiocamedomotic.models.Scenario`). If no scenario matches, the
+        server silently performs no activation.
+
+        Args:
+            name (str): The exact name of the scenario to activate.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Activating scenario by name '%s'", name)
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_ACTIVATION_BY_NAME.value,
+            "name": name,
+        }
+        await self.auth.async_send_command(payload)
+        LOGGER.info("Scenario '%s' activated by name", name)
+
+    async def async_set_relay_status_by_name(
+        self, name: str, status: RelayStatus
+    ) -> None:
+        """Set a relay's status by its name, without fetching the relay list.
+
+        This is the plant-level counterpart to
+        :meth:`~aiocamedomotic.models.Relay.async_set_status`: the server
+        resolves the relay by ``name`` itself, so there is no need to first
+        download the relays via :meth:`async_get_relays`.
+
+        The match is performed **server-side on the exact name**; pass the
+        exact name as returned by :meth:`async_get_relays` (the ``name``
+        property of each :class:`~aiocamedomotic.models.Relay`).
+
+        .. note::
+            The by-name variant has **not** been verified against a live
+            plant (our relays have never been tested against a real server;
+            see the ROADMAP). Behaviour may differ across firmware versions.
+
+        Args:
+            name (str): The exact name of the relay to control.
+            status (RelayStatus): Desired relay status (ON or OFF).
+
+        Raises:
+            ValueError: If ``status`` is ``RelayStatus.UNKNOWN``.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if status == RelayStatus.UNKNOWN:
+            raise ValueError("Cannot set relay status to UNKNOWN")
+
+        LOGGER.debug("Setting relay '%s' status to %s by name", name, status.name)
+        payload = {
+            "cmd_name": _CommandName.RELAY_ACTIVATION.value,
+            "name": name,
+            "wanted_status": status.value,
+        }
+        await self.auth.async_send_command(payload)
+        LOGGER.info("Relay '%s' set to %s by name", name, status.name)
 
     async def async_get_timers(self) -> list[Timer]:
         """Get the list of all timers defined on the server.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -180,6 +180,7 @@ class _CommandName(Enum):
     LIGHT_SWITCH = "light_switch_req"
     OPENING_MOVE = "opening_move_req"
     SCENARIO_ACTIVATION = "scenario_activation_req"
+    SCENARIO_ACTIVATION_BY_NAME = "scenario_activation_by_name_req"
     RELAY_ACTIVATION = "relay_activation_req"
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
     THERMO_SEASON = "thermo_season_req"

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -29,6 +29,7 @@ from aiocamedomotic.models import (
     Opening,
     PlantTopology,
     Relay,
+    RelayStatus,
     Room,
     Scenario,
     ServerInfo,
@@ -1059,6 +1060,96 @@ class TestAPIScenarios:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_scenarios()
+
+
+class TestAPIActivationByName:
+    # generic_reply ack, validated by the standard ack-check (no response_command)
+    GENERIC_REPLY = {
+        "cseq": 5,
+        "cmd_name": "generic_reply",
+        "sl_data_ack_reason": 0,
+    }
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_activate_scenario_by_name(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = self.GENERIC_REPLY
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_activate_scenario_by_name("Movie night")
+
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["cmd_name"] == "scenario_activation_by_name_req"
+        assert call_payload["name"] == "Movie night"
+        # The standard ack-check suffices: no response_command is passed.
+        assert "response_command" not in mock_send_command.call_args.kwargs
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_activate_scenario_by_name_auth_error_propagates(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = CameDomoticAuthError("bad auth")
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticAuthError):
+            await api.async_activate_scenario_by_name("Movie night")
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_activate_scenario_by_name_server_error_propagates(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = CameDomoticServerError("server down")
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticServerError):
+            await api.async_activate_scenario_by_name("Movie night")
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_set_relay_status_by_name_on(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = self.GENERIC_REPLY
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_set_relay_status_by_name("Garden pump", RelayStatus.ON)
+
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["cmd_name"] == "relay_activation_req"
+        assert call_payload["name"] == "Garden pump"
+        assert call_payload["wanted_status"] == 1
+        assert "response_command" not in mock_send_command.call_args.kwargs
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_set_relay_status_by_name_off(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = self.GENERIC_REPLY
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_set_relay_status_by_name("Garden pump", RelayStatus.OFF)
+
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["wanted_status"] == 0
+
+    async def test_set_relay_status_by_name_unknown_raises(self, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        with pytest.raises(ValueError, match="Cannot set relay status to UNKNOWN"):
+            await api.async_set_relay_status_by_name("Garden pump", RelayStatus.UNKNOWN)
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_set_relay_status_by_name_auth_error_propagates(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = CameDomoticAuthError("bad auth")
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticAuthError):
+            await api.async_set_relay_status_by_name("Garden pump", RelayStatus.ON)
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_set_relay_status_by_name_server_error_propagates(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = CameDomoticServerError("server down")
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticServerError):
+            await api.async_set_relay_status_by_name("Garden pump", RelayStatus.ON)
 
 
 class TestAPITimers:


### PR DESCRIPTION
## Summary

Implements **PR 1** of the Den901 feature plan (`local_only/implementation_plan_den901.md`): plant-level "by name" activation commands that resolve the target server-side, so callers don't need to fetch the full entity list first.

- **`async_activate_scenario_by_name(name)`** — sends `scenario_activation_by_name_req`. Verified live against a real plant on 2026-07-17: the server replies with a `generic_reply` (`sl_data_ack_reason: 0`), so the standard ack-check suffices (no `response_command`), followed by the usual `scenario_status_ind` already handled by `ScenarioUpdate`. Matching is server-side on the **exact** name.
- **`async_set_relay_status_by_name(name, status)`** — sends `relay_activation_req` with `name` + `wanted_status`. Documented behaviour only; **not** verified against a live plant (noted in the docstring and ROADMAP). Rejects `RelayStatus.UNKNOWN` with `ValueError`.

## Other changes

- `const.py`: new `_CommandName.SCENARIO_ACTIVATION_BY_NAME`.
- `ROADMAP.md`: scenarios note activation-by-name (create/delete still under Future considerations); generic relays note the by-name variant; new **Energy statistics** entry under Future considerations.

## Tests

New `TestAPIActivationByName` class covering scenario/relay success (payload shape, no `response_command`), the `UNKNOWN` guard, and auth/server error propagation.

Quality gate: `ruff format`/`ruff check`, `pylint --disable=W,R,C`, `mypy`, and `pytest` all pass — 100% coverage (772 passed, 28 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activate scenarios directly by their exact name without first loading the scenario list.
  * Set relay status directly by relay name, including turning relays on or off.
  * Invalid or unknown relay statuses are rejected with a clear validation error.

* **Documentation**
  * Updated the roadmap with planned scenario creation/deletion and energy statistics capabilities, including historical meter data and plant-wide measurement resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->