### PR TITLE
feat: acknowledge digital inputs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,9 +52,10 @@ insights. We look forward to growing this library together with our users and co
   name. Timed activation (switch on for a fixed interval, then auto-off) is available via
   `relay_timed_req`; the interval unit is undocumented (likely seconds) and not yet
   verified against a real server.
-- **Digital inputs (read-only)**: List binary sensors (door contacts, motion sensors, etc.)
+- **Digital inputs**: List binary sensors (door contacts, motion sensors, etc.)
   via `digitalin_list_req`. Each digital input exposes its current state and attributes.
-  Real-time updates are supported via `DigitalInputUpdate`.
+  Real-time updates are supported via `DigitalInputUpdate`. Inputs that latch a technical
+  alarm or signalling counter can be acknowledged via `digitalin_ack_req`.
 - **Analog inputs (read-only)**: List standalone analog sensors (hygrometers,
   thermometers, barometers) via `analogin_list_req`, independent of the
   thermoregulation sensors.

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -188,6 +188,7 @@ class _CommandName(Enum):
     TIMERS_ENABLE = "timers_enable_req"
     TIMERS_ENABLE_DAY = "timers_enable_day_req"
     TIMERS_SET = "timers_set_req"
+    DIGITALIN_ACK = "digitalin_ack_req"
     # Loadsctrl set commands: the server ack carries no cmd_name, so there is
     # no _CommandNameResponse counterpart for these two.
     LOADSCTRL_RELAY_SET = "loadsctrl_relay_set_req"
@@ -220,6 +221,7 @@ class _CommandNameResponse(Enum):
     # Status
     STATUS_UPDATE = "status_update_resp"
     # Actions
+    DIGITALIN_ACK = "digitalin_ack_resp"
 
 
 class _TopologicScope(Enum):

--- a/aiocamedomotic/models/digital_input.py
+++ b/aiocamedomotic/models/digital_input.py
@@ -5,9 +5,10 @@
 CAME Domotic digital input (binary sensor) entity models.
 
 This module implements the classes for working with digital inputs in a CAME
-Domotic system. Digital inputs represent read-only binary sensors such as
-physical buttons, contact sensors, and similar devices. They provide properties
-to access device attributes but do not support control commands.
+Domotic system. Digital inputs represent binary sensors such as physical
+buttons, contact sensors, and similar devices. They are read-only for their
+state, but inputs that raise a technical alarm or keep a signalling counter can
+be acknowledged via :meth:`DigitalInput.async_ack`.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from enum import Enum
 from typing import Any
 
 from ..auth import Auth
+from ..const import _CommandName, _CommandNameResponse
 from ..utils import (
     LOGGER,
     EntityValidator,
@@ -53,8 +55,10 @@ class DigitalInput(CameEntity):
     """
     Digital input (binary sensor) entity in the CameDomotic API.
 
-    Digital inputs are read-only devices that report their binary state
-    (ACTIVE/IDLE). They cannot be controlled remotely.
+    Digital inputs report their binary state (ACTIVE/IDLE) and cannot be
+    switched remotely. Inputs that raise a technical alarm or keep a
+    signalling counter can, however, be acknowledged via
+    :meth:`async_ack`.
 
     Raises:
         ValueError: If ``name`` or ``act_id`` keys are missing from the
@@ -148,3 +152,40 @@ class DigitalInput(CameEntity):
         Returns ``0`` if the digital input has never been triggered.
         """
         return self.raw_data.get("utc_time", 0)
+
+    async def async_ack(self) -> None:
+        """Acknowledge the digital input.
+
+        Some digital inputs raise a technical alarm or keep a signalling
+        counter that stays latched until it is acknowledged. This command
+        clears that pending signalling for the input; it has no effect on
+        inputs that do not track one.
+
+        The command is keyed on :attr:`addr` (not :attr:`act_id`). The
+        server replies with ``digitalin_ack_resp`` echoing the input record,
+        which is validated.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self.auth.async_get_valid_client_id()
+        LOGGER.debug(
+            "User authenticated, sending 'digitalin_ack_req' command to the API."
+        )
+
+        payload = {
+            "cmd_name": _CommandName.DIGITALIN_ACK.value,
+            "addr": self.addr,
+        }
+        await self.auth.async_send_command(
+            payload,
+            response_command=_CommandNameResponse.DIGITALIN_ACK.value,
+        )
+
+        LOGGER.info(
+            "Digital input '%s' (ID: %s, addr: %s) acknowledged",
+            self.name,
+            self.act_id,
+            self.addr,
+        )

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -2974,6 +2974,98 @@ class TestDigitalInput:
         assert di.type == DigitalInputType.UNKNOWN
 
 
+class TestDigitalInputAck:
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_ack(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        digital_input_data_with_status,
+        auth_instance,
+    ):
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+
+        await di.async_ack()
+
+        mock_send_command.assert_called_once()
+        payload = mock_send_command.call_args[0][0]
+        assert payload == {"cmd_name": "digitalin_ack_req", "addr": di.addr}
+        # The command is keyed on addr, not act_id.
+        assert payload["addr"] == 201
+        assert (
+            mock_send_command.call_args.kwargs["response_command"]
+            == "digitalin_ack_resp"
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_ack_default_addr(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        auth_instance,
+    ):
+        # An input without an explicit addr falls back to 0.
+        di = DigitalInput({"act_id": 5, "name": "Minimal Input"}, auth_instance)
+
+        await di.async_ack()
+
+        payload = mock_send_command.call_args[0][0]
+        assert payload["addr"] == 0
+
+    @pytest.mark.asyncio
+    @patch.object(
+        Auth,
+        "async_get_valid_client_id",
+        new_callable=AsyncMock,
+        return_value="my_session_id",
+    )
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_ack_server_error_propagates(
+        self,
+        mock_send_command,
+        mock_get_client_id,  # pylint: disable=unused-argument
+        digital_input_data_with_status,
+        auth_instance,
+    ):
+        mock_send_command.side_effect = CameDomoticServerError("boom")
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+
+        with pytest.raises(CameDomoticServerError, match="boom"):
+            await di.async_ack()
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_get_valid_client_id", new_callable=AsyncMock)
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_ack_auth_error_propagates(
+        self,
+        mock_send_command,
+        mock_get_client_id,
+        digital_input_data_with_status,
+        auth_instance,
+    ):
+        mock_get_client_id.side_effect = CameDomoticAuthError("auth failed")
+        di = DigitalInput(digital_input_data_with_status, auth_instance)
+
+        with pytest.raises(CameDomoticAuthError, match="auth failed"):
+            await di.async_ack()
+
+        mock_send_command.assert_not_called()
+
+
 class TestCamera:
     def test_init_valid_data(self, auth_instance, camera_data_flash):
         camera = Camera(camera_data_flash, auth_instance)


### PR DESCRIPTION
## Summary

Adds the ability to **acknowledge digital inputs** — inputs that latch a technical alarm or keep a signalling counter that stays pending until cleared.

- `DigitalInput.async_ack()` sends `digitalin_ack_req` keyed on the input's `addr` (not `act_id`).
- The server reply `digitalin_ack_resp` is validated (standard ACK check, `sl_data_ack_reason == 0`).
- New `_CommandName.DIGITALIN_ACK` / `_CommandNameResponse.DIGITALIN_ACK` constants.
- ROADMAP: the *Digital inputs* entry is no longer read-only — it documents the acknowledge command.

## Verification

Behaviour was verified **live against a real plant**: the request/response shape and the `digitalin_ack_resp` command name were confirmed, and the command is harmless (the server echoes the input record with `ack: 1`).

## Tests

New `TestDigitalInputAck` class: successful ack (payload + validated response command), default `addr` fallback, and auth/server error propagation. Full suite green at 100% coverage (781 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)