### PR TITLE
feat: timed relay activation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,9 @@ insights. We look forward to growing this library together with our users and co
   immutable `LoadsCtrlProfile` API (verified against a real plant).
 - **Generic relays**: List and control simple on/off relay actuators via
   `relays_list_req` and `relay_activation_req`, either by relay object or directly by
-  name (documented API, not yet verified against a real server).
+  name. Timed activation (switch on for a fixed interval, then auto-off) is available via
+  `relay_timed_req`; the interval unit is undocumented (likely seconds) and not yet
+  verified against a real server.
 - **Digital inputs (read-only)**: List binary sensors (door contacts, motion sensors, etc.)
   via `digitalin_list_req`. Each digital input exposes its current state and attributes.
   Real-time updates are supported via `DigitalInputUpdate`.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -182,6 +182,7 @@ class _CommandName(Enum):
     SCENARIO_ACTIVATION = "scenario_activation_req"
     SCENARIO_ACTIVATION_BY_NAME = "scenario_activation_by_name_req"
     RELAY_ACTIVATION = "relay_activation_req"
+    RELAY_TIMED = "relay_timed_req"
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
     THERMO_SEASON = "thermo_season_req"
     TIMERS_ENABLE = "timers_enable_req"

--- a/aiocamedomotic/models/relay.py
+++ b/aiocamedomotic/models/relay.py
@@ -10,9 +10,10 @@ controlled remotely. They provide binary state control without brightness,
 color, or position capabilities.
 
 .. note::
-    The relay API commands (``relays_list_req``, ``relay_activation_req``)
-    are documented in the CAME API specification but have not been verified
-    against a real server. Behaviour may differ across firmware versions.
+    The relay API commands (``relays_list_req``, ``relay_activation_req``,
+    ``relay_timed_req``) are documented in the CAME API specification but have
+    not been verified against a real server. Behaviour may differ across
+    firmware versions.
 """
 
 from __future__ import annotations
@@ -145,4 +146,52 @@ class Relay(CameEntity):
             self.name,
             self.act_id,
             status.name,
+        )
+
+    async def async_set_status_timed(self, interval: int) -> None:
+        """Activate the relay for a timed interval.
+
+        The relay switches ON and the server automatically switches it back OFF
+        once ``interval`` elapses. The subsequent OFF transition is reported
+        asynchronously by the server via the usual status update, so this
+        method does not update the local :attr:`status` (which momentarily
+        becomes ON).
+
+        Args:
+            interval (int): Activation time, passed verbatim to the server.
+                Must be greater than 0.
+
+                .. warning::
+                    The unit of ``interval`` is **not documented** by the CAME
+                    API nor by the reference implementations this method is
+                    based on, and has not been verified against a real server.
+                    Callers should confirm the
+                    behaviour on their own plant before relying on a precise
+                    duration.
+
+        Raises:
+            ValueError: If ``interval`` is not greater than 0.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if interval <= 0:
+            raise ValueError(f"interval must be greater than 0, got {interval}")
+
+        await self.auth.async_get_valid_client_id()
+        LOGGER.debug(
+            "User authenticated, sending 'relay_timed_req' command to the API."
+        )
+
+        payload = {
+            "act_id": self.act_id,
+            "cmd_name": _CommandName.RELAY_TIMED.value,
+            "interval": interval,
+        }
+        await self.auth.async_send_command(payload)
+
+        LOGGER.info(
+            "Relay '%s' (ID: %s) activated for a timed interval of %d",
+            self.name,
+            self.act_id,
+            interval,
         )

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -2049,6 +2049,71 @@ class TestRelay:
             Relay(relay_data, {"fake": "auth"})
 
 
+class TestRelayTimed:
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_timed(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        relay_data_off,
+        auth_instance,
+    ):
+        relay = Relay(relay_data_off, auth_instance)
+
+        await relay.async_set_status_timed(30)
+
+        mock_send_command.assert_called_once()
+        payload = mock_send_command.call_args[0][0]
+        assert payload["act_id"] == relay_data_off["act_id"]
+        assert payload["cmd_name"] == "relay_timed_req"
+        assert payload["interval"] == 30
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("interval", [0, -1, -30])
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_timed_invalid_interval_raises(
+        self,
+        mock_send_command,
+        interval,
+        relay_data_on,
+        auth_instance,
+    ):
+        relay = Relay(relay_data_on, auth_instance)
+
+        with pytest.raises(ValueError, match="interval must be greater than 0"):
+            await relay.async_set_status_timed(interval)
+
+        mock_send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_status_timed_server_error_propagates(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        relay_data_off,
+        auth_instance,
+    ):
+        mock_send_command.side_effect = CameDomoticServerError("boom")
+        relay = Relay(relay_data_off, auth_instance)
+
+        with pytest.raises(CameDomoticServerError, match="boom"):
+            await relay.async_set_status_timed(30)
+
+
 class TestFloor:
     def test_initialization(self):
         floor_data = {"floor_ind": 1, "name": "Ground Floor"}


### PR DESCRIPTION
## Summary

Implements **PR 2** of `local_only/implementation_plan_den901.md` — timed relay activation.

Adds `Relay.async_set_status_timed(interval)`, which switches a relay ON for a fixed interval; the server then auto-switches it back OFF (the OFF transition arrives asynchronously via the usual status update, so the local status is left untouched). The command maps to `relay_timed_req` with payload `{"cmd_name": "relay_timed_req", "act_id": ..., "interval": ...}` and validates `interval > 0` with `ValueError`.

## Verification

Live testing was not possible: `async_get_relays()` on the real plant (192.168.1.3) returns **0 relays**, so there is nothing to actuate safely. Implemented per the Den901 reference (`came_manager.relay_timed`), with the standard "not verified against a live plant" note.

**Interval unit:** deliberately left undocumented. The Den901 reference passes a bare `interval` with no unit, and the official CAME API docs don't cover `relay_timed_req` at all. The value is passed through verbatim and the docstring flags the unit as unverified rather than asserting "seconds".

## Changes

- `const.py`: `_CommandName.RELAY_TIMED = "relay_timed_req"`
- `models/relay.py`: `async_set_status_timed()` + module docstring note
- `ROADMAP.md`: Generic relays entry mentions timed activation
- `tests/…/test_models.py`: new `TestRelayTimed` (success, invalid interval, server error)

## Quality gate

`ruff format`/`check`, `pylint --disable=W,R,C`, `mypy` all clean; `pytest` 777 passed / 28 skipped, 100% coverage.