### PR TITLE
feat: add irrigation domain support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,12 @@ insights. We look forward to growing this library together with our users and co
 - **Analog inputs (read-only)**: List standalone analog sensors (hygrometers,
   thermometers, barometers) via `analogin_list_req`, independent of the
   thermoregulation sensors.
+- **Irrigation (experimental)**: List irrigation sectors via `irrigation_list_req`,
+  each exposing its schedule state (enabled, running, days, water percentage,
+  start/end windows, sprinklers). Force a watering cycle on/off (`irrigation_force_req`,
+  a toggle) and enable/disable a sector's weekly schedule (`irrigation_set_req`). This
+  feature is **not verified against a live plant** — it is implemented from the behaviour
+  of an existing, field-tested third-party integration.
 - **Cameras (TVCC, read-only)**: List IP cameras with their stream URIs.
 - **Maps (read-only)**: Retrieve floor-plan map pages with positioned device elements
   via `map_descr_req`.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -34,6 +34,7 @@ from .models import (
     DigitalInput,
     EnergyMeter,
     Floor,
+    Irrigation,
     Light,
     LoadsCtrlMeter,
     LoadsCtrlRelay,
@@ -895,6 +896,40 @@ class CameDomoticAPI:
         timers_list = json_response.get("array", []) or []
         LOGGER.info("Retrieved %d timer(s)", len(timers_list))
         return [Timer(timer_data, self.auth) for timer_data in timers_list]
+
+    async def async_get_irrigation_sectors(self) -> list[Irrigation]:
+        """Get the list of all irrigation sectors defined on the server.
+
+        Irrigation sectors are schedulable watering zones. Each can be forced
+        on/off and its weekly schedule enabled/disabled.
+
+        .. note::
+            Irrigation support is **not verified against a live plant**. See
+            :class:`~aiocamedomotic.models.Irrigation` for details.
+
+        Returns:
+            list[Irrigation]: List of irrigation sectors.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching irrigation sectors list")
+        payload = {
+            "cmd_name": _CommandName.IRRIGATION_LIST.value,
+            "detailed": 1,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.IRRIGATION_LIST.value
+        )
+
+        irrigation_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d irrigation sector(s)", len(irrigation_list))
+        return [
+            Irrigation(irrigation_data, self.auth)
+            for irrigation_data in irrigation_list
+        ]
 
     async def async_get_topology(self) -> PlantTopology:
         """Get the complete plant topology (floors and rooms).

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -169,6 +169,7 @@ class _CommandName(Enum):
     DIGITALIN_LIST = "digitalin_list_req"
     ANALOGIN_LIST = "analogin_list_req"
     TIMERS_LIST = "timers_list_req"
+    IRRIGATION_LIST = "irrigation_list_req"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_req"
     # Nested lists (topology-aware)
     NESTED_LIGHT_LIST = "nested_light_list_req"
@@ -189,6 +190,12 @@ class _CommandName(Enum):
     TIMERS_ENABLE_DAY = "timers_enable_day_req"
     TIMERS_SET = "timers_set_req"
     DIGITALIN_ACK = "digitalin_ack_req"
+    # Irrigation: the force/set/detail acks carry no reliable resp cmd_name
+    # (a generic_reply is returned), so only the list request has a
+    # _CommandNameResponse counterpart.
+    IRRIGATION_DETAIL = "irrigation_detail_req"
+    IRRIGATION_FORCE = "irrigation_force_req"
+    IRRIGATION_SET = "irrigation_set_req"
     # Loadsctrl set commands: the server ack carries no cmd_name, so there is
     # no _CommandNameResponse counterpart for these two.
     LOADSCTRL_RELAY_SET = "loadsctrl_relay_set_req"
@@ -216,6 +223,7 @@ class _CommandNameResponse(Enum):
     DIGITALIN_LIST = "digitalin_list_resp"
     ANALOGIN_LIST = "analogin_list_resp"
     TIMERS_LIST = "timers_list_resp"
+    IRRIGATION_LIST = "irrigation_list_resp"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_resp"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
     MAP_DESCR = "map_descr_resp"

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -29,6 +29,7 @@ from .digital_input import (  # noqa: F401
     DigitalInputType,
 )
 from .energy_meter import EnergyMeter, EnergyMeterType  # noqa: F401
+from .irrigation import Irrigation  # noqa: F401
 from .light import Light, LightStatus, LightType  # noqa: F401
 from .loads_ctrl import (  # noqa: F401
     LoadsCtrlMeter,
@@ -93,6 +94,7 @@ __all__ = [
     "EnergyMeterType",
     "EnergyMeterUpdate",
     "Floor",
+    "Irrigation",
     "Light",
     "LightStatus",
     "LightType",

--- a/aiocamedomotic/models/irrigation.py
+++ b/aiocamedomotic/models/irrigation.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CAME Domotic irrigation entity models and control functionality.
+
+This module implements the classes for working with irrigation sectors in a
+CAME Domotic system. An irrigation sector is a schedulable watering zone with
+its own weekly programme, water percentage, start/end windows, and sprinkler
+configuration. It can be forced on/off and its schedule can be
+enabled/disabled.
+
+.. note::
+    Irrigation support is **not verified against a live plant**: the feature is
+    absent from the reference plant's ``feature_list_resp``. The data model and
+    commands are implemented from the behaviour of an existing, field-tested
+    third-party integration. The exact shape of the ``start``, ``end``, and
+    ``sprinklers`` fields may vary between firmware versions; their raw values
+    are exposed as-is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..auth import Auth
+from ..const import _CommandName
+from ..utils import (
+    LOGGER,
+    EntityValidator,
+)
+from .base import CameEntity
+
+
+@dataclass
+class Irrigation(CameEntity):
+    """Irrigation sector entity in the CameDomotic API.
+
+    Represents a single schedulable watering zone. Sectors are keyed on their
+    ``id`` (not ``act_id``). They can be forced on/off via :meth:`async_force`
+    and their weekly schedule enabled/disabled via :meth:`async_set_enabled`.
+
+    .. note::
+        Not verified against a live plant — see the module docstring.
+
+    Raises:
+        ValueError: If the ``id`` key is missing from the input data, or the
+            auth argument is not an instance of the expected ``Auth`` class.
+    """
+
+    raw_data: dict[str, Any]
+    auth: Auth
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["id"],
+            typed_keys={"id": int},
+        )
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def id(self) -> int:
+        """Unique irrigation sector identifier."""
+        return self.raw_data["id"]
+
+    @property
+    def name(self) -> str | None:
+        """Display name of the sector, or ``None`` if the server omits it."""
+        return self.raw_data.get("name")
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the sector's weekly schedule is enabled."""
+        return bool(self.raw_data.get("enabled", 0))
+
+    @property
+    def status(self) -> int:
+        """Raw running status reported by the server (``0`` when absent)."""
+        return self.raw_data.get("status", 0)
+
+    @property
+    def forced(self) -> bool:
+        """Whether the sector is currently in a forced watering cycle."""
+        return bool(self.raw_data.get("forced", 0))
+
+    @property
+    def days(self) -> int:
+        """Bitmask of active days (bit 0 = Monday, ..., bit 6 = Sunday)."""
+        return self.raw_data.get("days", 0)
+
+    @property
+    def perc(self) -> int:
+        """Water percentage configured for the sector (``0`` when absent)."""
+        return self.raw_data.get("perc", 0)
+
+    @property
+    def start(self) -> Any:
+        """Raw start-window value, or ``None`` if absent.
+
+        The exact shape is firmware-dependent and passed through unchanged.
+        """
+        return self.raw_data.get("start")
+
+    @property
+    def end(self) -> Any:
+        """Raw end-window value, or ``None`` if absent.
+
+        The exact shape is firmware-dependent and passed through unchanged.
+        """
+        return self.raw_data.get("end")
+
+    @property
+    def sprinklers(self) -> Any:
+        """Raw sprinkler configuration, or ``None`` if absent.
+
+        The exact shape is firmware-dependent and passed through unchanged.
+        """
+        return self.raw_data.get("sprinklers")
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the sector is currently watering.
+
+        ``True`` when the sector reports a non-zero ``status`` or is in a
+        forced cycle.
+        """
+        return bool(self.raw_data.get("status") or self.raw_data.get("forced"))
+
+    # ------------------------------------------------------------------
+    # Control methods
+    # ------------------------------------------------------------------
+
+    async def async_force(self) -> None:
+        """Toggle a forced watering cycle for this sector.
+
+        The command is a **toggle**: sending it starts a forced cycle if the
+        sector is idle, and stops the running cycle otherwise. Callers that
+        want explicit on/off semantics should check :attr:`is_running` before
+        issuing the command.
+
+        The server replies with a generic acknowledgement (no dedicated
+        response command), so only the standard ack is validated.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug(
+            "Sending cmd 'irrigation_force_req' for sector '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )
+        await self.auth.async_send_command(
+            {
+                "cmd_name": _CommandName.IRRIGATION_FORCE.value,
+                "id": self.id,
+            }
+        )
+        LOGGER.info(
+            "Irrigation sector '%s' (ID: %s) force toggled.", self.name, self.id
+        )
+
+    async def async_set_enabled(self, enabled: bool) -> None:
+        """Enable or disable the sector's weekly schedule.
+
+        Args:
+            enabled: ``True`` to enable the schedule, ``False`` to disable it.
+
+        The server replies with a generic acknowledgement (no dedicated
+        response command), so only the standard ack is validated.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        value = 1 if enabled else 0
+        LOGGER.debug(
+            "Sending cmd 'irrigation_set_req' for sector '%s' (ID: %s), enabled=%d.",
+            self.name,
+            self.id,
+            value,
+        )
+        await self.auth.async_send_command(
+            {
+                "cmd_name": _CommandName.IRRIGATION_SET.value,
+                "id": self.id,
+                "enabled": value,
+            }
+        )
+        self.raw_data["enabled"] = value
+        LOGGER.info(
+            "Irrigation sector '%s' (ID: %s) schedule %s.",
+            self.name,
+            self.id,
+            "enabled" if enabled else "disabled",
+        )

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -24,6 +24,7 @@ from aiocamedomotic.models import (
     Camera,
     DigitalInput,
     Floor,
+    Irrigation,
     Light,
     MapPage,
     Opening,
@@ -1325,6 +1326,132 @@ class TestAPITimers:
 
         with pytest.raises(ValueError, match="Data is missing required keys: name"):
             await api.async_get_timers()
+
+
+# Inline mock: irrigation is absent from the reference plant, so the response
+# is modelled on the field-tested third-party integration's data shape and is
+# not part of mocked_responses.py.
+IRRIGATION_LIST_RESP_INLINE = {
+    "array": [
+        {
+            "id": 1,
+            "name": "Front lawn",
+            "enabled": 1,
+            "status": 0,
+            "forced": 0,
+            "days": 42,
+            "perc": 80,
+            "start": {"hour": 6, "min": 0},
+            "end": {"hour": 6, "min": 30},
+            "sprinklers": [1, 2, 3],
+        },
+        {
+            "id": 2,
+            "name": "Back garden",
+            "enabled": 0,
+            "status": 1,
+            "forced": 0,
+            "days": 0,
+            "perc": 100,
+            "start": {"hour": 20, "min": 15},
+            "end": {"hour": 20, "min": 45},
+            "sprinklers": [4],
+        },
+    ],
+    "cmd_name": "irrigation_list_resp",
+    "cseq": 5,
+    "sl_data_ack_reason": 0,
+}
+
+
+class TestAPIIrrigation:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = IRRIGATION_LIST_RESP_INLINE
+
+        sectors = await api.async_get_irrigation_sectors()
+
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "irrigation_list_req", "detailed": 1},
+            response_command="irrigation_list_resp",
+        )
+        assert len(sectors) == 2
+        assert isinstance(sectors[0], Irrigation)
+        assert isinstance(sectors[1], Irrigation)
+        assert sectors[0].id == 1
+        assert sectors[0].name == "Front lawn"
+        assert sectors[0].enabled is True
+        assert sectors[0].is_running is False
+        assert sectors[1].id == 2
+        assert sectors[1].enabled is False
+        assert sectors[1].is_running is True
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "irrigation_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        sectors = await api.async_get_irrigation_sectors()
+        assert sectors == []
+        assert isinstance(sectors, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "irrigation_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        sectors = await api.async_get_irrigation_sectors()
+        assert sectors == []
+        assert isinstance(sectors, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors_missing_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [{"name": "No id", "enabled": 1}],
+            "cmd_name": "irrigation_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            await api.async_get_irrigation_sectors()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors_auth_error(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.side_effect = CameDomoticAuthError("auth failed")
+
+        with pytest.raises(CameDomoticAuthError):
+            await api.async_get_irrigation_sectors()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_irrigation_sectors_server_error(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.side_effect = CameDomoticServerError("server failed")
+
+        with pytest.raises(CameDomoticServerError):
+            await api.async_get_irrigation_sectors()
 
 
 class TestAPIUpdates:

--- a/tests/aiocamedomotic/test_irrigation.py
+++ b/tests/aiocamedomotic/test_irrigation.py
@@ -113,7 +113,6 @@ class TestIrrigation:
 
 
 class TestIrrigationControl:
-    @pytest.mark.asyncio
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
     async def test_async_force(self, mock_send_command, auth_instance):
         irrigation = Irrigation(IRRIGATION_DATA, auth_instance)
@@ -127,7 +126,6 @@ class TestIrrigationControl:
             }
         )
 
-    @pytest.mark.asyncio
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
     async def test_async_set_enabled_true(self, mock_send_command, auth_instance):
         irrigation = Irrigation({"id": 3, "enabled": 0}, auth_instance)
@@ -144,7 +142,6 @@ class TestIrrigationControl:
         )
         assert irrigation.enabled is True
 
-    @pytest.mark.asyncio
     @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
     async def test_async_set_enabled_false(self, mock_send_command, auth_instance):
         irrigation = Irrigation({"id": 3, "enabled": 1}, auth_instance)

--- a/tests/aiocamedomotic/test_irrigation.py
+++ b/tests/aiocamedomotic/test_irrigation.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aiocamedomotic import Auth
+from aiocamedomotic.models.irrigation import Irrigation
+
+# Irrigation is absent from the reference plant, so all data below is inline
+# and modelled on the field-tested third-party integration's data shape.
+IRRIGATION_DATA = {
+    "id": 7,
+    "name": "Front lawn",
+    "enabled": 1,
+    "status": 0,
+    "forced": 0,
+    "days": 42,
+    "perc": 80,
+    "start": {"hour": 6, "min": 0},
+    "end": {"hour": 6, "min": 30},
+    "sprinklers": [1, 2, 3],
+}
+
+
+class TestIrrigation:
+    def test_init_valid(self, auth_instance):
+        irrigation = Irrigation(IRRIGATION_DATA, auth_instance)
+        assert irrigation.raw_data == IRRIGATION_DATA
+        assert irrigation.auth == auth_instance
+
+    def test_missing_id_raises(self, auth_instance):
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            Irrigation({"name": "No id"}, auth_instance)
+
+    def test_id_wrong_type_raises(self, auth_instance):
+        with pytest.raises(ValueError):
+            Irrigation({"id": "not-an-int"}, auth_instance)
+
+    def test_none_data_raises(self, auth_instance):
+        with pytest.raises((ValueError, TypeError)):
+            Irrigation(None, auth_instance)  # type: ignore[arg-type]
+
+    def test_invalid_auth_raises(self):
+        with pytest.raises(ValueError, match="'auth' must be an instance of Auth"):
+            Irrigation(IRRIGATION_DATA, "not_auth")  # type: ignore[arg-type]
+
+    def test_properties(self, auth_instance):
+        irrigation = Irrigation(IRRIGATION_DATA, auth_instance)
+        assert irrigation.id == 7
+        assert irrigation.name == "Front lawn"
+        assert irrigation.enabled is True
+        assert irrigation.status == 0
+        assert irrigation.forced is False
+        assert irrigation.days == 42
+        assert irrigation.perc == 80
+        assert irrigation.start == {"hour": 6, "min": 0}
+        assert irrigation.end == {"hour": 6, "min": 30}
+        assert irrigation.sprinklers == [1, 2, 3]
+
+    def test_name_missing_returns_none(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.name is None
+
+    def test_enabled_defaults_false(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.enabled is False
+
+    def test_status_defaults_zero(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.status == 0
+
+    def test_forced_defaults_false(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.forced is False
+
+    def test_days_defaults_zero(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.days == 0
+
+    def test_perc_defaults_zero(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.perc == 0
+
+    def test_optional_fields_default_none(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.start is None
+        assert irrigation.end is None
+        assert irrigation.sprinklers is None
+
+    def test_is_running_idle(self, auth_instance):
+        irrigation = Irrigation({"id": 1, "status": 0, "forced": 0}, auth_instance)
+        assert irrigation.is_running is False
+
+    def test_is_running_by_status(self, auth_instance):
+        irrigation = Irrigation({"id": 1, "status": 1, "forced": 0}, auth_instance)
+        assert irrigation.is_running is True
+
+    def test_is_running_by_forced(self, auth_instance):
+        irrigation = Irrigation({"id": 1, "status": 0, "forced": 1}, auth_instance)
+        assert irrigation.is_running is True
+        assert irrigation.forced is True
+
+    def test_is_running_missing_fields(self, auth_instance):
+        irrigation = Irrigation({"id": 1}, auth_instance)
+        assert irrigation.is_running is False
+
+
+class TestIrrigationControl:
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_force(self, mock_send_command, auth_instance):
+        irrigation = Irrigation(IRRIGATION_DATA, auth_instance)
+
+        await irrigation.async_force()
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "irrigation_force_req",
+                "id": 7,
+            }
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_enabled_true(self, mock_send_command, auth_instance):
+        irrigation = Irrigation({"id": 3, "enabled": 0}, auth_instance)
+        assert irrigation.enabled is False
+
+        await irrigation.async_set_enabled(True)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "irrigation_set_req",
+                "id": 3,
+                "enabled": 1,
+            }
+        )
+        assert irrigation.enabled is True
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_enabled_false(self, mock_send_command, auth_instance):
+        irrigation = Irrigation({"id": 3, "enabled": 1}, auth_instance)
+        assert irrigation.enabled is True
+
+        await irrigation.async_set_enabled(False)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "irrigation_set_req",
+                "id": 3,
+                "enabled": 0,
+            }
+        )
+        assert irrigation.enabled is False


### PR DESCRIPTION
## Summary

Implements **PR 5** of the Den901 integration plan (`local_only/implementation_plan_den901.md`): a new **irrigation** domain.

- **`const.py`**: new command names — `irrigation_list_req`/`irrigation_list_resp`, `irrigation_detail_req`, `irrigation_force_req`, `irrigation_set_req`.
- **`models/irrigation.py`**: new `Irrigation` entity (dataclass over `raw_data`) with typed properties (`id`, `name`, `enabled`, `status`, `forced`, `days`, `perc`, `start`, `end`, `sprinklers`) plus a derived `is_running`. Control methods `async_force()` (toggle a forced cycle) and `async_set_enabled(bool)` (enable/disable the weekly schedule).
- **`came_domotic_api.py`**: `async_get_irrigation_sectors()` (sends `irrigation_list_req` with `detailed: 1`).
- **`models/__init__.py`**: export `Irrigation`.
- **`ROADMAP.md`**: new *Irrigation (experimental)* entry under Current Features.
- **Tests**: new `tests/aiocamedomotic/test_irrigation.py` (`TestIrrigation`, `TestIrrigationControl`) and `TestAPIIrrigation` in `test_came_domotic_api.py`, with inline Den901-shaped mock data.

## Notes

- The feature is **absent from the reference plant's `feature_list_resp`**, so per the plan it is implemented from the behaviour of an existing, field-tested third-party integration and documented as **not verified against a live plant**. No live commands were issued.
- `force` is a **toggle**; on/off convenience logic is intentionally left to the caller (e.g. Home Assistant), as the plan specifies.
- The `force`/`set` responses carry no reliable `resp_command` (a generic reply is returned), so only the standard ack is validated — no `response_command` is passed. Only the list request has a `_CommandNameResponse` counterpart.

## Quality gates

- `ruff format` / `ruff check`: clean
- `pylint --disable=W,R,C`: 10.00/10
- `mypy`: no issues
- `pytest`: 813 passed, 28 skipped, **100% coverage**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental irrigation support.
  * View irrigation sectors, schedules, run status, watering state, and weekly schedule settings.
  * Force watering on or off.
  * Enable or disable weekly irrigation schedules.
* **Documentation**
  * Added irrigation capabilities and experimental-use notes to the roadmap.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->