### PR TITLE
feat: add custom scenario recording, rename, and delete support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,9 +20,11 @@ insights. We look forward to growing this library together with our users and co
   tilting).
 - **Scenarios management**: List available scenarios and trigger their activation, either
   by scenario object or directly by name (`scenario_activation_by_name_req`) without
-  fetching the list first. Creating and deleting scenarios remains under
-  [Future considerations](#future-considerations), pending a real capture of the
-  registration flow.
+  fetching the list first. Record new custom scenarios (`scenario_registration_start` /
+  `scenario_registration_done`), rename them (`scenario_rename_req`), and delete them
+  (`scenario_delete_req`). The recording flow has been verified against a real plant
+  with actions performed via physical switches; capturing of API-issued commands during
+  recording is expected but not yet verified.
 - **Thermoregulation (full control)**: List thermoregulation zones with their current
   state; set target temperature, operating mode (OFF, MANUAL, AUTO, JOLLY), and fan speed
   (OFF, SLOW, MEDIUM, FAST, AUTO) for individual zones via `thermo_zone_config_req`.
@@ -114,8 +116,6 @@ The following features are known from reverse-engineered sources (API_reference.
 API_MANUAL.md) but have not been verified with real traffic captures. They may be
 considered for future development once real-world testing is possible:
 
-- **Scenario management**: Create and delete scenarios (beyond the current
-  list/activate/activate-by-name).
 - **Energy statistics**: Historical energy statistics per meter (`energy_stat_req`) —
   deferred until real traffic captures are available. The plant-wide measurement
   history reset (`energy_reset_store_req`) is already supported via

--- a/aiocamedomotic/came_domotic_api.py
+++ b/aiocamedomotic/came_domotic_api.py
@@ -25,7 +25,7 @@ from .const import (
     _CommandType,
     _TopologicScope,
 )
-from .errors import CameDomoticAuthError
+from .errors import CameDomoticAuthError, CameDomoticServerError
 from .models import (
     AnalogIn,
     AnalogSensor,
@@ -76,6 +76,10 @@ class CameDomoticAPI:
         """
         self.auth = auth
         self.auth.command_timeout = command_timeout
+        # Name of the custom scenario currently being recorded via
+        # async_start_scenario_recording, used by async_stop_scenario_recording
+        # to identify the newly created scenario in the scenarios list.
+        self._recording_scenario_name: str | None = None
         LOGGER.debug(
             "CameDomoticAPI initialized (command_timeout=%ds)", command_timeout
         )
@@ -854,6 +858,111 @@ class CameDomoticAPI:
         }
         await self.auth.async_send_command(payload)
         LOGGER.info("Scenario '%s' activated by name", name)
+
+    async def async_start_scenario_recording(self, name: str) -> None:
+        """Start recording a new custom (user-defined) scenario.
+
+        Puts the CAME server in scenario-recording mode: the actions performed
+        on the plant after this call (e.g. switching lights on/off) are
+        captured as the steps of a new scenario named ``name``. Call
+        :meth:`async_stop_scenario_recording` to finalize the recording and
+        save the scenario on the server.
+
+        .. note::
+            The recording verified against a real plant captures actions
+            performed via **physical switches**. Actions sent through the API
+            (e.g. :meth:`~aiocamedomotic.models.Light.async_set_status`) are
+            expected to be captured as well — the official CAME app records
+            its own commands this way — but this has not been verified yet.
+
+        Args:
+            name (str): The name of the new scenario.
+
+        Raises:
+            ValueError: If ``name`` is not a non-empty string.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error or rejects
+                the recording request.
+        """
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("name must be a non-empty string")
+
+        LOGGER.debug("Starting recording of scenario '%s'", name)
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_REGISTRATION_START.value,
+            "name": name,
+        }
+        json_response = await self.auth.async_send_command(
+            payload,
+            response_command=_CommandNameResponse.SCENARIO_REGISTRATION.value,
+        )
+
+        result = json_response.get("result")
+        if result != 1:
+            raise CameDomoticServerError(
+                f"The server rejected the recording of scenario '{name}' "
+                f"(result={result})"
+            )
+
+        self._recording_scenario_name = name
+        LOGGER.info("Recording of scenario '%s' started", name)
+
+    async def async_stop_scenario_recording(self) -> Scenario | None:
+        """Stop the ongoing scenario recording and save the new scenario.
+
+        Finalizes the recording started with
+        :meth:`async_start_scenario_recording`: the server stores the captured
+        actions as a new user-defined scenario.
+
+        Returns:
+            Scenario | None: The newly created scenario, retrieved from the
+            server by matching the name passed to
+            :meth:`async_start_scenario_recording` (if several user-defined
+            scenarios share that name, the one with the highest ID is
+            returned). Returns ``None`` if the recording was not started via
+            this API instance or if the new scenario cannot be identified.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error or rejects
+                the finalization request.
+        """
+        LOGGER.debug("Stopping scenario recording")
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_REGISTRATION_DONE.value,
+        }
+        json_response = await self.auth.async_send_command(
+            payload,
+            response_command=_CommandNameResponse.SCENARIO_REGISTRATION_DONE.value,
+        )
+
+        result = json_response.get("result")
+        if result != 1:
+            raise CameDomoticServerError(
+                f"The server rejected the finalization of the scenario "
+                f"recording (result={result})"
+            )
+
+        name = self._recording_scenario_name
+        self._recording_scenario_name = None
+        LOGGER.info("Scenario recording stopped")
+
+        if name is None:
+            LOGGER.debug(
+                "No recording was started via this API instance: "
+                "cannot identify the newly created scenario"
+            )
+            return None
+
+        scenarios = await self.async_get_scenarios()
+        matches = [s for s in scenarios if s.user_defined and s.name == name]
+        if not matches:
+            LOGGER.warning(
+                "Newly recorded scenario '%s' not found in the scenarios list",
+                name,
+            )
+            return None
+        return max(matches, key=lambda s: s.id)
 
     async def async_set_relay_status_by_name(
         self, name: str, status: RelayStatus

--- a/aiocamedomotic/const.py
+++ b/aiocamedomotic/const.py
@@ -183,6 +183,13 @@ class _CommandName(Enum):
     OPENING_MOVE = "opening_move_req"
     SCENARIO_ACTIVATION = "scenario_activation_req"
     SCENARIO_ACTIVATION_BY_NAME = "scenario_activation_by_name_req"
+    # Custom scenario recording: note that the start/done commands carry no
+    # "_req" suffix. Rename/delete return a generic_reply, so only the
+    # start/done commands have a _CommandNameResponse counterpart.
+    SCENARIO_REGISTRATION_START = "scenario_registration_start"
+    SCENARIO_REGISTRATION_DONE = "scenario_registration_done"
+    SCENARIO_RENAME = "scenario_rename_req"
+    SCENARIO_DELETE = "scenario_delete_req"
     RELAY_ACTIVATION = "relay_activation_req"
     RELAY_TIMED = "relay_timed_req"
     THERMO_ZONE_CONFIG = "thermo_zone_config_req"
@@ -244,6 +251,8 @@ class _CommandNameResponse(Enum):
     STATUS_UPDATE = "status_update_resp"
     # Actions
     DIGITALIN_ACK = "digitalin_ack_resp"
+    SCENARIO_REGISTRATION = "scenario_registration_resp"
+    SCENARIO_REGISTRATION_DONE = "scenario_registration_done_resp"
 
 
 class _TopologicScope(Enum):

--- a/aiocamedomotic/models/scenario.py
+++ b/aiocamedomotic/models/scenario.py
@@ -136,3 +136,99 @@ class Scenario(CameEntity):
             self.name,
             self.id,
         )
+
+    async def async_rename(self, name: str) -> None:
+        """Rename the scenario.
+
+        Sends the scenario rename command to the CAME Domotic server and
+        updates the local ``name`` accordingly.
+
+        .. note::
+            Renaming is meant for **user-defined** scenarios (see
+            :attr:`user_defined`): the official CAME app does not allow
+            renaming system-defined ones. The command is sent anyway, but the
+            server behaviour on system-defined scenarios is unverified.
+
+        Args:
+            name (str): The new name of the scenario.
+
+        Raises:
+            ValueError: If ``name`` is not a non-empty string.
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("name must be a non-empty string")
+
+        if not self.user_defined:
+            LOGGER.warning(
+                "Renaming scenario '%s' (ID: %s), which is not user-defined: "
+                "the server may ignore or reject the request.",
+                self.name,
+                self.id,
+            )
+
+        LOGGER.debug(
+            "Sending cmd 'scenario_rename_req' for scenario '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )
+
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_RENAME.value,
+            "id": self.id,
+            "name": name,
+        }
+
+        await self.auth.async_send_command(payload)
+        self.raw_data["name"] = name
+
+        LOGGER.info(
+            "Successfully renamed scenario (ID: %s) to '%s'.",
+            self.id,
+            name,
+        )
+
+    async def async_delete(self) -> None:
+        """Delete the scenario from the CAME Domotic server.
+
+        .. warning::
+            The deletion is irreversible: the server discards the scenario
+            and there is no way to restore it.
+
+        .. note::
+            Deletion is meant for **user-defined** scenarios (see
+            :attr:`user_defined`): the official CAME app does not allow
+            deleting system-defined ones. The command is sent anyway, but the
+            server behaviour on system-defined scenarios is unverified.
+
+        Raises:
+            CameDomoticAuthError: If the authentication fails.
+            CameDomoticServerError: If the server returns an error.
+        """
+        if not self.user_defined:
+            LOGGER.warning(
+                "Deleting scenario '%s' (ID: %s), which is not user-defined: "
+                "the server may ignore or reject the request.",
+                self.name,
+                self.id,
+            )
+
+        LOGGER.debug(
+            "Sending cmd 'scenario_delete_req' for scenario '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )
+
+        payload = {
+            "cmd_name": _CommandName.SCENARIO_DELETE.value,
+            "id": self.id,
+        }
+
+        await self.auth.async_send_command(payload)
+
+        LOGGER.info(
+            "Successfully deleted scenario '%s' (ID: %s).",
+            self.name,
+            self.id,
+        )

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -385,6 +385,67 @@ activated (fire-and-forget); there is no bidirectional status control.
     if good_morning:
         await good_morning.async_activate()
 
+**Recording a new custom scenario:**
+
+Custom (user-defined) scenarios are created by *recording* them: you put
+the server in recording mode, perform the actions you want the scenario
+to replay (e.g. switching lights on/off), and then finalize the
+recording. This mirrors the recording feature of the official CAME app.
+
+.. code-block:: python
+
+    # 1. Start recording a new scenario
+    await api.async_start_scenario_recording("Movie night")
+
+    # 2. Perform the actions to be captured, e.g. by pressing physical
+    #    switches on the plant, or via API commands:
+    lights = await api.async_get_lights()
+    living_room = next(l for l in lights if l.name == "Living room")
+    await living_room.async_set_status(LightStatus.OFF)
+
+    # 3. Finalize the recording: the server saves the new scenario and
+    #    the method returns it as a Scenario object
+    movie_night = await api.async_stop_scenario_recording()
+    print(f"Created scenario '{movie_night.name}' (ID: {movie_night.id})")
+
+    # The new scenario can now be activated like any other one
+    await movie_night.async_activate()
+
+.. note::
+    Recording has been verified against a real plant with actions
+    performed via **physical switches**. Actions sent through the API
+    while recording are expected to be captured as well — the official
+    CAME app records its own commands this way — but this has not been
+    verified yet.
+
+:meth:`~aiocamedomotic.CameDomoticAPI.async_stop_scenario_recording`
+identifies the new scenario by the name passed to
+:meth:`~aiocamedomotic.CameDomoticAPI.async_start_scenario_recording`
+and returns ``None`` if it cannot be found (e.g. when finalizing a
+recording started by another client).
+
+**Renaming and deleting custom scenarios:**
+
+User-defined scenarios (``user_defined == 1``) can be renamed and
+deleted. System-defined scenarios are not meant to be modified: the
+command is sent anyway, but a warning is logged and the server behaviour
+is unverified.
+
+.. code-block:: python
+
+    scenarios = await api.async_get_scenarios()
+    movie_night = next(
+        (s for s in scenarios if s.name == "Movie night" and s.user_defined),
+        None,
+    )
+
+    if movie_night:
+        # Rename the scenario (the local object is updated too)
+        await movie_night.async_rename("Cinema mode")
+
+        # Delete the scenario (irreversible!)
+        await movie_night.async_delete()
+
 Thermoregulation zones
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/aiocamedomotic/test_came_domotic_api.py
+++ b/tests/aiocamedomotic/test_came_domotic_api.py
@@ -1163,6 +1163,220 @@ class TestAPIScenarios:
             await api.async_get_scenarios()
 
 
+class TestAPIScenarioRecording:
+    REGISTRATION_RESP = {
+        "cseq": 18,
+        "cmd_name": "scenario_registration_resp",
+        "result": 1,
+        "sl_data_ack_reason": 0,
+    }
+    REGISTRATION_DONE_RESP = {
+        "cseq": 44,
+        "cmd_name": "scenario_registration_done_resp",
+        "result": 1,
+        "sl_data_ack_reason": 0,
+    }
+    SCENARIOS_LIST_WITH_CUSTOM_RESP = {
+        "cseq": 46,
+        "cmd_name": "scenarios_list_resp",
+        "array": [
+            {
+                "name": "Luci giorno accese",
+                "id": 1,
+                "status": 0,
+                "scenario_status": 0,
+                "icon_id": 14,
+                "user-defined": 0,
+            },
+            {
+                "name": "SCENARIO di prova",
+                "id": 65536,
+                "status": 0,
+                "scenario_status": 0,
+                "user-defined": 1,
+            },
+        ],
+        "sl_data_ack_reason": 0,
+    }
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_start_scenario_recording(self, mock_send_command, auth_instance):
+        mock_send_command.return_value = self.REGISTRATION_RESP
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_start_scenario_recording("SCENARIO di prova")
+
+        call_payload = mock_send_command.call_args[0][0]
+        assert call_payload["cmd_name"] == "scenario_registration_start"
+        assert call_payload["name"] == "SCENARIO di prova"
+        assert (
+            mock_send_command.call_args.kwargs["response_command"]
+            == "scenario_registration_resp"
+        )
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_start_scenario_recording_empty_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(ValueError, match="name must be a non-empty string"):
+            await api.async_start_scenario_recording("   ")
+        mock_send_command.assert_not_called()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_start_scenario_recording_non_string_name(
+        self, mock_send_command, auth_instance
+    ):
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(ValueError, match="name must be a non-empty string"):
+            await api.async_start_scenario_recording(42)
+        mock_send_command.assert_not_called()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_start_scenario_recording_rejected(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.return_value = {
+            "cseq": 18,
+            "cmd_name": "scenario_registration_resp",
+            "result": 0,
+            "sl_data_ack_reason": 0,
+        }
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticServerError, match="result=0"):
+            await api.async_start_scenario_recording("SCENARIO di prova")
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_stop_scenario_recording(self, mock_send_command, auth_instance):
+        mock_send_command.side_effect = [
+            self.REGISTRATION_RESP,
+            self.REGISTRATION_DONE_RESP,
+            self.SCENARIOS_LIST_WITH_CUSTOM_RESP,
+        ]
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_start_scenario_recording("SCENARIO di prova")
+        scenario = await api.async_stop_scenario_recording()
+
+        done_payload = mock_send_command.call_args_list[1][0][0]
+        assert done_payload["cmd_name"] == "scenario_registration_done"
+        assert (
+            mock_send_command.call_args_list[1].kwargs["response_command"]
+            == "scenario_registration_done_resp"
+        )
+        assert isinstance(scenario, Scenario)
+        assert scenario.id == 65536
+        assert scenario.name == "SCENARIO di prova"
+        assert scenario.user_defined == 1
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_stop_scenario_recording_without_start(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.return_value = self.REGISTRATION_DONE_RESP
+        api = CameDomoticAPI(auth_instance)
+
+        scenario = await api.async_stop_scenario_recording()
+
+        # The done command is sent anyway, but the scenarios list is not
+        # fetched since the new scenario cannot be identified.
+        assert scenario is None
+        mock_send_command.assert_called_once()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_stop_scenario_recording_rejected(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = [
+            self.REGISTRATION_RESP,
+            {
+                "cseq": 44,
+                "cmd_name": "scenario_registration_done_resp",
+                "result": 0,
+                "sl_data_ack_reason": 0,
+            },
+        ]
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_start_scenario_recording("SCENARIO di prova")
+        with pytest.raises(CameDomoticServerError, match="result=0"):
+            await api.async_stop_scenario_recording()
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_stop_scenario_recording_scenario_not_found(
+        self, mock_send_command, auth_instance, caplog
+    ):
+        mock_send_command.side_effect = [
+            self.REGISTRATION_RESP,
+            self.REGISTRATION_DONE_RESP,
+            {
+                "cseq": 46,
+                "cmd_name": "scenarios_list_resp",
+                "array": [],
+                "sl_data_ack_reason": 0,
+            },
+        ]
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_start_scenario_recording("SCENARIO di prova")
+        scenario = await api.async_stop_scenario_recording()
+
+        assert scenario is None
+        assert "not found in the scenarios list" in caplog.text
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_stop_scenario_recording_duplicate_names(
+        self, mock_send_command, auth_instance
+    ):
+        list_resp = {
+            "cseq": 46,
+            "cmd_name": "scenarios_list_resp",
+            "array": [
+                {
+                    "name": "SCENARIO di prova",
+                    "id": 65536,
+                    "status": 0,
+                    "scenario_status": 0,
+                    "user-defined": 1,
+                },
+                {
+                    "name": "SCENARIO di prova",
+                    "id": 65537,
+                    "status": 0,
+                    "scenario_status": 0,
+                    "user-defined": 1,
+                },
+            ],
+            "sl_data_ack_reason": 0,
+        }
+        mock_send_command.side_effect = [
+            self.REGISTRATION_RESP,
+            self.REGISTRATION_DONE_RESP,
+            list_resp,
+        ]
+        api = CameDomoticAPI(auth_instance)
+
+        await api.async_start_scenario_recording("SCENARIO di prova")
+        scenario = await api.async_stop_scenario_recording()
+
+        # Among duplicates, the scenario with the highest ID is returned
+        assert scenario is not None
+        assert scenario.id == 65537
+
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_start_scenario_recording_auth_error_propagates(
+        self, mock_send_command, auth_instance
+    ):
+        mock_send_command.side_effect = CameDomoticAuthError("bad auth")
+        api = CameDomoticAPI(auth_instance)
+
+        with pytest.raises(CameDomoticAuthError):
+            await api.async_start_scenario_recording("SCENARIO di prova")
+
+
 class TestAPIActivationByName:
     # generic_reply ack, validated by the standard ack-check (no response_command)
     GENERIC_REPLY = {

--- a/tests/aiocamedomotic/test_models.py
+++ b/tests/aiocamedomotic/test_models.py
@@ -7,6 +7,7 @@
 # pylint: disable=protected-access
 
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -2263,6 +2264,141 @@ class TestScenario:
             "id": scenario.id,
         }
         mock_send_command.assert_called_once_with(expected_payload)
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_rename(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        await scenario.async_rename("New name")
+
+        expected_payload = {
+            "cmd_name": "scenario_rename_req",
+            "id": scenario.id,
+            "name": "New name",
+        }
+        mock_send_command.assert_called_once_with(expected_payload)
+        assert scenario.name == "New name"
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_rename_empty_name(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        with pytest.raises(ValueError, match="name must be a non-empty string"):
+            await scenario.async_rename("   ")
+        mock_send_command.assert_not_called()
+        assert scenario.name == scenario_data_on["name"]
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_rename_non_string_name(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        with pytest.raises(ValueError, match="name must be a non-empty string"):
+            await scenario.async_rename(42)
+        mock_send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_rename_system_scenario_warns(
+        self,
+        mock_send_command,
+        scenario_data_off,
+        auth_instance,
+        caplog,
+    ):
+        # scenario_data_off is a system-defined scenario (user-defined == 0)
+        scenario = Scenario(scenario_data_off, auth_instance)
+
+        with caplog.at_level(logging.WARNING):
+            await scenario.async_rename("New name")
+
+        # The command is sent anyway, but a warning is logged
+        assert "not user-defined" in caplog.text
+        mock_send_command.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_rename_server_error_propagates(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        mock_send_command.side_effect = CameDomoticServerError("server down")
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        with pytest.raises(CameDomoticServerError):
+            await scenario.async_rename("New name")
+        # The local name is not updated on failure
+        assert scenario.name == scenario_data_on["name"]
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_delete(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        await scenario.async_delete()
+
+        expected_payload = {
+            "cmd_name": "scenario_delete_req",
+            "id": scenario.id,
+        }
+        mock_send_command.assert_called_once_with(expected_payload)
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_delete_system_scenario_warns(
+        self,
+        mock_send_command,
+        scenario_data_off,
+        auth_instance,
+        caplog,
+    ):
+        # scenario_data_off is a system-defined scenario (user-defined == 0)
+        scenario = Scenario(scenario_data_off, auth_instance)
+
+        with caplog.at_level(logging.WARNING):
+            await scenario.async_delete()
+
+        # The command is sent anyway, but a warning is logged
+        assert "not user-defined" in caplog.text
+        mock_send_command.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(Auth, "async_send_command", new_callable=AsyncMock)
+    async def test_async_delete_auth_error_propagates(
+        self,
+        mock_send_command,
+        scenario_data_on,
+        auth_instance,
+    ):
+        mock_send_command.side_effect = CameDomoticAuthError("bad auth")
+        scenario = Scenario(scenario_data_on, auth_instance)
+
+        with pytest.raises(CameDomoticAuthError):
+            await scenario.async_delete()
 
     def test_active_status(self, auth_instance):
         active_status_data = {


### PR DESCRIPTION
## Summary

Adds full lifecycle management for custom (user-defined) scenarios, based on real traffic captured from a CAME ETI/Domo 3.0.1 server (`local_only/sniffed_traffic/set_custom_scenario.txt`):

- **`CameDomoticAPI.async_start_scenario_recording(name)`** — sends `scenario_registration_start` and validates the `scenario_registration_resp` ack (`result == 1`), raising `CameDomoticServerError` on rejection.
- **`CameDomoticAPI.async_stop_scenario_recording()`** — sends `scenario_registration_done`, validates the ack, then re-fetches the scenarios list and returns the newly created `Scenario` (matched by the recorded name among user-defined scenarios, highest ID on duplicates; `None` if it cannot be identified, e.g. when finalizing a recording started by another client).
- **`Scenario.async_rename(name)`** — sends `scenario_rename_req` and updates the local `raw_data` on success.
- **`Scenario.async_delete()`** — sends `scenario_delete_req` (irreversible).

Rename/delete on system-defined scenarios (`user_defined == 0`) are sent anyway but log a warning, since the official app does not allow them and the server behaviour is unverified.

## Notes

- The recording flow was verified on a real plant with actions performed via **physical switches**; capturing of API-issued commands during recording is expected (the official app works this way) but not yet verified — documented accordingly.
- New commands added to `_CommandName` / `_CommandNameResponse` in `const.py` (note: the start/done commands carry no `_req` suffix, per captured traffic).
- Usage examples added to `docs/source/usage_examples.rst` (recording, renaming, deleting); ROADMAP updated (feature moved out of Future considerations).

## Testing

- 34 scenario-related tests (9 new API tests, 8 new model tests) covering payloads, response validation, rejection paths, duplicate-name resolution, warnings on system scenarios, and error propagation.
- Full suite: 879 passed, 28 skipped. `ruff`, `pylint` (10/10), `mypy`, and Sphinx docs build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)