### PR TITLE
feat: add energy counters reset support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,8 +116,10 @@ considered for future development once real-world testing is possible:
 
 - **Scenario management**: Create and delete scenarios (beyond the current
   list/activate/activate-by-name).
-- **Energy statistics**: Historical energy statistics per meter (`energy_stat_req`) and
-  plant-wide measurement history reset (`energy_reset_store_req`) — deferred until real traffic captures are available.
+- **Energy statistics**: Historical energy statistics per meter (`energy_stat_req`) —
+  deferred until real traffic captures are available. The plant-wide measurement
+  history reset (`energy_reset_store_req`) is already supported via
+  `async_reset_energy_counters()`.
 - **Security system**: Area/scenario management and alarm control (entirely unverified).
 - **Infrastructure improvements**: Automated keep-alive scheduling, per-actuator scope
   queries, and connection resilience improvements.

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -589,6 +589,30 @@ class CameDomoticAPI:
         LOGGER.info("Retrieved %d energy meter(s)", len(meters_list))
         return [EnergyMeter(meter_data) for meter_data in meters_list]
 
+    async def async_reset_energy_counters(self) -> None:
+        """Reset the stored energy measurement history on the server.
+
+        This is a plant-level command that clears the stored energy
+        consumption history of **all** energy meters at once (e.g. the
+        values behind ``last_24h_avg`` and ``last_month_avg``); it cannot
+        target a single meter. Instantaneous power readings are not
+        affected.
+
+        .. warning::
+            The reset is irreversible: the server discards the stored
+            energy history and there is no way to restore it.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        LOGGER.debug("Resetting energy counters")
+        payload = {
+            "cmd_name": _CommandName.ENERGY_RESET_STORE.value,
+        }
+        await self.auth.async_send_command(payload)
+        LOGGER.info("Energy counters reset")
+
     async def async_get_loadsctrl_meters(self) -> list[LoadsCtrlMeter]:
         """Get the list of all loads controllers defined on the server.
 

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -191,6 +191,9 @@ class _CommandName(Enum):
     TIMERS_ENABLE_DAY = "timers_enable_day_req"
     TIMERS_SET = "timers_set_req"
     DIGITALIN_ACK = "digitalin_ack_req"
+    # Energy: the reset ack carries no cmd_name, so there is no
+    # _CommandNameResponse counterpart.
+    ENERGY_RESET_STORE = "energy_reset_store_req"
     # Irrigation: the force/set/detail acks carry no reliable resp cmd_name
     # (a generic_reply is returned), so only the list request has a
     # _CommandNameResponse counterpart.

--- a/aiocamedomotic/models/energy_meter.py
+++ b/aiocamedomotic/models/energy_meter.py
@@ -11,7 +11,10 @@ line together with energy values. They have no ``act_id`` and
 no floor/room placement — the ``id`` field is their identifier, and it is
 also the matching key for ``meter_instant_power_ind`` push updates.
 
-Energy meters provide readings but do not support control commands.
+Energy meters provide readings but do not support per-meter control
+commands. The only related action is the plant-level
+:meth:`~aiocamedomotic.CameDomoticAPI.async_reset_energy_counters`, which
+clears the stored energy history of all meters at once.
 """
 
 from __future__ import annotations

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -1018,6 +1018,17 @@ fields, expressed in ``energy_unit`` (typically ``Wh``):
 Real-time power readings are delivered as push updates — see
 :ref:`energy-meter-updates` in the monitoring section below.
 
+**Resetting the energy history:**
+
+The stored energy history can be cleared with a single plant-level
+command. The reset applies to **all** energy meters at once (it cannot
+target a single meter) and is **irreversible**; instantaneous power
+readings are not affected:
+
+.. code-block:: python
+
+    await api.async_reset_energy_counters()
+
 Loads control
 ^^^^^^^^^^^^^
 

--- a/tests/aiocamedomotic/test_energy_meter.py
+++ b/tests/aiocamedomotic/test_energy_meter.py
@@ -120,3 +120,16 @@ class TestAPIEnergyMeters:
 
         meters = await api.async_get_energy_meters()
         assert meters == []
+
+
+class TestAPIEnergyResetCounters:
+    @patch.object(Auth, "async_send_command")
+    async def test_async_reset_energy_counters(self, mock_send_command, auth_instance):
+        api = CameDomoticAPI(auth_instance)
+        mock_send_command.return_value = {"cseq": 1, "sl_data_ack_reason": 0}
+
+        await api.async_reset_energy_counters()
+
+        mock_send_command.assert_called_once_with(
+            {"cmd_name": "energy_reset_store_req"}
+        )


### PR DESCRIPTION
## Summary
- Add `async_reset_energy_counters()` to clear the stored energy consumption history (all meters at once, plant-level).
- Based on the `energy_reset_store_req` command captured from real traffic (see `local_only/sniffed_traffic/reset_energy_counters.txt`), which sends no parameters and is acknowledged with a plain `sl_data_ack_reason: 0`.
- Update ROADMAP: this closes the previously "deferred" reset item, leaving only `energy_stat_req` (historical per-meter statistics) outstanding.
- Add usage example and unit test coverage.

## Test plan
- [x] `pytest` — all tests pass
- [x] `ruff format --check`, `ruff check`, `mypy`, `pylint --disable=W,R,C` — all clean