### PR TITLE
feat: add sound zones domain support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,15 @@ insights. We look forward to growing this library together with our users and co
   a toggle) and enable/disable a sector's weekly schedule (`irrigation_set_req`). This
   feature is **not verified against a live plant** — it is implemented from the behaviour
   of an existing, field-tested third-party integration.
+- **Sound zones (experimental)**: List audio zones via `sound_room_list_req`, each
+  exposing its power state (standby), mute state, volume with its min/max range
+  (plus a normalized 0–1 volume level), and the available input sources (both the
+  array-based and the flat `source_N` firmware formats are normalized). Control
+  zones via `sound_switch_req` (on/off, mute, volume, source selection), send
+  advanced source commands via `suftif_cmd_req`, and refresh a single zone via
+  `sound_room_src_req`. This feature is **not verified against a live plant** — it
+  is implemented from the behaviour of an existing, field-tested third-party
+  integration.
 - **Cameras (TVCC, read-only)**: List IP cameras with their stream URIs.
 - **Maps (read-only)**: Retrieve floor-plan map pages with positioned device elements
   via `map_descr_req`.
@@ -109,7 +118,6 @@ considered for future development once real-world testing is possible:
   list/activate/activate-by-name).
 - **Energy statistics**: Historical energy statistics per meter (`energy_stat_req`) and
   plant-wide measurement history reset (`energy_reset_store_req`) — deferred until real traffic captures are available.
-- **Audio system**: Sound zone and source management (entirely unverified).
 - **Security system**: Area/scenario management and alarm control (entirely unverified).
 - **Infrastructure improvements**: Automated keep-alive scheduling, per-actuator scope
   queries, and connection resilience improvements.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -47,6 +47,7 @@ from .models import (
     Scenario,
     ServerDateTime,
     ServerInfo,
+    SoundZone,
     TerminalGroup,
     ThermoZone,
     ThermoZoneSeason,
@@ -930,6 +931,37 @@ class CameDomoticAPI:
             Irrigation(irrigation_data, self.auth)
             for irrigation_data in irrigation_list
         ]
+
+    async def async_get_sound_zones(self) -> list[SoundZone]:
+        """Get the list of all sound zones defined on the server.
+
+        Sound zones are audio output rooms. Each can be powered on/off,
+        muted, adjusted in volume, and switched between the available input
+        sources.
+
+        .. note::
+            Sound zone support is **not verified against a live plant**. See
+            :class:`~aiocamedomotic.models.SoundZone` for details.
+
+        Returns:
+            list[SoundZone]: List of sound zones.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Fetching sound zones list")
+        payload = {
+            "cmd_name": _CommandName.SOUND_ROOM_LIST.value,
+        }
+
+        json_response = await self.auth.async_send_command(
+            payload, response_command=_CommandNameResponse.SOUND_ROOM_LIST.value
+        )
+
+        zones_list = json_response.get("array", []) or []
+        LOGGER.info("Retrieved %d sound zone(s)", len(zones_list))
+        return [SoundZone(zone_data, self.auth) for zone_data in zones_list]
 
     async def async_get_topology(self) -> PlantTopology:
         """Get the complete plant topology (floors and rooms).

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -170,6 +170,7 @@ class _CommandName(Enum):
     ANALOGIN_LIST = "analogin_list_req"
     TIMERS_LIST = "timers_list_req"
     IRRIGATION_LIST = "irrigation_list_req"
+    SOUND_ROOM_LIST = "sound_room_list_req"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_req"
     # Nested lists (topology-aware)
     NESTED_LIGHT_LIST = "nested_light_list_req"
@@ -196,6 +197,12 @@ class _CommandName(Enum):
     IRRIGATION_DETAIL = "irrigation_detail_req"
     IRRIGATION_FORCE = "irrigation_force_req"
     IRRIGATION_SET = "irrigation_set_req"
+    # Sound zones: the switch/suftif acks carry no reliable resp cmd_name
+    # (a generic_reply is returned), so only the list and single-zone
+    # refresh requests have _CommandNameResponse counterparts.
+    SOUND_ROOM_SRC = "sound_room_src_req"
+    SOUND_SWITCH = "sound_switch_req"
+    SUFTIF_CMD = "suftif_cmd_req"
     # Loadsctrl set commands: the server ack carries no cmd_name, so there is
     # no _CommandNameResponse counterpart for these two.
     LOADSCTRL_RELAY_SET = "loadsctrl_relay_set_req"
@@ -224,6 +231,8 @@ class _CommandNameResponse(Enum):
     ANALOGIN_LIST = "analogin_list_resp"
     TIMERS_LIST = "timers_list_resp"
     IRRIGATION_LIST = "irrigation_list_resp"
+    SOUND_ROOM_LIST = "sound_room_list_resp"
+    SOUND_ROOM_SRC = "sound_room_src_resp"
     TVCC_CAMERAS_LIST = "tvcc_cameras_list_resp"
     TERMINALS_GROUPS_LIST = "terminals_groups_list_resp"
     MAP_DESCR = "map_descr_resp"

--- a/aiocamedomotic/models/__init__.py
+++ b/aiocamedomotic/models/__init__.py
@@ -48,6 +48,7 @@ from .profiles import (  # noqa: F401
 )
 from .relay import Relay, RelayStatus  # noqa: F401
 from .scenario import Scenario, ScenarioStatus  # noqa: F401
+from .sound_zone import SoundZone, SoundZoneAction  # noqa: F401
 from .thermo_zone import (  # noqa: F401
     AnalogSensor,
     AnalogSensorType,
@@ -124,6 +125,8 @@ __all__ = [
     "ServerDateTime",
     "ServerFeature",
     "ServerInfo",
+    "SoundZone",
+    "SoundZoneAction",
     "TerminalGroup",
     "ThermoProfile",
     "ThermoZone",

--- a/aiocamedomotic/models/sound_zone.py
+++ b/aiocamedomotic/models/sound_zone.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CAME Domotic sound zone entity models and control functionality.
+
+This module implements the classes for working with audio (sound) zones in a
+CAME Domotic system. A sound zone is an audio output room that can be powered
+on/off (standby), muted, adjusted in volume within a server-provided range,
+and switched between the available input sources.
+
+.. note::
+    Sound zone support is **not verified against a live plant**. The data model and
+    commands are implemented from the behaviour of an existing, field-tested
+    third-party integration. Depending on the firmware, the available sources
+    are reported either as a ``sources`` array or as flat ``source_N`` /
+    ``id_source_N`` fields; both formats are normalized by :attr:`SoundZone.sources`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ..auth import Auth
+from ..const import _CommandName, _CommandNameResponse
+from ..utils import (
+    LOGGER,
+    EntityValidator,
+)
+from .base import CameEntity
+
+# Values of the "standby" and "mute" flags in the sound zone data.
+_SOUND_STANDBY_ON = 1
+_SOUND_MUTE_ON = 1
+
+# Highest index scanned for the flat "source_N" fields format.
+_MAX_FLAT_SOURCES = 31
+
+# Keys of the server envelope that must not leak into the zone raw_data
+# when refreshing from a sound_room_src_resp payload.
+_PROTOCOL_KEYS = ("cmd_name", "cseq", "sl_data_ack_reason")
+
+
+class SoundZoneAction(Enum):
+    """Actions accepted by the ``sound_switch_req`` command.
+
+    Values:
+        - STANDBY ("standby"): power the zone on/off
+        - MUTE ("mute"): mute/unmute the zone
+        - VOLUME ("volume"): set the raw volume value
+        - SOURCE ("source"): select an input source by ID
+    """
+
+    STANDBY = "standby"
+    MUTE = "mute"
+    VOLUME = "volume"
+    SOURCE = "source"
+
+
+@dataclass
+class SoundZone(CameEntity):
+    """Sound zone entity in the CameDomotic API.
+
+    Represents a single audio zone. Zones are keyed on their ``id`` (not
+    ``act_id``). They can be powered on/off, muted, adjusted in volume, and
+    switched between the available input sources.
+
+    .. note::
+        Not verified against a live plant — see the module docstring.
+
+    Raises:
+        ValueError: If the ``id`` key is missing from the input data, or the
+            auth argument is not an instance of the expected ``Auth`` class.
+    """
+
+    raw_data: dict[str, Any]
+    auth: Auth
+
+    def __post_init__(self) -> None:
+        EntityValidator.validate_data(
+            self.raw_data,
+            required_keys=["id"],
+            typed_keys={"id": int},
+        )
+        # Basic type-safety on the auth argument
+        if not isinstance(self.auth, Auth):
+            raise ValueError(
+                f"'auth' must be an instance of Auth, got {type(self.auth).__name__}"
+            )
+
+    @property
+    def id(self) -> int:
+        """Unique sound zone identifier."""
+        return self.raw_data["id"]
+
+    @property
+    def name(self) -> str | None:
+        """Display name of the zone, or ``None`` if the server omits it."""
+        return self.raw_data.get("name")
+
+    @property
+    def is_on(self) -> bool:
+        """Whether the zone is powered on (i.e. not in standby)."""
+        return self.raw_data.get("standby") != _SOUND_STANDBY_ON
+
+    @property
+    def is_muted(self) -> bool:
+        """Whether the zone is muted."""
+        return self.raw_data.get("mute") == _SOUND_MUTE_ON
+
+    @property
+    def volume(self) -> int | None:
+        """Raw volume value reported by the server, or ``None`` if absent."""
+        return self.raw_data.get("volume")
+
+    @property
+    def min_volume(self) -> int | None:
+        """Lower bound of the raw volume range, or ``None`` if absent."""
+        return self.raw_data.get("min_volume")
+
+    @property
+    def max_volume(self) -> int | None:
+        """Upper bound of the raw volume range, or ``None`` if absent."""
+        return self.raw_data.get("max_volume")
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume normalized to the 0.0–1.0 range.
+
+        Returns ``None`` when the raw volume or its range is unknown, and
+        ``0.0`` when the server reports an empty range
+        (``max_volume == min_volume``). Values are clamped to 0.0–1.0.
+        """
+        volume = self.volume
+        min_volume = self.min_volume
+        max_volume = self.max_volume
+        if volume is None or min_volume is None or max_volume is None:
+            return None
+        if max_volume == min_volume:
+            return 0.0
+        return max(0.0, min(1.0, (volume - min_volume) / (max_volume - min_volume)))
+
+    @property
+    def source(self) -> str | None:
+        """Name of the currently selected source, or ``None`` if unknown."""
+        return self.raw_data.get("source_name") or self.raw_data.get("source")
+
+    @property
+    def sources(self) -> list[dict[str, Any]]:
+        """Available input sources, normalized to ``{"name", "id"}`` dicts.
+
+        Depending on the firmware, the server reports sources either as a
+        ``sources`` array (items carrying ``source`` or ``source_name`` plus
+        ``id``) or as flat ``source_N`` fields with an optional
+        ``id_source_N`` companion (defaulting to ``N - 1``). Both formats are
+        merged and deduplicated by ``(name, id)``.
+        """
+        sources: list[dict[str, Any]] = []
+        for src in self.raw_data.get("sources") or []:
+            name = src.get("source") or src.get("source_name")
+            sources.append({"name": name, "id": src.get("id")})
+
+        for index in range(1, _MAX_FLAT_SOURCES + 1):
+            name = self.raw_data.get(f"source_{index}")
+            if name is None:
+                continue
+            sources.append(
+                {
+                    "name": name,
+                    "id": self.raw_data.get(f"id_source_{index}", index - 1),
+                }
+            )
+
+        deduped: list[dict[str, Any]] = []
+        seen: set[tuple[Any, Any]] = set()
+        for src in sources:
+            key = (src["name"], src["id"])
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(src)
+        return deduped
+
+    # ------------------------------------------------------------------
+    # Control methods
+    # ------------------------------------------------------------------
+
+    async def _async_switch(self, action: SoundZoneAction, value: int) -> None:
+        """Send a ``sound_switch_req`` command for this zone.
+
+        The server replies with a generic acknowledgement (no dedicated
+        response command), so only the standard ack is validated.
+        """
+        LOGGER.debug(
+            "Sending cmd 'sound_switch_req' for zone '%s' (ID: %s), "
+            "action=%s, value=%s.",
+            self.name,
+            self.id,
+            action.value,
+            value,
+        )
+        await self.auth.async_send_command(
+            {
+                "cmd_name": _CommandName.SOUND_SWITCH.value,
+                "id": self.id,
+                "action": action.value,
+                "value": value,
+            }
+        )
+
+    async def async_turn_on(self) -> None:
+        """Power on the zone (leave standby).
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self._async_switch(SoundZoneAction.STANDBY, 0)
+        self.raw_data["standby"] = 0
+        LOGGER.info("Sound zone '%s' (ID: %s) turned on.", self.name, self.id)
+
+    async def async_turn_off(self) -> None:
+        """Put the zone in standby.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        await self._async_switch(SoundZoneAction.STANDBY, _SOUND_STANDBY_ON)
+        self.raw_data["standby"] = _SOUND_STANDBY_ON
+        LOGGER.info("Sound zone '%s' (ID: %s) turned off.", self.name, self.id)
+
+    async def async_set_mute(self, muted: bool) -> None:
+        """Mute or unmute the zone.
+
+        Args:
+            muted: ``True`` to mute the zone, ``False`` to unmute it.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        value = _SOUND_MUTE_ON if muted else 0
+        await self._async_switch(SoundZoneAction.MUTE, value)
+        self.raw_data["mute"] = value
+        LOGGER.info(
+            "Sound zone '%s' (ID: %s) %s.",
+            self.name,
+            self.id,
+            "muted" if muted else "unmuted",
+        )
+
+    async def async_set_volume_level(self, volume_level: float) -> None:
+        """Set the zone volume from a normalized 0.0–1.0 level.
+
+        The level is denormalized onto the server-provided
+        ``min_volume``/``max_volume`` range and rounded to the nearest raw
+        value.
+
+        Args:
+            volume_level: Desired volume in the 0.0–1.0 range.
+
+        Raises:
+            ValueError: If ``volume_level`` is outside the 0.0–1.0 range, or
+                the zone does not report its volume range.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if not 0.0 <= volume_level <= 1.0:
+            raise ValueError(
+                f"volume_level must be between 0.0 and 1.0, got {volume_level}"
+            )
+        min_volume = self.min_volume
+        max_volume = self.max_volume
+        if min_volume is None or max_volume is None:
+            raise ValueError(
+                "Cannot set the volume: the zone does not report its "
+                "min_volume/max_volume range"
+            )
+        value = round(min_volume + (max_volume - min_volume) * volume_level)
+        await self._async_switch(SoundZoneAction.VOLUME, value)
+        self.raw_data["volume"] = value
+        LOGGER.info(
+            "Sound zone '%s' (ID: %s) volume set to %s.", self.name, self.id, value
+        )
+
+    async def async_select_source(self, source_name: str) -> None:
+        """Select an input source by name.
+
+        The name is matched against the normalized :attr:`sources` list and
+        the corresponding source ID is sent to the server.
+
+        Args:
+            source_name: Name of the source to select, as reported in
+                :attr:`sources`.
+
+        Raises:
+            ValueError: If no source with the given name (and a valid ID) is
+                available on this zone.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        for src in self.sources:
+            source_id = src["id"]
+            if src["name"] == source_name and source_id is not None:
+                await self._async_switch(SoundZoneAction.SOURCE, source_id)
+                self.raw_data["source_name"] = source_name
+                self.raw_data["source_id"] = source_id
+                LOGGER.info(
+                    "Sound zone '%s' (ID: %s) switched to source '%s'.",
+                    self.name,
+                    self.id,
+                    source_name,
+                )
+                return
+        raise ValueError(
+            f"Source '{source_name}' is not available on sound zone "
+            f"'{self.name}' (ID: {self.id})"
+        )
+
+    async def async_send_source_command(self, source_id: int, action: str) -> None:
+        """Send an advanced command to an audio source (``suftif_cmd_req``).
+
+        This is a low-level primitive: the set of supported actions depends on
+        the source device (e.g. tuner or media player transport commands) and
+        is passed through to the server unchanged.
+
+        Args:
+            source_id: ID of the target source, as reported in :attr:`sources`.
+            action: Action string understood by the source device.
+
+        The server replies with a generic acknowledgement (no dedicated
+        response command), so only the standard ack is validated.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug(
+            "Sending cmd 'suftif_cmd_req' for source ID %s, action=%s.",
+            source_id,
+            action,
+        )
+        await self.auth.async_send_command(
+            {
+                "cmd_name": _CommandName.SUFTIF_CMD.value,
+                "id": source_id,
+                "action": action,
+            }
+        )
+        LOGGER.info("Source ID %s sent action '%s'.", source_id, action)
+
+    async def async_refresh(self) -> None:
+        """Refresh this zone's state from the server (``sound_room_src_req``).
+
+        Fetches the current state of this single zone and merges it into
+        :attr:`raw_data`. The update is applied only if the response refers to
+        this zone's ID.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Refreshing sound zone '%s' (ID: %s) state.", self.name, self.id)
+        response = await self.auth.async_send_command(
+            {
+                "cmd_name": _CommandName.SOUND_ROOM_SRC.value,
+                "value": self.id,
+            },
+            response_command=_CommandNameResponse.SOUND_ROOM_SRC.value,
+        )
+        if response.get("id") != self.id:
+            LOGGER.warning(
+                "Ignoring sound zone refresh for ID %s: response refers to ID %s.",
+                self.id,
+                response.get("id"),
+            )
+            return
+        self.raw_data.update(
+            {k: v for k, v in response.items() if k not in _PROTOCOL_KEYS}
+        )
+        LOGGER.info("Sound zone '%s' (ID: %s) state refreshed.", self.name, self.id)

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -35,6 +35,7 @@ from aiocamedomotic.models import (
     Scenario,
     ServerDateTime,
     ServerInfo,
+    SoundZone,
     TerminalGroup,
     ThermoZone,
     ThermoZoneSeason,
@@ -1452,6 +1453,143 @@ class TestAPIIrrigation:
 
         with pytest.raises(CameDomoticServerError):
             await api.async_get_irrigation_sectors()
+
+
+# Inline mock: sound zones are absent from the reference plant, so the response
+# is modelled on the field-tested third-party integration's data shape and is
+# not part of mocked_responses.py. The two zones cover both source formats
+# (array-based and flat source_N fields).
+SOUND_ROOM_LIST_RESP_INLINE = {
+    "array": [
+        {
+            "id": 1,
+            "name": "Living room",
+            "standby": 0,
+            "mute": 0,
+            "volume": 25,
+            "min_volume": 0,
+            "max_volume": 50,
+            "source_name": "Radio",
+            "sources": [
+                {"source": "Radio", "id": 0},
+                {"source_name": "Aux", "id": 1},
+            ],
+        },
+        {
+            "id": 2,
+            "name": "Kitchen",
+            "standby": 1,
+            "mute": 1,
+            "volume": 10,
+            "min_volume": 5,
+            "max_volume": 35,
+            "source": "Radio",
+            "source_1": "Radio",
+            "source_2": "Aux",
+            "id_source_2": 7,
+        },
+    ],
+    "cmd_name": "sound_room_list_resp",
+    "cseq": 5,
+    "sl_data_ack_reason": 0,
+}
+
+
+class TestAPISoundZones:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = SOUND_ROOM_LIST_RESP_INLINE
+
+        zones = await api.async_get_sound_zones()
+
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "sound_room_list_req"},
+            response_command="sound_room_list_resp",
+        )
+        assert len(zones) == 2
+        assert isinstance(zones[0], SoundZone)
+        assert isinstance(zones[1], SoundZone)
+        assert zones[0].id == 1
+        assert zones[0].name == "Living room"
+        assert zones[0].is_on is True
+        assert zones[0].sources == [
+            {"name": "Radio", "id": 0},
+            {"name": "Aux", "id": 1},
+        ]
+        assert zones[1].id == 2
+        assert zones[1].is_on is False
+        assert zones[1].is_muted is True
+        assert zones[1].sources == [
+            {"name": "Radio", "id": 0},
+            {"name": "Aux", "id": 7},
+        ]
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones_empty_array(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [],
+            "cmd_name": "sound_room_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        zones = await api.async_get_sound_zones()
+        assert zones == []
+        assert isinstance(zones, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones_missing_array_key(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "sound_room_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        zones = await api.async_get_sound_zones()
+        assert zones == []
+        assert isinstance(zones, list)
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones_missing_id(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {
+            "array": [{"name": "No id", "standby": 0}],
+            "cmd_name": "sound_room_list_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+        }
+
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            await api.async_get_sound_zones()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones_auth_error(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.side_effect = CameDomoticAuthError("auth failed")
+
+        with pytest.raises(CameDomoticAuthError):
+            await api.async_get_sound_zones()
+
+    @patch.object(Auth, "async_send_command")
+    async def test_async_get_sound_zones_server_error(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.side_effect = CameDomoticServerError("server failed")
+
+        with pytest.raises(CameDomoticServerError):
+            await api.async_get_sound_zones()
 
 
 class TestAPIUpdates:

--- a/tests/aiocamedomotic/test_sound_zone.py
+++ b/tests/aiocamedomotic/test_sound_zone.py
@@ -1,0 +1,431 @@
+# SPDX-FileCopyrightText: 2026 - GitHub user: fredericks1982
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aiocamedomotic import Auth
+from aiocamedomotic.models.sound_zone import SoundZone, SoundZoneAction
+
+# Sound zones are absent from the reference plant, so all data below is inline
+# and modelled on the field-tested third-party integration's data shape.
+# Array-based sources format.
+SOUND_ZONE_DATA = {
+    "id": 3,
+    "name": "Living room",
+    "standby": 0,
+    "mute": 0,
+    "volume": 25,
+    "min_volume": 0,
+    "max_volume": 50,
+    "source_name": "Radio",
+    "sources": [
+        {"source": "Radio", "id": 0},
+        {"source_name": "Aux", "id": 1},
+    ],
+}
+
+# Flat source_N fields format.
+SOUND_ZONE_FLAT_DATA = {
+    "id": 4,
+    "name": "Kitchen",
+    "standby": 1,
+    "mute": 1,
+    "volume": 10,
+    "min_volume": 5,
+    "max_volume": 35,
+    "source": "Radio",
+    "source_1": "Radio",
+    "source_3": "Aux",
+    "id_source_3": 7,
+}
+
+
+class TestSoundZone:
+    def test_init_valid(self, auth_instance):
+        zone = SoundZone(SOUND_ZONE_DATA, auth_instance)
+        assert zone.raw_data == SOUND_ZONE_DATA
+        assert zone.auth == auth_instance
+
+    def test_missing_id_raises(self, auth_instance):
+        with pytest.raises(ValueError, match="Data is missing required keys: id"):
+            SoundZone({"name": "No id"}, auth_instance)
+
+    def test_id_wrong_type_raises(self, auth_instance):
+        with pytest.raises(ValueError):
+            SoundZone({"id": "not-an-int"}, auth_instance)
+
+    def test_none_data_raises(self, auth_instance):
+        with pytest.raises((ValueError, TypeError)):
+            SoundZone(None, auth_instance)  # type: ignore[arg-type]
+
+    def test_invalid_auth_raises(self):
+        with pytest.raises(ValueError, match="'auth' must be an instance of Auth"):
+            SoundZone(SOUND_ZONE_DATA, "not_auth")  # type: ignore[arg-type]
+
+    def test_properties(self, auth_instance):
+        zone = SoundZone(SOUND_ZONE_DATA, auth_instance)
+        assert zone.id == 3
+        assert zone.name == "Living room"
+        assert zone.is_on is True
+        assert zone.is_muted is False
+        assert zone.volume == 25
+        assert zone.min_volume == 0
+        assert zone.max_volume == 50
+        assert zone.volume_level == 0.5
+        assert zone.source == "Radio"
+
+    def test_standby_zone(self, auth_instance):
+        zone = SoundZone(SOUND_ZONE_FLAT_DATA, auth_instance)
+        assert zone.is_on is False
+        assert zone.is_muted is True
+
+    def test_name_missing_returns_none(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.name is None
+
+    def test_is_on_defaults_true_when_standby_missing(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.is_on is True
+
+    def test_is_muted_defaults_false_when_mute_missing(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.is_muted is False
+
+    def test_volume_fields_default_none(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.volume is None
+        assert zone.min_volume is None
+        assert zone.max_volume is None
+
+    def test_volume_level_none_when_volume_missing(self, auth_instance):
+        zone = SoundZone({"id": 1, "min_volume": 0, "max_volume": 50}, auth_instance)
+        assert zone.volume_level is None
+
+    def test_volume_level_none_when_range_missing(self, auth_instance):
+        zone = SoundZone({"id": 1, "volume": 25}, auth_instance)
+        assert zone.volume_level is None
+
+    def test_volume_level_zero_when_range_empty(self, auth_instance):
+        zone = SoundZone(
+            {"id": 1, "volume": 20, "min_volume": 20, "max_volume": 20},
+            auth_instance,
+        )
+        assert zone.volume_level == 0.0
+
+    def test_volume_level_clamped_above_max(self, auth_instance):
+        zone = SoundZone(
+            {"id": 1, "volume": 99, "min_volume": 0, "max_volume": 50},
+            auth_instance,
+        )
+        assert zone.volume_level == 1.0
+
+    def test_volume_level_clamped_below_min(self, auth_instance):
+        zone = SoundZone(
+            {"id": 1, "volume": 2, "min_volume": 5, "max_volume": 35},
+            auth_instance,
+        )
+        assert zone.volume_level == 0.0
+
+    def test_source_missing_returns_none(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.source is None
+
+    def test_source_prefers_source_name(self, auth_instance):
+        zone = SoundZone(
+            {"id": 1, "source_name": "Aux", "source": "Radio"}, auth_instance
+        )
+        assert zone.source == "Aux"
+
+    def test_source_falls_back_to_source(self, auth_instance):
+        zone = SoundZone({"id": 1, "source": "Radio"}, auth_instance)
+        assert zone.source == "Radio"
+
+    def test_sources_array_format(self, auth_instance):
+        zone = SoundZone(SOUND_ZONE_DATA, auth_instance)
+        assert zone.sources == [
+            {"name": "Radio", "id": 0},
+            {"name": "Aux", "id": 1},
+        ]
+
+    def test_sources_flat_format(self, auth_instance):
+        zone = SoundZone(SOUND_ZONE_FLAT_DATA, auth_instance)
+        # source_1 has no id_source_1 companion, so its id defaults to N-1.
+        assert zone.sources == [
+            {"name": "Radio", "id": 0},
+            {"name": "Aux", "id": 7},
+        ]
+
+    def test_sources_mixed_formats_deduped(self, auth_instance):
+        zone = SoundZone(
+            {
+                "id": 1,
+                "sources": [{"source": "Radio", "id": 0}],
+                "source_1": "Radio",
+                "source_2": "Aux",
+                "id_source_2": 5,
+            },
+            auth_instance,
+        )
+        assert zone.sources == [
+            {"name": "Radio", "id": 0},
+            {"name": "Aux", "id": 5},
+        ]
+
+    def test_sources_empty(self, auth_instance):
+        zone = SoundZone({"id": 1}, auth_instance)
+        assert zone.sources == []
+
+    def test_sources_none_array(self, auth_instance):
+        zone = SoundZone({"id": 1, "sources": None}, auth_instance)
+        assert zone.sources == []
+
+
+class TestSoundZoneAction:
+    def test_values(self):
+        assert SoundZoneAction.STANDBY.value == "standby"
+        assert SoundZoneAction.MUTE.value == "mute"
+        assert SoundZoneAction.VOLUME.value == "volume"
+        assert SoundZoneAction.SOURCE.value == "source"
+
+
+class TestSoundZoneControl:
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_turn_on(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_FLAT_DATA), auth_instance)
+        assert zone.is_on is False
+
+        await zone.async_turn_on()
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 4,
+                "action": "standby",
+                "value": 0,
+            }
+        )
+        assert zone.is_on is True
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_turn_off(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+        assert zone.is_on is True
+
+        await zone.async_turn_off()
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 3,
+                "action": "standby",
+                "value": 1,
+            }
+        )
+        assert zone.is_on is False
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_mute_true(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+        assert zone.is_muted is False
+
+        await zone.async_set_mute(True)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 3,
+                "action": "mute",
+                "value": 1,
+            }
+        )
+        assert zone.is_muted is True
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_mute_false(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_FLAT_DATA), auth_instance)
+        assert zone.is_muted is True
+
+        await zone.async_set_mute(False)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 4,
+                "action": "mute",
+                "value": 0,
+            }
+        )
+        assert zone.is_muted is False
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_volume_level(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_FLAT_DATA), auth_instance)
+
+        # 0.5 on the 5-35 range -> 5 + 30 * 0.5 = 20
+        await zone.async_set_volume_level(0.5)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 4,
+                "action": "volume",
+                "value": 20,
+            }
+        )
+        assert zone.volume == 20
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_set_volume_level_rounds(
+        self, mock_send_command, auth_instance
+    ):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+
+        # 0.33 on the 0-50 range -> 16.5, rounds to 16 (banker's rounding)
+        await zone.async_set_volume_level(0.33)
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 3,
+                "action": "volume",
+                "value": 16,
+            }
+        )
+        assert zone.volume == 16
+
+    @pytest.mark.parametrize("level", [-0.1, 1.1])
+    async def test_async_set_volume_level_out_of_range_raises(
+        self, auth_instance, level
+    ):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+
+        with pytest.raises(ValueError, match="volume_level must be between"):
+            await zone.async_set_volume_level(level)
+
+    async def test_async_set_volume_level_missing_range_raises(self, auth_instance):
+        zone = SoundZone({"id": 1, "volume": 10}, auth_instance)
+
+        with pytest.raises(ValueError, match="does not report its"):
+            await zone.async_set_volume_level(0.5)
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_select_source(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+
+        await zone.async_select_source("Aux")
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 3,
+                "action": "source",
+                "value": 1,
+            }
+        )
+        assert zone.source == "Aux"
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_select_source_flat_format(
+        self, mock_send_command, auth_instance
+    ):
+        zone = SoundZone(dict(SOUND_ZONE_FLAT_DATA), auth_instance)
+
+        await zone.async_select_source("Aux")
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "sound_switch_req",
+                "id": 4,
+                "action": "source",
+                "value": 7,
+            }
+        )
+        assert zone.source == "Aux"
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_select_source_unknown_raises(
+        self, mock_send_command, auth_instance
+    ):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+
+        with pytest.raises(ValueError, match="Source 'Bluetooth' is not available"):
+            await zone.async_select_source("Bluetooth")
+        mock_send_command.assert_not_called()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_select_source_none_id_raises(
+        self, mock_send_command, auth_instance
+    ):
+        zone = SoundZone({"id": 1, "sources": [{"source": "Radio"}]}, auth_instance)
+
+        with pytest.raises(ValueError, match="Source 'Radio' is not available"):
+            await zone.async_select_source("Radio")
+        mock_send_command.assert_not_called()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_send_source_command(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+
+        await zone.async_send_source_command(7, "next_track")
+
+        mock_send_command.assert_called_once_with(
+            {
+                "cmd_name": "suftif_cmd_req",
+                "id": 7,
+                "action": "next_track",
+            }
+        )
+
+
+class TestSoundZoneRefresh:
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_refresh(self, mock_send_command, auth_instance):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "sound_room_src_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+            "id": 3,
+            "standby": 1,
+            "mute": 1,
+            "volume": 30,
+        }
+
+        await zone.async_refresh()
+
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "sound_room_src_req", "value": 3},
+            response_command="sound_room_src_resp",
+        )
+        assert zone.is_on is False
+        assert zone.is_muted is True
+        assert zone.volume == 30
+        # Protocol envelope keys must not leak into the zone data.
+        assert "cseq" not in zone.raw_data
+        assert "cmd_name" not in zone.raw_data
+        assert "sl_data_ack_reason" not in zone.raw_data
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_refresh_id_mismatch_ignored(
+        self, mock_send_command, auth_instance
+    ):
+        zone = SoundZone(dict(SOUND_ZONE_DATA), auth_instance)
+        mock_send_command.return_value = {
+            "cmd_name": "sound_room_src_resp",
+            "cseq": 5,
+            "sl_data_ack_reason": 0,
+            "id": 99,
+            "standby": 1,
+        }
+
+        await zone.async_refresh()
+
+        assert zone.is_on is True
+        assert zone.volume == 25


### PR DESCRIPTION
## Summary

- Add a new `SoundZone` domain (`aiocamedomotic/models/sound_zone.py`): list zones via `sound_room_list_req`, power on/off, mute/unmute, set a normalized volume level, select an input source by name, send advanced source commands (`suftif_cmd_req`), and refresh a single zone's state (`sound_room_src_req`).
- Normalize the two source-list formats observed in the reference implementation (array-based `sources` and flat `source_N`/`id_source_N` fields), deduplicating by `(name, id)`.
- Add `async_get_sound_zones()` to `CameDomoticAPI`, export `SoundZone`/`SoundZoneAction` from `aiocamedomotic.models`, and update `ROADMAP.md` (Audio system moved from Future considerations to Current Features, marked experimental).

This is a **fede Den901** PR per the implementation plan: the reference plant has no audio zones (`feature_list_resp` doesn't report the feature) and no traffic could be sniffed, so the data model and command semantics are implemented from the behaviour of an existing, field-tested third-party integration rather than a live capture. Docstrings carry the "not verified against a live plant" note throughout.

## Test plan

- [x] `ruff format aiocamedomotic tests` / `ruff check aiocamedomotic`
- [x] `pylint --disable=W,R,C aiocamedomotic` (10.00/10)
- [x] `mypy aiocamedomotic` (no issues)
- [x] `pytest --cov=aiocamedomotic --cov-report=term-missing` — 100% coverage, all tests passing
- [x] New `tests/aiocamedomotic/test_sound_zone.py` covers both source formats, volume clamping/rounding, toggle semantics, and the single-zone refresh path (including protocol-key stripping and ID-mismatch handling)
- [x] New `TestAPISoundZones` class in `tests/aiocamedomotic/test_came_domotic_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental sound zone support.
  * Retrieve available sound zones and inspect power, mute, volume, and input source status.
  * Control zones by turning them on or off, muting, adjusting volume, and selecting sources.
  * Added support for multiple sound zone data formats across firmware versions.

* **Documentation**
  * Updated the roadmap to list sound zones as a Version 1.13 experimental feature.
  * Noted that live-system verification is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->